### PR TITLE
Fixes Timestamp JSON serialization by defaulting to `str`

### DIFF
--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -48,7 +48,9 @@ def make_artifact(value: typing.Any, type_: typing.Any) -> Artifact:
         id=_get_value_sha1_digest(
             value_serialization, type_serialization, json_summary
         ),
-        json_summary=_fix_nan_inf(json.dumps(json_summary, sort_keys=True)),
+        json_summary=_fix_nan_inf(
+            json.dumps(json_summary, sort_keys=True, default=str)
+        ),
         type_serialization=json.dumps(type_serialization, sort_keys=True),
         created_at=datetime.datetime.utcnow(),
         updated_at=datetime.datetime.utcnow(),
@@ -69,7 +71,9 @@ def _get_value_sha1_digest(
         # Should there be some sort of type versioning concept here?
     }
 
-    binary = _fix_nan_inf(json.dumps(payload, sort_keys=True)).encode("utf-8")
+    binary = _fix_nan_inf(json.dumps(payload, sort_keys=True, default=str)).encode(
+        "utf-8"
+    )
 
     sha1_digest = hashlib.sha1(binary)
 

--- a/sematic/types/types/pandas/dataframe.py
+++ b/sematic/types/types/pandas/dataframe.py
@@ -19,7 +19,7 @@ def _dataframe_json_encodable_summary(value: pandas.DataFrame, _) -> Any:
     payload: Any = value.to_dict()
     index = list(value.index)
 
-    if len(json.dumps(payload)) > _PAYLOAD_CUTOFF:
+    if len(json.dumps(payload, default=str)) > _PAYLOAD_CUTOFF:
         payload = value.head().to_dict()
         index = index[: len(value.head())]
         truncated = True

--- a/sematic/types/types/pandas/tests/BUILD
+++ b/sematic/types/types/pandas/tests/BUILD
@@ -5,6 +5,7 @@ pytest_test(
     deps = [
         "//sematic/types:serialization",
         "//sematic/types:init",
+        "//sematic/db/models:factories",
         requirement("pandas")
     ]
 )

--- a/sematic/types/types/pandas/tests/test_dataframe.py
+++ b/sematic/types/types/pandas/tests/test_dataframe.py
@@ -1,9 +1,12 @@
 # Third-party
+import datetime
 import os
 import pandas
+import json
 
 # Sematic
 from sematic.types.serialization import get_json_encodable_summary
+from sematic.db.models.factories import make_artifact
 
 
 def test_dataframe_summary():
@@ -18,3 +21,14 @@ def test_dataframe_summary():
     assert len(list(summary["dataframe"].values())[0]) == 5
     assert len(summary["describe"]) == 12
     assert len(summary["isna"]) == 19
+
+
+def test_dataframe_datetime():
+    timestamp = datetime.datetime.now()
+    df = pandas.DataFrame([dict(a=timestamp)])
+
+    artifact = make_artifact(df, pandas.DataFrame)
+
+    assert json.loads(artifact.json_summary)["dataframe"] == {
+        "a": {"0": str(timestamp)}
+    }


### PR DESCRIPTION
Fixes #63 