### PR TITLE
Support for getitem and iter on futures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+* HEAD
+    * [feature] `getitem` support for futures of list, tuples, dictionaries
+    * [feature] `__iter__` support for futures of tuples
 * 0.4.0
     * [feature] ability to deploy the Sematic API to a cloud instance and run
       pipelines against it (pipeline still runs locally)

--- a/docs/future-algebra.md
+++ b/docs/future-algebra.md
@@ -108,6 +108,60 @@ def pipeline(a: float, b: float) -> List[float]:
 Here Sematic will know how to convert `List[Future[float]]` into
 `Future[List[float]]`.
 
+### Item access
+
+If a future is of type `Future[List[T]]`, `Future[Dict[K, V]]`, or
+`Future[Tuple[U, V]]`, you can access elements of the container directly using
+standard Python notations.
+
+If `future` is of type `Future[List[T]]` or `Future[Tuple[U, V]]`, you can do `future[i]` where `i` is an `int`.
+
+If `future` is of type `Future[Dict[K, V]]`, you can do `future[key]`, where `key` is of type `K` (usually `str`).
+
+For example:
+
+```python
+@sematic.func
+def foo() -> Tuple[int, str]:
+    return 42, "foo"
+
+@sematic.func
+def pipeline() -> str:
+    a = foo()[1]
+    return a
+```
+
+### Unpacking and iterating on tuples
+
+If a future is of type `Future[Tuple[T, U]]`, it can be unpacked using standard Python syntax.
+
+For example, unpacking:
+
+```python
+@sematic.func
+def foo() -> Tuple[int, str]:
+    return 42, "foo"
+
+@sematic.func
+def pipeline() -> str:
+    a, b = foo()
+    return b
+```
+
+Iteration:
+```python
+@sematic.func
+def foo() -> Tuple[int, str]:
+    return 42, "foo"
+
+@sematic.func
+def pipeline():
+    for a in foo():
+        some_list.append(process(a))
+    
+    return
+```
+
 ## Currently unsupported behaviors
 
 We are working hard to move these unsupported behaviors to the supported section
@@ -145,7 +199,7 @@ def pipeline(...) -> MyOutput:
     return make_output(foo, bar)
 ```
 
-### Unpacking and iteration
+### Unpacking and iteration on lists
 
 If your future is a `Future[List[T]]`, you cannot currently unpack it or iterate
 on it.
@@ -172,11 +226,7 @@ def iterate_on_list(some_list: List[U]) -> T:
         ...
 ```
 
-### Attribute and item access
-
-At this time, if `future` is of type `Future[List[T]]`, you cannot do `future[0]`.
-
-If `future` is of type `Future[Dict[K, V]]`, you cannot do `future["some-key"]`.
+### Attribute access
 
 If `future` is of type `Future[SomeClass]` where `SomeClass` has an attribute
 named `foo`, you cannot do `future.foo`.
@@ -193,16 +243,6 @@ def pipeline() -> T:
     future = some_sematic_func()
     return get_attr(future, "foo")
 ```
-
-Here is a workaround for item access:
-
-```python
-@sematic.func
-def get_item(obj: List[T], item: int) -> T:
-    return obj[item]
-```
-
-Use a similar approach for dictionaries.
 
 ### Arithmetic operations
 

--- a/requirements/ci-requirements.txt
+++ b/requirements/ci-requirements.txt
@@ -17,4 +17,5 @@ snowflake-connector-python
 
 # To generate the wheel
 mistune==0.8.4
+docutils==0.18.1
 m2r

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -7,6 +7,7 @@ sematic_py_lib(
         "//sematic/resolvers:local_resolver",
         "//sematic/types:init",
         "//sematic/types:casting",
+        "//sematic/future_operators:init",
     ]
 )
 

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -5,3 +5,4 @@ from sematic.calculator import func  # noqa: F401
 from sematic.resolver import Resolver  # noqa: F401
 from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401
 import sematic.types  # noqa: F401
+import sematic.future_operators  # noqa: F401

--- a/sematic/future_operators/BUILD
+++ b/sematic/future_operators/BUILD
@@ -1,0 +1,27 @@
+sematic_py_lib(
+    name = "init",
+    srcs = ["__init__.py"],
+    deps = [
+        ":getitem",
+        ":iter",
+    ]
+)
+
+sematic_py_lib(
+    name = "getitem",
+    srcs = ["getitem.py"],
+    deps = [
+        "//sematic:future",
+        "//sematic/types:casting",
+        "//sematic:calculator",
+    ]
+)
+
+sematic_py_lib(
+    name = "iter",
+    srcs = ["iter.py"],
+    deps = [
+        "//sematic:future",
+        "//sematic/future_operators:getitem"
+    ]
+)

--- a/sematic/future_operators/__init__.py
+++ b/sematic/future_operators/__init__.py
@@ -1,0 +1,2 @@
+import sematic.future_operators.getitem  # noqa: F401
+import sematic.future_operators.iter  # noqa: F401

--- a/sematic/future_operators/getitem.py
+++ b/sematic/future_operators/getitem.py
@@ -1,0 +1,56 @@
+# Standard library
+from types import GenericAlias
+from typing import Any, cast
+
+# Sematic
+from sematic.future import Future
+from sematic.types.casting import can_cast_type, safe_cast
+from sematic.calculator import func
+
+
+def __getitem__(self: Future, key: Any):
+    """
+    Implementation of __getitem__ on Futures.
+
+    When users try to access an item on a future returning a list, tuple, dict,
+    a new Sematic Function needs to be created on the fly to access the item.
+    """
+    future_type: GenericAlias = cast(GenericAlias, self.calculator.output_type)
+
+    try:
+        origin_type = future_type.__origin__
+    except AttributeError:
+        raise TypeError("__getitem__ is not supported on type {}".format(future_type))
+
+    if origin_type not in (tuple, list, dict):
+        raise TypeError("__getitem__ is not supported on type {}".format(future_type))
+
+    element_types = future_type.__args__
+
+    if origin_type is dict:
+        key_type, value_type = element_types
+
+        if isinstance(key, Future):
+            _, error = can_cast_type(key.calculator.output_type, key_type)
+        else:
+            _, error = safe_cast(key, key_type)
+
+        if error is not None:
+            raise TypeError("Invalid key {}: {}".format(repr(key), error))
+
+    if origin_type is tuple:
+        key_type = int
+        value_type = element_types[key]
+
+    if origin_type is list:
+        key_type = int
+        value_type = element_types[0]
+
+    @func
+    def _getitem(container: future_type, key: key_type) -> value_type:  # type: ignore
+        return container[key]  # type: ignore
+
+    return _getitem(self, key)
+
+
+Future.__getitem__ = __getitem__  # type: ignore

--- a/sematic/future_operators/getitem.py
+++ b/sematic/future_operators/getitem.py
@@ -1,3 +1,7 @@
+"""
+Defining these operators in seperate modules in order to avoid circular
+dependencies between Future and Calculator
+"""
 # Standard library
 from types import GenericAlias
 from typing import Any, cast

--- a/sematic/future_operators/iter.py
+++ b/sematic/future_operators/iter.py
@@ -1,0 +1,27 @@
+# standard library
+from types import GenericAlias
+from typing import cast
+
+# Sematic
+from sematic.future import Future
+from sematic.future_operators.getitem import __getitem__
+
+
+def __iter__(self: Future):
+    is_tuple_future = False
+    future_type: GenericAlias = cast(GenericAlias, self.calculator.output_type)
+
+    try:
+        is_tuple_future = future_type.__origin__ is tuple
+    except AttributeError:
+        pass
+
+    if not is_tuple_future:
+        raise NotImplementedError(
+            "Future.__iter__ is only supported on Tuple futures. Find a workaround at https://docs.sematic.ai/diving-deeper/future-algebra#unpacking-and-iteration"  # noqa: E501
+        )
+
+    yield from [__getitem__(self, idx) for idx, _ in enumerate(future_type.__args__)]
+
+
+Future.__iter__ = __iter__  # type: ignore

--- a/sematic/future_operators/iter.py
+++ b/sematic/future_operators/iter.py
@@ -8,6 +8,14 @@ from sematic.future_operators.getitem import __getitem__
 
 
 def __iter__(self: Future):
+    """
+    Implementation of __iter__ on Futures.
+
+    When users try to iterate on a future returning an iterable, a list of
+    futures needs to be returned.
+
+    Only supporting tuples for now.
+    """
     is_tuple_future = False
     future_type: GenericAlias = cast(GenericAlias, self.calculator.output_type)
 

--- a/sematic/future_operators/tests/BUILD
+++ b/sematic/future_operators/tests/BUILD
@@ -1,0 +1,19 @@
+pytest_test(
+    name = "test_getitem",
+    srcs = ["test_getitem.py"],
+    deps = [
+        "//sematic:future",
+        "//sematic/future_operators:getitem",
+        "//sematic:calculator",
+    ]
+)
+
+pytest_test(
+    name = "test_iter",
+    srcs = ["test_iter.py"],
+    deps = [
+        "//sematic:future",
+        "//sematic:calculator",
+        "//sematic/future_operators:iter",
+    ]
+)

--- a/sematic/future_operators/tests/test_getitem.py
+++ b/sematic/future_operators/tests/test_getitem.py
@@ -1,0 +1,30 @@
+# Standard library
+from typing import List
+
+# Sematic
+from sematic.future import Future
+import sematic.future_operators.getitem  # # noqa: F401
+from sematic.calculator import func
+
+
+@func
+def foo() -> List[str]:
+    return ["foo", "bar", "bat"]
+
+
+@func
+def pipeline() -> str:
+    return foo()[1]
+
+
+def test_getitem():
+
+    a = foo()[0]
+
+    assert isinstance(a, Future)
+    assert a.kwargs["key"] == 0
+    assert a.calculator.output_type is str
+
+
+def test_resolution():
+    assert pipeline().resolve(tracking=False) == "bar"

--- a/sematic/future_operators/tests/test_iter.py
+++ b/sematic/future_operators/tests/test_iter.py
@@ -1,0 +1,35 @@
+# Standard library
+from typing import Tuple
+
+# Sematic
+from sematic.future import Future
+import sematic.future_operators.iter  # # noqa: F401
+from sematic.calculator import func
+
+
+@func
+def foo() -> Tuple[int, str]:
+    return 42, "foo"
+
+
+@func
+def pipeline() -> str:
+    _, b = foo()
+
+    return b
+
+
+def test_iter():
+    a, b = foo()
+
+    assert isinstance(a, Future)
+    assert a.kwargs["key"] == 0
+    assert a.calculator.output_type is int
+
+    assert isinstance(b, Future)
+    assert b.kwargs["key"] == 1
+    assert b.calculator.output_type is str
+
+
+def test_resolution():
+    assert pipeline().resolve(tracking=False) == "foo"

--- a/sematic/tests/test_future.py
+++ b/sematic/tests/test_future.py
@@ -44,16 +44,6 @@ def test_no_tracking():
     assert foo().resolve(tracking=False) == "foo"
 
 
-def test_getitem():
-    with pytest.raises(NotImplementedError, match="docs.sematic.ai"):
-        foo()[0]
-
-
-def test_iter():
-    with pytest.raises(NotImplementedError, match="docs.sematic.ai"):
-        a, b = foo()
-
-
 def test_bool():
     with pytest.raises(NotImplementedError, match="docs.sematic.ai"):
         if foo():


### PR DESCRIPTION
Now users can do
```python
@sematic.func
def foo() -> Tuple[int, str]:
    return 42, "foo"

@sematic.func
def pipeline() -> str:
    a = foo()[1]
    return a
```

and

```python
@sematic.func
def foo() -> Tuple[int, str]:
    return 42, "foo"

@sematic.func
def pipeline() -> str:
    a, b = foo()
    return b
```