### PR TITLE
fix public roadmap link in docs

### DIFF
--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -58,7 +58,7 @@ cloud infrastructure. See [Deploy Sematic](./coming-soon.md).
 
 {% hint style="warning" %}
 
-Cloud execution is currently under development, check our [public roadmap]().
+Cloud execution is currently under development, check our [public roadmap](https://trello.com/b/AznpHZ7e/sematic-roadmap).
 
 {% endhint %}
 


### PR DESCRIPTION
Fix the link to public roadmap on Trello