### PR TITLE
Add friendly error message for bad python versions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
+* HEAD
+    * [improvement] Friendly error message for unsupported Python version
 * 0.9.0
     * [feature] Grafana integration for log panels
 * 0.8.0

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -1,13 +1,27 @@
 """
 Sematic Public API
 """
-from sematic.calculator import func  # noqa: F401
-from sematic.resolver import Resolver  # noqa: F401
-from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401
-from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401
-from sematic.resolvers.resource_requirements import (  # noqa: F401
+import sys
+
+MIN_PYTHON_VERSION = (3, 9, 0)
+_CURRENT_PYTHON_VERSION = sys.version_info[0:3]
+
+if _CURRENT_PYTHON_VERSION < MIN_PYTHON_VERSION:
+    _min_version_as_str = ".".join(str(i) for i in MIN_PYTHON_VERSION)
+    _current_version_as_str = ".".join(str(i) for i in _CURRENT_PYTHON_VERSION)
+    raise RuntimeError(
+        f"Sematic requires python to be at {_min_version_as_str} or above, "
+        f"but you are running {_current_version_as_str}. Please upgrade "
+        f"to continue."
+    )
+
+from sematic.calculator import func  # noqa: F401,E402
+from sematic.resolver import Resolver  # noqa: F401,E402
+from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401,E402
+from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
+from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
     ResourceRequirements,
     KubernetesResourceRequirements,
 )
-import sematic.types  # noqa: F401
-import sematic.future_operators  # noqa: F401
+import sematic.types  # noqa: F401,E402
+import sematic.future_operators  # noqa: F401,E402


### PR DESCRIPTION
Addresses https://github.com/sematic-ai/sematic/issues/73

Users can currently receive a message like this if they try to use Sematic with invalid python versions:
```
    from typing import (  # type: ignore
ImportError: cannot import name 'GenericAlias' from 'typing' (/usr/lib/python3.7/typing.py)
```

For folks installing with pip, this shouldn't be possible, but other mechanisms of depending on sematic might make it possible to try it with older interpreters. For such users, we should make the message more explicit.

## Testing
This turns out to be surprisingly difficult to write an automated test for, since the mocking/patching libs apparently rely on importing the module first to apply the patch (makes sense, but it means that we can't mock the current/min versions before the checking code has already run and the module import is cached). However, I tested it manually by changing the minimum version to something higher than the interpreter I was testing with and confirmed that `bazel test //sematic/tests:test_init` failed. Leaving it at 3.9.0, `bazel test //sematic/tests:test_init` passes.