### PR TITLE
Tuple support, SDK + UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
+* HEAD
+    * [feature] Support for Tuple types
 * 0.2.0
     * [bugfix] UI scroll issues
     * [bugfix] Dataframe UI previews fails for null/NaN values

--- a/docs/type-support.md
+++ b/docs/type-support.md
@@ -12,7 +12,7 @@ The type hints are used in the following way:
 In regular Python, type hints are used by mypy for static type checking but are
 not actually enforced at runtime.
 
-If a function declares it expected an argument `foo: int`, but an `"abc"` is
+If a function declares it expects an argument `foo: int`, but `"abc"` is
 passed, Python will not complain. This at-times practical behavior can be
 detrimental in long-running pipelines. Imagine a pipeline failing after 12 hours
 of processing because of a silly mistyped input (e.g. `foo / 2` in the case above).
@@ -38,7 +38,7 @@ Let's execute this Sematic Function:
 TypeError: Invalid input type for argument 'a' when calling '__main__.f'. Cannot cast 'abc' to <class 'int'>
 ```
 
-Sematic will not even let us generate a future of the `f`.
+Sematic will not even let us generate a future of `f`.
 
 Now let's pass a valid `int`:
 

--- a/sematic/types/BUILD
+++ b/sematic/types/BUILD
@@ -12,6 +12,7 @@ sematic_py_lib(
         "//sematic/types/types:none",
         "//sematic/types/types:union",
         "//sematic/types/types:list",
+        "//sematic/types/types:tuple",
         "//sematic/types/types:str",
         # Does not actually create a dependency on torch
         "//sematic/types/types/pytorch:init",

--- a/sematic/types/__init__.py
+++ b/sematic/types/__init__.py
@@ -8,6 +8,7 @@ import sematic.types.types.bool  # noqa: F401
 import sematic.types.types.dataclass  # noqa: F401
 import sematic.types.types.integer  # noqa: F401
 import sematic.types.types.list  # noqa: F401
+import sematic.types.types.tuple  # noqa: F401
 import sematic.types.types.float  # noqa: F401
 import sematic.types.types.none  # noqa: F401
 import sematic.types.types.union  # noqa: F401

--- a/sematic/types/registry.py
+++ b/sematic/types/registry.py
@@ -242,7 +242,7 @@ def is_valid_typing_alias(type_: Any) -> bool:
         return True
 
     if isinstance(type_, (_SpecialForm, _BaseGenericAlias)):  # type: ignore
-        raise ValueError("{} must be parametrized")
+        raise ValueError("{} must be parametrized".format(type_))
 
     return False
 

--- a/sematic/types/types/BUILD
+++ b/sematic/types/types/BUILD
@@ -86,3 +86,12 @@ sematic_py_lib(
         "//sematic/types:serialization",
     ]
 )
+
+sematic_py_lib(
+    name = "tuple",
+    srcs = ["tuple.py"],
+    deps = [
+        "//sematic/types:registry",
+        "//sematic/types:casting",
+    ]
+)

--- a/sematic/types/types/tests/BUILD
+++ b/sematic/types/types/tests/BUILD
@@ -57,3 +57,13 @@ pytest_test(
         "//sematic/types:serialization",
     ]
 )
+
+pytest_test(
+    name = "test_tuple",
+    srcs = ["test_tuple.py"],
+    deps = [
+        "//sematic/types:init",
+        "//sematic/types:casting",
+        "//sematic/types:serialization"
+    ]
+)

--- a/sematic/types/types/tests/test_tuple.py
+++ b/sematic/types/types/tests/test_tuple.py
@@ -1,0 +1,42 @@
+# Standard library
+from typing import Tuple
+
+# Third-party
+import pytest
+
+# Sematic
+from sematic.types.casting import safe_cast
+from sematic.types.serialization import get_json_encodable_summary
+
+
+@pytest.mark.parametrize(
+    "value, type_, expected_value, expected_error",
+    (
+        ((42, "foo"), Tuple[float, str], (42, "foo"), None),
+        ([42, "foo"], Tuple[float, str], (42, "foo"), None),
+        (
+            [42, 43],
+            Tuple[int, ...],
+            None,
+            "Sematic does not support Ellipsis in Tuples yet (...)",
+        ),
+        ((42,), Tuple[float, str], None, "Expected 2 elements, got 1: (42,)"),
+        (
+            ("foo",),
+            Tuple[float],
+            None,
+            "Cannot cast ('foo',) to typing.Tuple[float]: Cannot cast 'foo' to <class 'float'>",  # noqa: E501
+        ),
+    ),
+)
+def test_tuple(value, type_, expected_value, expected_error):
+    cast_value, error = safe_cast(value, type_)
+
+    assert error == expected_error
+    assert cast_value == expected_value
+
+
+def test_summary():
+    summary = get_json_encodable_summary(("foo", 42), Tuple[str, float])
+
+    assert summary == ["foo", 42]

--- a/sematic/types/types/tuple.py
+++ b/sematic/types/types/tuple.py
@@ -1,0 +1,67 @@
+# Standard Library
+from typing import Any, Iterable, List, Tuple, Type, Optional
+
+# Sematic
+from sematic.types.registry import (
+    register_safe_cast,
+    register_to_json_encodable_summary,
+    register_to_json_encodable,
+)
+from sematic.types.casting import safe_cast
+from sematic.types.serialization import (
+    value_to_json_encodable,
+    get_json_encodable_summary,
+)
+
+
+@register_safe_cast(tuple)
+def _tuple_safe_cast(
+    value: Tuple, type_: Type
+) -> Tuple[Optional[Tuple], Optional[str]]:
+    """
+    Casting logic for tuples.
+
+    Ellipsis not supported at this time.
+    """
+    if not isinstance(value, Iterable):
+        return None, "{} not an iterable".format(value)
+
+    element_types = type_.__args__
+
+    if element_types[-1] is ...:
+        return None, "Sematic does not support Ellipsis in Tuples yet (...)"
+
+    if len(value) != len(element_types):
+        return None, "Expected {} elements, got {}: {}".format(
+            len(element_types), len(value), repr(value)
+        )
+
+    result: List[Any] = []  # type: ignore
+
+    for element, element_type in zip(value, element_types):
+        cast_element, error = safe_cast(element, element_type)
+        if error is not None:
+            return None, "Cannot cast {} to {}: {}".format(repr(value), type_, error)
+
+        result.append(cast_element)
+
+    return tuple(result), None
+
+
+@register_to_json_encodable(tuple)
+def _tuple_to_json_encodable(value: Tuple, type_: Type) -> List:
+    return [
+        value_to_json_encodable(element, element_type)
+        for element, element_type in zip(value, type_.__args__)
+    ]
+
+
+@register_to_json_encodable_summary(tuple)
+def _tuple_to_json_encodable_summary(value: Tuple, type_: Type) -> List:
+    """
+    Generate summary for the UI.
+    """
+    return [
+        get_json_encodable_summary(element, element_type)
+        for element, element_type in zip(value, type_.__args__)
+    ]

--- a/sematic/ui/src/types/Types.tsx
+++ b/sematic/ui/src/types/Types.tsx
@@ -21,6 +21,8 @@ import {
   TableRow,
   TableBody,
   Chip,
+  List,
+  ListItem,
 } from "@mui/material";
 const Plot = createPlotlyComponent(Plotly);
 
@@ -169,7 +171,7 @@ function ReprValueView(props: ValueViewProps) {
 
 function StrValueView(props: ValueViewProps) {
   return (
-    <Typography>
+    <Typography component="div">
       <pre>"{props.valueSummary}"</pre>
     </Typography>
   );
@@ -259,6 +261,27 @@ function ListValueView(props: ValueViewProps) {
         </TableRow>
       </TableBody>
     </Table>
+  );
+}
+
+function TupleValueView(props: ValueViewProps) {
+  let typeRepr = props.typeRepr as AliasTypeRepr;
+
+  let elementTypesRepr = typeRepr[2].args;
+
+  return (
+    <List>
+      {Array.from(props.valueSummary).map((element, index) => (
+        <ListItem key={index}>
+          {renderSummary(
+            props.typeSerialization,
+            element,
+            elementTypesRepr[index].type as TypeRepr,
+            index.toString()
+          )}
+        </ListItem>
+      ))}
+    </List>
   );
 }
 
@@ -620,6 +643,7 @@ const TypeComponents: Map<string, ComponentPair> = new Map([
   ["bool", { type: TypeView, value: BoolValueView }],
   ["FloatInRange", { type: FloatInRangeTypeView, value: FloatValueView }],
   ["list", { type: ListTypeView, value: ListValueView }],
+  ["tuple", { type: TypeView, value: TupleValueView }],
   ["dataclass", { type: DataclassTypeView, value: DataclassValueView }],
   ["Union", { type: UnionTypeView, value: ValueView }],
   [


### PR DESCRIPTION
Users should be able to use `Tuple` types in their Sematic functions:

```python
@sematic.func
def tuple_tuple(input: Tuple[float, str, bool]) -> Tuple[float, str, bool]:
    return input

tuple_tuple((42, "abc", True)).resolve()

```

![Screen Shot 2022-06-30 at 12 08 17 PM](https://user-images.githubusercontent.com/429433/176758469-772c6896-b67c-42db-9e61-90b5bcd29d01.png)

