### PR TITLE
New `Link` type to display buttons in the UI

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 * [A real ML pipeline](real-example.md)
 * [The Sematic UI](sematic-ui.md)
 * [The Sematic CLI](cli.md)
+* [Types](types.md)
 * [Local and Cloud execution](execution-modes.md)
 * [Sematic vs. _____](sematic-vs.md)
 * [Join us on Discord](https://discord.gg/4KZJ6kYVax)

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,26 @@
+# Types
+
+Sematic comes with a number of types for greater convenience.
+
+## `Link` type
+
+If you need to output a URL in one of your Sematic functions and you would like
+this URL to be clickable in the UI. Use the `Link` type as such:
+
+```python
+from sematic.types import Link
+
+@sematic.func
+def my_function() -> Link:
+    return Link(
+        label="Sematic documentation",
+        url="https://docs.sematic.dev",
+    )
+```
+
+and the following button will show up in the UI:
+
+![Link view in the UI](https://user-images.githubusercontent.com/429433/183307054-5361cb1d-fba2-4b81-80b4-fc73b817b1d9.png)
+
+Note that you can also return an instance of `Link` as part of a dataclass,
+list, tuple, or dictionary as well.

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,6 +1,6 @@
 # Types
 
-Sematic comes with a number of types for greater convenience.
+Sematic comes with a number of types for greater convenience. These types may have special support within Sematic, such as custom visualizations in the UI.
 
 ## `Link` type
 

--- a/sematic/types/BUILD
+++ b/sematic/types/BUILD
@@ -12,6 +12,7 @@ sematic_py_lib(
         "//sematic/types/types:none",
         "//sematic/types/types:union",
         "//sematic/types/types:list",
+        "//sematic/types/types:link",
         "//sematic/types/types:tuple",
         "//sematic/types/types:dict",
         "//sematic/types/types:str",
@@ -21,11 +22,11 @@ sematic_py_lib(
         "//sematic/types/types/plotly:init",
         # Does not actually create a dependency on pandas
         "//sematic/types/types/pandas:init",
-        # Does not actually create a dependency on matplotlib 
+        # Does not actually create a dependency on matplotlib
         "//sematic/types/types/matplotlib:init",
         # Does not actually create a dependency on snowflake
         "//sematic/types/types/snowflake:init",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -41,7 +42,7 @@ sematic_py_lib(
     srcs = ["generic_type.py"],
     deps = [
         ":type",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -62,8 +63,8 @@ sematic_py_lib(
     name = "serialization",
     srcs = ["serialization.py"],
     deps = [
-        ":registry",
         ":generic_type",
+        ":registry",
         requirement("cloudpickle"),
     ],
 )

--- a/sematic/types/__init__.py
+++ b/sematic/types/__init__.py
@@ -15,7 +15,7 @@ import sematic.types.types.none  # noqa: F401
 import sematic.types.types.union  # noqa: F401
 import sematic.types.types.str  # noqa: F401
 from sematic.types.types.float_in_range import FloatInRange  # noqa: F401
-
+from sematic.types.types.link import Link  # noqa: F401
 
 # PyTorch
 # Only activates if torch is available

--- a/sematic/types/types/BUILD
+++ b/sematic/types/types/BUILD
@@ -2,10 +2,10 @@ sematic_py_lib(
     name = "dataclass",
     srcs = ["dataclass.py"],
     deps = [
-        "//sematic/types:registry",
         "//sematic/types:casting",
+        "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -21,11 +21,11 @@ sematic_py_lib(
     name = "float_in_range",
     srcs = ["float_in_range.py"],
     deps = [
-        "//sematic/types:generic_type",
         "//sematic/types:casting",
+        "//sematic/types:generic_type",
         "//sematic/types:registry",
-        "//sematic/types:type",
         "//sematic/types:serialization",
+        "//sematic/types:type",
     ],
 )
 
@@ -38,17 +38,15 @@ sematic_py_lib(
     ],
 )
 
-
 sematic_py_lib(
     name = "list",
     srcs = ["list.py"],
     deps = [
-        "//sematic/types:registry",
         "//sematic/types:casting",
+        "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
-
 
 sematic_py_lib(
     name = "str",
@@ -56,7 +54,7 @@ sematic_py_lib(
     deps = [
         "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -65,7 +63,7 @@ sematic_py_lib(
     deps = [
         "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -75,7 +73,7 @@ sematic_py_lib(
         "//sematic/types:casting",
         "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 sematic_py_lib(
@@ -84,23 +82,29 @@ sematic_py_lib(
     deps = [
         "//sematic/types:registry",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 sematic_py_lib(
     name = "tuple",
     srcs = ["tuple.py"],
     deps = [
-        "//sematic/types:registry",
         "//sematic/types:casting",
-    ]
+        "//sematic/types:registry",
+    ],
 )
 
 sematic_py_lib(
     name = "dict",
     srcs = ["dict.py"],
     deps = [
-        "//sematic/types:registry",
         "//sematic/types:casting",
-    ]
+        "//sematic/types:registry",
+    ],
+)
+
+sematic_py_lib(
+    name = "link",
+    srcs = ["link.py"],
+    deps = [],
 )

--- a/sematic/types/types/link.py
+++ b/sematic/types/types/link.py
@@ -5,6 +5,23 @@ from urllib.parse import urlparse
 
 @dataclass
 class Link:
+    """
+    Link lets users return a URL from a Sematic function which
+    will render as a button in the UI.
+
+    Parameters
+    ----------
+    label: str
+        The label of the button that will be displayed in the UI
+    url: str
+        The URL to link to
+
+    Raises
+    ------
+    ValueError
+        In case of missing URL scheme and netloc as extracted by `urllib.parse.urlparse`.
+    """
+
     label: str
     url: str
 

--- a/sematic/types/types/link.py
+++ b/sematic/types/types/link.py
@@ -1,0 +1,17 @@
+# Standard library
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass
+class Link:
+    label: str
+    url: str
+
+    def __init__(self, label: str, url: str):
+        parsed_url = urlparse(url)
+        if len(parsed_url.scheme) == 0 or len(parsed_url.netloc) == 0:
+            raise ValueError("Incorrect URL: {}".format(repr(parsed_url)))
+
+        self.label = label
+        self.url = url

--- a/sematic/types/types/link.py
+++ b/sematic/types/types/link.py
@@ -27,8 +27,16 @@ class Link:
 
     def __init__(self, label: str, url: str):
         parsed_url = urlparse(url)
-        if len(parsed_url.scheme) == 0 or len(parsed_url.netloc) == 0:
-            raise ValueError("Incorrect URL: {}".format(repr(parsed_url)))
+
+        if len(parsed_url.scheme) == 0:
+            raise ValueError(
+                f"Incorrect URL, missing scheme (e.g. https://): {repr(parsed_url)}"
+            )
+
+        if len(parsed_url.netloc) == 0:
+            raise ValueError(
+                f"Incorrect URL, missing netloc (e.g. https://<netloc>): {repr(parsed_url)}"  # noqa: E501
+            )
 
         self.label = label
         self.url = url

--- a/sematic/types/types/tests/BUILD
+++ b/sematic/types/types/tests/BUILD
@@ -2,78 +2,86 @@ pytest_test(
     name = "test_dataclass",
     srcs = ["test_dataclass.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
-    ]
+        "//sematic/types:init",
+    ],
 )
 
 pytest_test(
     name = "test_float",
     srcs = ["test_float.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
-    ]
+        "//sematic/types:init",
+    ],
 )
 
 pytest_test(
     name = "test_float_in_range",
     srcs = ["test_float_in_range.py"],
     deps = [
+        "//sematic/types:casting",
         "//sematic/types:generic_type",
         "//sematic/types:init",
-        "//sematic/types:casting",
         "//sematic/types:serialization",
         "//sematic/types/types:float_in_range",
-    ]
+    ],
 )
 
 pytest_test(
     name = "test_integer",
     srcs = ["test_integer.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
+        "//sematic/types:init",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 pytest_test(
     name = "test_list",
     srcs = ["test_list.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
+        "//sematic/types:init",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 pytest_test(
     name = "test_none",
     srcs = ["test_none.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
+        "//sematic/types:init",
         "//sematic/types:serialization",
-    ]
+    ],
 )
 
 pytest_test(
     name = "test_tuple",
     srcs = ["test_tuple.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
-        "//sematic/types:serialization"
-    ]
+        "//sematic/types:init",
+        "//sematic/types:serialization",
+    ],
 )
 
 pytest_test(
     name = "test_dict",
     srcs = ["test_dict.py"],
     deps = [
-        "//sematic/types:init",
         "//sematic/types:casting",
+        "//sematic/types:init",
         "//sematic/types:serialization",
-    ]
+    ],
+)
+
+pytest_test(
+    name = "test_link",
+    srcs = ["test_link.py"],
+    deps = [
+        "//sematic/types/types:link",
+    ],
 )

--- a/sematic/types/types/tests/test_link.py
+++ b/sematic/types/types/tests/test_link.py
@@ -11,6 +11,13 @@ def test_url_validation_pass():
     assert link.url == "https://example.com"
 
 
-def test_url_validation_fail():
-    with pytest.raises(ValueError, match="Incorrect URL"):
-        Link(label="my link", url="foo")
+@pytest.mark.parametrize(
+    "expected_exception_str, url",
+    (
+        ("Incorrect URL, missing scheme", "foo"),
+        ("Incorrect URL, missing netloc", "foo://"),
+    ),
+)
+def test_url_validation_fail(expected_exception_str, url):
+    with pytest.raises(ValueError, match=expected_exception_str):
+        Link(label="my link", url=url)

--- a/sematic/types/types/tests/test_link.py
+++ b/sematic/types/types/tests/test_link.py
@@ -1,0 +1,16 @@
+# Sematic
+from sematic.types.types.link import Link
+
+# Third-party
+import pytest
+
+
+def test_url_validation_pass():
+    link = Link(label="my link", url="https://example.com")
+    assert link.label == "my link"
+    assert link.url == "https://example.com"
+
+
+def test_url_validation_fail():
+    with pytest.raises(ValueError, match="Incorrect URL"):
+        Link(label="my link", url="foo")

--- a/sematic/ui/src/types/Types.tsx
+++ b/sematic/ui/src/types/Types.tsx
@@ -24,7 +24,9 @@ import {
   List,
   ListItem,
   TableHead,
+  Button,
 } from "@mui/material";
+import { OpenInNew } from "@mui/icons-material";
 const Plot = createPlotlyComponent(Plotly);
 
 type TypeCategory = "builtin" | "typing" | "dataclass" | "generic" | "class";
@@ -663,6 +665,22 @@ function DataFrameValueView(props: ValueViewProps) {
   );
 }
 
+function LinkValueView(props: ValueViewProps) {
+  let { valueSummary } = props;
+  let { values } = valueSummary;
+
+  return (
+    <Button
+      href={values.url}
+      variant="contained"
+      target="blank"
+      endIcon={<OpenInNew />}
+    >
+      {values.label}
+    </Button>
+  );
+}
+
 type ComponentPair = {
   type: (props: TypeViewProps) => JSX.Element;
   value: (props: ValueViewProps) => JSX.Element;
@@ -680,6 +698,7 @@ const TypeComponents: Map<string, ComponentPair> = new Map([
   ["dict", { type: TypeView, value: DictValueView }],
   ["dataclass", { type: DataclassTypeView, value: DataclassValueView }],
   ["Union", { type: UnionTypeView, value: ValueView }],
+  ["Link", { type: TypeView, value: LinkValueView }],
   [
     "torch.utils.data.dataloader.DataLoader",
     { type: TypeView, value: TorchDataLoaderValueView },


### PR DESCRIPTION
This PR introduces a new `Link` type that enables users to display links in the UI.

```python
link = Link(label="Sematic documentation", url="https://docs.sematic.dev")
```

The type validates the passed `url` simply by checking that it has a `scheme` and `netloc`.


![Screen Shot 2022-08-07 at 12 05 51 PM](https://user-images.githubusercontent.com/429433/183307054-5361cb1d-fba2-4b81-80b4-fc73b817b1d9.png)
