### PR TITLE
[bugfix] Make sure that migration files are always returned in a sorted order

### DIFF
--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -16,6 +16,7 @@ now.
 # Standard library
 import os
 import sqlite3
+from typing import List
 
 # Sematic
 from sematic.config import get_config, SQLITE_FILE
@@ -28,6 +29,12 @@ def _get_conn() -> sqlite3.Connection:
     sqlite_file_path = os.path.join(get_config().config_dir, SQLITE_FILE)
 
     return sqlite3.connect(sqlite_file_path)
+
+
+def _get_migration_files() -> List[str]:
+    migrations_dir = get_config().migrations_dir
+
+    return sorted(os.listdir(migrations_dir))
 
 
 def migrate():
@@ -50,16 +57,16 @@ def migrate():
 
     versions = [row[0] for row in schema_migrations]
 
-    migrations_dir = get_config().migrations_dir
-
-    migration_files = os.listdir(migrations_dir)
+    migration_files = _get_migration_files()
 
     for migration_file in migration_files:
         version = migration_file.split("_")[0]
         if version in versions:
             continue
 
-        with open(os.path.join(migrations_dir, migration_file), "r") as file:
+        with open(
+            os.path.join(get_config().migrations_dir, migration_file), "r"
+        ) as file:
             sql = file.read()
 
         up_sql = sql.split("-- migrate:down")[0].split("-- migrate:up")[1].strip()

--- a/sematic/db/tests/test_migrate.py
+++ b/sematic/db/tests/test_migrate.py
@@ -6,7 +6,7 @@ import sqlite3
 import pytest
 
 # Sematic
-from sematic.db.migrate import migrate
+from sematic.db.migrate import migrate, _get_migration_files
 
 
 _MEMORY_CONN = sqlite3.connect(":memory:")
@@ -28,3 +28,26 @@ def test_migrate(_):
         run_count = _MEMORY_CONN.execute("SELECT COUNT(*) from runs;")
 
     assert list(run_count)[0][0] == 0
+
+
+def test_get_migration_files():
+    """
+    Tests that the actual migration files are returned.
+    """
+    migration_files = _get_migration_files()
+
+    assert len(migration_files) > 0
+    assert all(migration_file.endswith(".sql") for migration_file in migration_files)
+
+
+# Make sure return_value is unordered
+@patch(
+    "sematic.db.migrate.os.listdir",
+    return_value=["20220521155336", "20220424062956", "20220522082435"],
+)
+def test_get_migration_files_sorted(_):
+    """
+    Tests that migration files are sorted.
+    """
+    migration_files = _get_migration_files()
+    assert migration_files == ["20220424062956", "20220521155336", "20220522082435"]


### PR DESCRIPTION
`os.listdir` is used to list migration files stored in `sematic/db/migrations` in order to apply them at startup.

`os.listdir` does not guarantee the order in which files are returned, but migrations need to be applied in chronological order. This PR ensures this.