### PR TITLE
[bugfix] Make sure API payloads contain UTC timestamps

### DIFF
--- a/sematic/db/migrations/20220424062956_create_runs_table.sql
+++ b/sematic/db/migrations/20220424062956_create_runs_table.sql
@@ -5,12 +5,12 @@ CREATE TABLE runs (
     future_state TEXT NOT NULL,
     name TEXT,
     calculator_path TEXT,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    started_at timestamp without time zone,
-    ended_at timestamp without time zone,
-    resolved_at timestamp without time zone,
-    failed_at timestamp without time zone,
+    created_at timestamp WITH time zone NOT NULL,
+    updated_at timestamp WITH time zone NOT NULL,
+    started_at timestamp,
+    ended_at timestamp,
+    resolved_at timestamp,
+    failed_at timestamp,
     parent_id character(32),
 
     PRIMARY KEY (id)

--- a/sematic/db/migrations/20220514015440_create_artifacts_table.sql
+++ b/sematic/db/migrations/20220514015440_create_artifacts_table.sql
@@ -4,8 +4,8 @@ CREATE TABLE artifacts (
     -- sha1 hex digest are 40 characters
     id character(40) NOT NULL,
     json_summary JSONB NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
 
     PRIMARY KEY (id)
 );

--- a/sematic/db/migrations/20220527000512_add_edges_table.sql
+++ b/sematic/db/migrations/20220527000512_add_edges_table.sql
@@ -8,8 +8,8 @@ CREATE TABLE edges (
     destination_name TEXT,
     artifact_id character(40),
     parent_id character(32),
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
 
     PRIMARY KEY (id),
 

--- a/sematic/db/models/json_encodable_mixin.py
+++ b/sematic/db/models/json_encodable_mixin.py
@@ -33,7 +33,18 @@ def _to_json_encodable(value, column):
             return base64.b64encode(value).decode("ascii")
 
     if isinstance(value, datetime.datetime):
-        return value.isoformat()
+        # SQLite does not store timezone
+        utc_value = datetime.datetime(
+            value.year,
+            value.month,
+            value.day,
+            value.hour,
+            value.minute,
+            value.second,
+            value.microsecond,
+            tzinfo=datetime.timezone.utc,
+        )
+        return utc_value.isoformat()
 
     if isinstance(value, enum.Enum):
         return value.value

--- a/sematic/db/models/tests/BUILD
+++ b/sematic/db/models/tests/BUILD
@@ -16,3 +16,12 @@ pytest_test(
         "//sematic/db/models:run",
     ]
 )
+
+pytest_test(
+    name = "test_json_encodable_mixin",
+    srcs = ["test_json_encodable_mixin.py"],
+    deps = [
+        "//sematic/db/tests:fixtures",
+        "//sematic/db/models:run",
+    ]
+)

--- a/sematic/db/models/tests/test_json_encodable_mixin.py
+++ b/sematic/db/models/tests/test_json_encodable_mixin.py
@@ -1,0 +1,12 @@
+# Sematic
+from sematic.db.models.run import Run
+from sematic.db.tests.fixtures import run, persisted_run, test_db  # noqa: F401
+
+
+def test_utc_timestamp(persisted_run: Run):  # noqa: F811
+    """
+    Test that the JSON mixin outputs UTC times even if the DB does not
+    store it.
+    """
+    created_at = persisted_run.to_json_encodable()["created_at"]
+    assert created_at == "{}+00:00".format(persisted_run.created_at.isoformat())

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -4,13 +4,13 @@ CREATE TABLE runs (
     future_state TEXT NOT NULL,
     name TEXT,
     calculator_path TEXT,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    started_at timestamp without time zone,
-    ended_at timestamp without time zone,
-    resolved_at timestamp without time zone,
-    failed_at timestamp without time zone,
-    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32) NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
+    started_at timestamp,
+    ended_at timestamp,
+    resolved_at timestamp,
+    failed_at timestamp,
+    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32),
 
     PRIMARY KEY (id)
 );
@@ -18,8 +18,8 @@ CREATE TABLE artifacts (
     -- sha1 hex digest are 40 characters
     id character(40) NOT NULL,
     json_summary JSONB NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL, type_serialization JSONB NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL, type_serialization JSONB NOT NULL DEFAULT "{}",
 
     PRIMARY KEY (id)
 );
@@ -31,8 +31,8 @@ CREATE TABLE edges (
     destination_name TEXT,
     artifact_id character(40),
     parent_id character(32),
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
 
     PRIMARY KEY (id),
 


### PR DESCRIPTION
SQLite does not store timezone info by default. All timestamps are stored in UTC. This PR makes sure that the API returns timestamps marked as UTC.