### PR TITLE
Support for dictionaries: SDK + UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 * HEAD
     * [feature] Support for Tuple types
+    * [feature] Support for Dict types
 * 0.2.0
     * [bugfix] UI scroll issues
     * [bugfix] Dataframe UI previews fails for null/NaN values

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -18,7 +18,7 @@ of wasted time.
 
 Sematic provides the following execution stragegies:
 
-### Silent execution
+## Silent execution
 
 Silent execution runs your code locally (i.e. on your machine) and does not
 write anything to the database. Your pipeline will not show up in the UI.
@@ -31,7 +31,7 @@ To use this mode, simply do:
 >>> pipeline(...).resolve(tracking=False)
 ```
 
-### Local execution
+## Local execution
 
 This is the default mode. Your pipeline still runs on your local machine, but
 tracks execution in Sematic's database. Your pipeline's runs and artifacts are
@@ -54,7 +54,7 @@ cloud infrastructure. See [Deploy Sematic](./coming-soon.md).
 
 {% endhint %}
 
-### Cloud execution
+## Cloud execution
 
 {% hint style="warning" %}
 

--- a/docs/first-pipeline.md
+++ b/docs/first-pipeline.md
@@ -107,24 +107,26 @@ can do in Sematic functions:
 
 Really anything you can do in Python 🙂.
 
+Check out [A real ML pipeline](./real-example.md).
+
 {% endhint %}
 
 ## What happens when I decorate a function with `@sematic.func`?
 
 The `@sematic.func` decorator converts any plain Python function into a
 so-called ["Sematic Function"](glossary.md). Sematic functions are tracked by
-Sematic as pipeline steps. This means that there inputs and outputs are
-type-checked and tracked as [Artifacts](glossary.md), and that you will be able
+Sematic as pipeline steps. This means that their inputs and outputs are
+type-checked and tracked as [Artifacts](glossary.md#artifact), and that you will be able
 to inspect and visualize the function's execution in the UI.
 
-In the case of [cloud execution](glossary.md), each function can run as its own
+In the case of [cloud execution](glossary.md#cloud-execution), each function can run as its own
 isolated job with its own set of resources.
 
 {% hint style="info" %}
 
 Note that calling a Sematic Function returns a **Future** instead of the actual
 value returned by the decorated Python function. Read more about Futures in the
-[Glossary](glossary.md).
+[Glossary](glossary.md#future).
 
 Futures are the way Sematic constructs the execution graph of your pipeline.
 Futures support a subset of native Python's operation, although we are adding
@@ -133,7 +135,7 @@ details.
 
 In order to trigger the actual execution of a graph, you need to call
 `.resolve()` on the entry point of your graph, that is typically the function
-called `pipeline`. See the [Glossary](glossary.md) for more details.
+called `pipeline`. See the [Glossary](glossary.md#pipeline) for more details.
 
 {% endhint %}
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,7 +1,5 @@
 # Get started
 
-Welcome to Sematic, let's get you set up.
-
 ## Installation
 
 First, let's install Sematic
@@ -12,7 +10,7 @@ $ pip install sematic
 
 ## Starting the app
 
-Now you should be able to launch the Sematic App on your local with
+Now you should be able to launch the Sematic App on your local machine with
 
 ```shell
 $ sematic start
@@ -22,7 +20,7 @@ This will open the app in your browser.
 
 {% hint style="info" %}
 This runs the Sematic app on your local machine. To
-deploy it withing your cloud see [Deploying Sematic](deployment.md).
+deploy it within your cloud see [Deploying Sematic](deployment.md).
 {% endhint %}
 
 To stop the app, simply do

--- a/sematic/examples/add/__main__.py
+++ b/sematic/examples/add/__main__.py
@@ -2,7 +2,6 @@
 import logging
 
 # Sematic
-from sematic import LocalResolver
 from sematic.examples.add.pipeline import pipeline
 
 
@@ -12,6 +11,6 @@ if __name__ == "__main__":
     future = pipeline(1, 2, 3).set(
         name="Basic add example pipeline", tags=["example", "basic", "final"]
     )
-    result = future.resolve(LocalResolver())
+    result = future.resolve()
 
     logging.info(result)

--- a/sematic/types/BUILD
+++ b/sematic/types/BUILD
@@ -13,6 +13,7 @@ sematic_py_lib(
         "//sematic/types/types:union",
         "//sematic/types/types:list",
         "//sematic/types/types:tuple",
+        "//sematic/types/types:dict",
         "//sematic/types/types:str",
         # Does not actually create a dependency on torch
         "//sematic/types/types/pytorch:init",

--- a/sematic/types/__init__.py
+++ b/sematic/types/__init__.py
@@ -9,6 +9,7 @@ import sematic.types.types.dataclass  # noqa: F401
 import sematic.types.types.integer  # noqa: F401
 import sematic.types.types.list  # noqa: F401
 import sematic.types.types.tuple  # noqa: F401
+import sematic.types.types.dict  # noqa: F401
 import sematic.types.types.float  # noqa: F401
 import sematic.types.types.none  # noqa: F401
 import sematic.types.types.union  # noqa: F401

--- a/sematic/types/types/BUILD
+++ b/sematic/types/types/BUILD
@@ -95,3 +95,12 @@ sematic_py_lib(
         "//sematic/types:casting",
     ]
 )
+
+sematic_py_lib(
+    name = "dict",
+    srcs = ["dict.py"],
+    deps = [
+        "//sematic/types:registry",
+        "//sematic/types:casting",
+    ]
+)

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -1,0 +1,83 @@
+# Standard library
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type
+
+# Sematic
+from sematic.types.registry import (
+    register_safe_cast,
+    register_to_json_encodable,
+    register_to_json_encodable_summary,
+)
+from sematic.types.casting import safe_cast
+from sematic.types.serialization import (
+    get_json_encodable_summary,
+    value_to_json_encodable,
+)
+
+
+@register_safe_cast(dict)
+def _dict_safe_cast(value: Dict, type_: Type) -> Tuple[Optional[Dict], Optional[str]]:
+    """
+    Casting logic for dictionaries.
+    """
+    if not isinstance(value, Mapping):
+        return None, "{} is not a mapping. Cannot cast to {}.".format(
+            repr(value), type_
+        )
+
+    key_type, element_type = type_.__args__
+
+    cast_value = dict()
+
+    for key, element in value.items():
+        cast_key, error = safe_cast(key, key_type)
+        if error is not None:
+            return None, "Cannot cast {} to key type: {}".format(repr(key), error)
+
+        cast_element, error = safe_cast(element, element_type)
+
+        if error is not None:
+            return None, "Cannot cast {} to value type: {}".format(repr(element), error)
+
+        cast_value[cast_key] = cast_element
+
+    return cast_value, None
+
+
+@register_to_json_encodable(dict)
+def _dict_to_json_encodable(value: Dict, type_: Type) -> List[Tuple[Any, Any]]:
+    """
+    Dict serialization
+    """
+    key_type, element_type = type_.__args__
+
+    # Sorting keys for determinism
+    sorted_keys = sorted(value.keys())
+
+    return [
+        (
+            value_to_json_encodable(key, key_type),
+            value_to_json_encodable(value[key], element_type),
+        )
+        for key in sorted_keys
+    ]
+
+
+@register_to_json_encodable_summary(dict)
+def _dict_to_json_encodable_summary(value: Dict, type_: Type) -> List[Tuple[Any, Any]]:
+    """
+    UI summary for dict
+
+    TODO: Introduce a payload size limit like on List
+    """
+    key_type, element_type = type_.__args__
+
+    # Sorting keys for determinism
+    sorted_keys = sorted(value.keys())
+
+    return [
+        (
+            get_json_encodable_summary(key, key_type),
+            get_json_encodable_summary(value[key], element_type),
+        )
+        for key in sorted_keys
+    ]

--- a/sematic/types/types/tests/BUILD
+++ b/sematic/types/types/tests/BUILD
@@ -67,3 +67,13 @@ pytest_test(
         "//sematic/types:serialization"
     ]
 )
+
+pytest_test(
+    name = "test_dict",
+    srcs = ["test_dict.py"],
+    deps = [
+        "//sematic/types:init",
+        "//sematic/types:casting",
+        "//sematic/types:serialization",
+    ]
+)

--- a/sematic/types/types/tests/test_dict.py
+++ b/sematic/types/types/tests/test_dict.py
@@ -1,0 +1,36 @@
+# Standard library
+from typing import Dict, Union
+
+# Third-party
+import pytest
+
+# Sematic
+from sematic.types.casting import safe_cast
+from sematic.types.serialization import get_json_encodable_summary
+
+
+@pytest.mark.parametrize(
+    "value, type_, expected_value, expected_error",
+    (
+        (dict(a=1), Dict[str, float], dict(a=1), None),
+        (dict(a=1, b="foo"), Dict[str, Union[float, str]], dict(a=1, b="foo"), None),
+        (dict(), Dict[str, float], dict(), None),
+        (
+            dict(a="foo"),
+            Dict[str, int],
+            None,
+            "Cannot cast 'foo' to value type: Cannot cast 'foo' to <class 'int'>",
+        ),
+    ),
+)
+def test_dict(value, type_, expected_value, expected_error):
+    cast_value, error = safe_cast(value, type_)
+
+    assert error == expected_error
+    assert cast_value == expected_value
+
+
+def test_dict_summary():
+    summary = get_json_encodable_summary(dict(a=123), Dict[str, int])
+
+    assert summary == [("a", 123)]

--- a/sematic/types/types/tuple.py
+++ b/sematic/types/types/tuple.py
@@ -50,6 +50,9 @@ def _tuple_safe_cast(
 
 @register_to_json_encodable(tuple)
 def _tuple_to_json_encodable(value: Tuple, type_: Type) -> List:
+    """
+    Serialization of tuples
+    """
     return [
         value_to_json_encodable(element, element_type)
         for element, element_type in zip(value, type_.__args__)

--- a/sematic/ui/src/types/Types.tsx
+++ b/sematic/ui/src/types/Types.tsx
@@ -23,6 +23,7 @@ import {
   Chip,
   List,
   ListItem,
+  TableHead,
 } from "@mui/material";
 const Plot = createPlotlyComponent(Plotly);
 
@@ -439,6 +440,38 @@ function DataclassValueView(props: ValueViewProps) {
   );
 }
 
+function DictValueView(props: ValueViewProps) {
+  let typeRepr = props.typeRepr as AliasTypeRepr;
+
+  let keyTypeRepr = typeRepr[2].args[0].type as TypeRepr;
+  let valueTypeRepr = typeRepr[2].args[1].type as TypeRepr;
+
+  let valueSummary = props.valueSummary as [any, any];
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>key</TableCell>
+          <TableCell>value</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {Array.from(valueSummary).map((pair, index) => (
+          <TableRow key={index}>
+            <TableCell>
+              {renderSummary(props.valueSummary, pair[0], keyTypeRepr)}
+            </TableCell>
+            <TableCell>
+              {renderSummary(props.valueSummary, pair[1], valueTypeRepr)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
 function TorchDataLoaderValueView(props: ValueViewProps) {
   let { valueSummary } = props;
 
@@ -644,6 +677,7 @@ const TypeComponents: Map<string, ComponentPair> = new Map([
   ["FloatInRange", { type: FloatInRangeTypeView, value: FloatValueView }],
   ["list", { type: ListTypeView, value: ListValueView }],
   ["tuple", { type: TypeView, value: TupleValueView }],
+  ["dict", { type: TypeView, value: DictValueView }],
   ["dataclass", { type: DataclassTypeView, value: DataclassValueView }],
   ["Union", { type: UnionTypeView, value: ValueView }],
   [


### PR DESCRIPTION
Users should be able to do
```python
@sematic.finc
def pipeline(input: Dict[str, float]) -> Dict[str, float]:
    return input

pipeline(dict(a=123).resolve()
```

UI treatment:
![Screen Shot 2022-06-30 at 3 34 53 PM](https://user-images.githubusercontent.com/429433/176789806-573a3efe-c172-433f-8235-ee096de9c97c.png)

