### PR TITLE
Version compatibility check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
+<!--- When updating the version, update versions.py and sematic/BUILD accordingly -->
 * HEAD
     * [improvement] Friendly error message for unsupported Python version
+    * [improvement] Friendly error message when clients don't match server version
 * 0.9.0
     * [feature] Grafana integration for log panels
 * 0.8.0

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -109,6 +109,12 @@ sematic_py_lib(
     ],
 )
 
+sematic_py_lib(
+    name = "versions",
+    srcs = ["versions.py"],
+    deps = [],
+)
+
 sematic_py_wheel(
     name = "wheel",
     author = "Sematic AI, Inc.",
@@ -135,7 +141,7 @@ sematic_py_wheel(
         # how to fix versions
         "eventlet==0.30.2",
     ],
-    version = "0.9.0",  #+{BUILD_TIMESTAMP}",
+    version = "0.10.0",  #+{BUILD_TIMESTAMP}",  # When updating this, also update versions.py and changelog.md
     visibility = ["//visibility:public"],
     deps = [
         "//sematic:init",

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -47,6 +47,7 @@ sematic_py_lib(
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:run",
+        "//sematic/utils:retry",
         requirement("requests"),
     ],
 )
@@ -142,7 +143,7 @@ sematic_py_wheel(
         # how to fix versions
         "eventlet==0.30.2",
     ],
-    version = "0.10.0",  #+{BUILD_TIMESTAMP}",  # When updating this, also update versions.py and changelog.md
+    version = "0.9.0",  #+{BUILD_TIMESTAMP}",  # When updating this, also update versions.py and changelog.md
     visibility = ["//visibility:public"],
     deps = [
         "//sematic:init",

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -43,6 +43,7 @@ sematic_py_lib(
     srcs = ["api_client.py"],
     deps = [
         ":config",
+        "//sematic:versions",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:run",

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -25,3 +25,4 @@ from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
 )
 import sematic.types  # noqa: F401,E402
 import sematic.future_operators  # noqa: F401,E402
+from sematic.versions import CURRENT_VERSION_STR as __version__  # noqa: F401,E402

--- a/sematic/api/BUILD
+++ b/sematic/api/BUILD
@@ -18,6 +18,7 @@ sematic_py_lib(
         "//sematic/api/endpoints:artifacts",
         "//sematic/api/endpoints:auth",
         "//sematic/api/endpoints:edges",
+        "//sematic/api/endpoints:meta",
         "//sematic/api/endpoints:notes",
         "//sematic/api/endpoints:runs",
         requirement("flask"),

--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -50,6 +50,16 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "meta",
+    srcs = ["meta.py"],
+    deps = [
+        "//sematic/api:app",
+        "//sematic:versions",
+        requirement("flask"),
+    ],
+)
+
+sematic_py_lib(
     name = "notes",
     srcs = ["notes.py"],
     deps = [

--- a/sematic/api/endpoints/auth.py
+++ b/sematic/api/endpoints/auth.py
@@ -1,7 +1,7 @@
 # Standard library
 import functools
 from http import HTTPStatus
-from typing import Callable, Optional
+from typing import Callable
 import distutils.util
 
 # Third-party
@@ -23,7 +23,6 @@ from sematic.db.queries import (
     save_user,
 )
 from sematic.user_settings import MissingSettingsError, SettingsVar, get_user_settings
-from sematic.db.models.user import User
 
 
 @sematic_api.route("/authenticate", methods=["GET"])
@@ -160,20 +159,3 @@ def authenticate(endpoint_fn: Callable) -> Callable:
         return endpoint_fn(user, *args, **kwargs)
 
     return endpoint
-
-
-@sematic_api.route("/env", methods=["GET"])
-@authenticate
-def env_endpoint(user: Optional[User]) -> flask.Response:
-    env = {}
-    for settings in (
-        SettingsVar.GOOGLE_OAUTH_CLIENT_ID,
-        SettingsVar.KUBERNETES_NAMESPACE,
-        SettingsVar.GRAFANA_PANEL_URL,
-    ):
-        try:
-            env[settings.value] = get_user_settings(settings)
-        except MissingSettingsError:
-            continue
-
-    return flask.jsonify(dict(env=env))

--- a/sematic/api/endpoints/meta.py
+++ b/sematic/api/endpoints/meta.py
@@ -35,9 +35,10 @@ def get_server_version_info() -> flask.Response:
     return flask.jsonify(payload)
 
 
-@sematic_api.route("/env", methods=["GET"])
+@sematic_api.route("/api/v1/meta/env", methods=["GET"])
 @authenticate
 def env_endpoint(user: Optional[User]) -> flask.Response:
+    """Return a dictionary with information about the configuration of the server"""
     env = {}
     for settings in (
         SettingsVar.GOOGLE_OAUTH_CLIENT_ID,

--- a/sematic/api/endpoints/meta.py
+++ b/sematic/api/endpoints/meta.py
@@ -1,0 +1,52 @@
+"""Metadata about the server itself."""
+
+# Standard
+from typing import Optional
+
+# Third-party
+import flask
+
+# Sematic
+from sematic.api.app import sematic_api
+from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
+from sematic.db.models.user import User
+from sematic.user_settings import MissingSettingsError, SettingsVar, get_user_settings
+from sematic.api.endpoints.auth import authenticate
+
+
+@sematic_api.route("/api/v1/meta/versions", methods=["GET"])
+def get_server_version_info() -> flask.Response:
+    """Get information about the server version and clients it supports
+
+    Returns
+    -------
+    A flask response with a json payload. The payload has two fields:
+        server: the version of Sematic the server is running, as 3 integers. Note that
+            clients whose version is greater than this may not work with the server.
+        min_client_supported: the minimum version of Sematic the current server version
+            supports. Clients with versions less than this may fail when used with the
+            server.
+    """
+    payload = dict(
+        server=CURRENT_VERSION,
+        min_client_supported=MIN_CLIENT_SERVER_SUPPORTS,
+    )
+
+    return flask.jsonify(payload)
+
+
+@sematic_api.route("/env", methods=["GET"])
+@authenticate
+def env_endpoint(user: Optional[User]) -> flask.Response:
+    env = {}
+    for settings in (
+        SettingsVar.GOOGLE_OAUTH_CLIENT_ID,
+        SettingsVar.KUBERNETES_NAMESPACE,
+        SettingsVar.GRAFANA_PANEL_URL,
+    ):
+        try:
+            env[settings.value] = get_user_settings(settings)
+        except MissingSettingsError:
+            continue
+
+    return flask.jsonify(dict(env=env))

--- a/sematic/api/endpoints/tests/BUILD
+++ b/sematic/api/endpoints/tests/BUILD
@@ -37,3 +37,16 @@ pytest_test(
         requirement("flask"),
     ],
 )
+
+pytest_test(
+    name = "test_meta",
+    srcs = ["test_meta.py"],
+    deps = [
+        "//sematic/api/endpoints:meta",
+        "//sematic/api:app",
+        "//sematic:user_settings",
+        "//sematic:versions",
+        "//sematic/api/tests:fixtures",
+        requirement("flask"),
+    ],
+)

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -1,6 +1,5 @@
 # Standard library
 from http import HTTPStatus
-from typing import Any, Dict, cast
 from unittest import mock
 import uuid
 

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -26,29 +26,6 @@ from sematic.api.app import sematic_api
 from sematic.user_settings import SettingsVar
 
 
-@pytest.mark.parametrize(
-    "authenticate_config, expected_providers",
-    ((True, {"GOOGLE_OAUTH_CLIENT_ID": "ABC123"}), (False, {})),
-)
-def test_authenticate_endpoint(
-    authenticate_config: bool,
-    expected_providers: Dict[str, str],
-    test_client: flask.testing.FlaskClient,  # noqa: F811
-):
-    with mock_user_settings(
-        {
-            SettingsVar.SEMATIC_AUTHENTICATE: authenticate_config,
-            SettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",
-        }
-    ):
-        response = test_client.get("/authenticate")
-
-        assert response.json == {
-            "authenticate": authenticate_config,
-            "providers": expected_providers,
-        }
-
-
 def test_login_new_user(test_client: flask.testing.FlaskClient):  # noqa: F811
     idinfo = {
         "hd": "example.com",
@@ -192,14 +169,3 @@ def test_authenticate_decorator_fail(
         response = test_client.get("/test-{}".format(test_id), headers=headers)
 
         assert response.status_code == HTTPStatus.UNAUTHORIZED
-
-
-def test_env(test_client: flask.testing.FlaskClient):  # noqa: F811
-    with mock_user_settings(
-        {SettingsVar.GRAFANA_PANEL_URL: "abc", SettingsVar.SEMATIC_AUTHENTICATE: False}
-    ):
-        response = test_client.get("/env")
-        payload = response.json
-        payload = cast(Dict[str, Any], payload)
-
-        assert payload["env"][SettingsVar.GRAFANA_PANEL_URL.value] == "abc"

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -2,6 +2,7 @@
 from http import HTTPStatus
 from unittest import mock
 import uuid
+from typing import Dict
 
 # Third-party
 import flask.testing
@@ -23,6 +24,29 @@ from sematic.db.tests.fixtures import test_db, persisted_user  # noqa: F401
 from sematic.api.endpoints.auth import authenticate
 from sematic.api.app import sematic_api
 from sematic.user_settings import SettingsVar
+
+
+@pytest.mark.parametrize(
+    "authenticate_config, expected_providers",
+    ((True, {"GOOGLE_OAUTH_CLIENT_ID": "ABC123"}), (False, {})),
+)
+def test_authenticate_endpoint(
+    authenticate_config: bool,
+    expected_providers: Dict[str, str],
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    with mock_user_settings(
+        {
+            SettingsVar.SEMATIC_AUTHENTICATE: authenticate_config,
+            SettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",
+        }
+    ):
+        response = test_client.get("/authenticate")
+
+        assert response.json == {
+            "authenticate": authenticate_config,
+            "providers": expected_providers,
+        }
 
 
 def test_login_new_user(test_client: flask.testing.FlaskClient):  # noqa: F811

--- a/sematic/api/endpoints/tests/test_meta.py
+++ b/sematic/api/endpoints/tests/test_meta.py
@@ -1,0 +1,63 @@
+# Standard library
+from typing import Any, Dict, cast
+
+# Third-party
+import flask.testing
+import flask
+import pytest
+
+# Sematic
+from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
+from sematic.api.tests.fixtures import (  # noqa: F401
+    mock_no_auth,
+    test_client,
+    mock_requests,
+    mock_user_settings,
+)
+from sematic.db.tests.fixtures import test_db, persisted_user  # noqa: F401
+import sematic.api.endpoints.meta  # noqa: F401
+from sematic.api.app import sematic_api  # noqa: F401
+from sematic.user_settings import SettingsVar
+
+
+@pytest.mark.parametrize(
+    "authenticate_config, expected_providers",
+    ((True, {"GOOGLE_OAUTH_CLIENT_ID": "ABC123"}), (False, {})),
+)
+def test_authenticate_endpoint(
+    authenticate_config: bool,
+    expected_providers: Dict[str, str],
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    with mock_user_settings(
+        {
+            SettingsVar.SEMATIC_AUTHENTICATE: authenticate_config,
+            SettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",
+        }
+    ):
+        response = test_client.get("/authenticate")
+
+        assert response.json == {
+            "authenticate": authenticate_config,
+            "providers": expected_providers,
+        }
+
+
+def test_env(test_client: flask.testing.FlaskClient):  # noqa: F811
+    with mock_user_settings(
+        {SettingsVar.GRAFANA_PANEL_URL: "abc", SettingsVar.SEMATIC_AUTHENTICATE: False}
+    ):
+        response = test_client.get("/env")
+        payload = response.json
+        payload = cast(Dict[str, Any], payload)
+
+        assert payload["env"][SettingsVar.GRAFANA_PANEL_URL.value] == "abc"
+
+
+def test_versions(test_client: flask.testing.FlaskClient):  # noqa: F811
+    response = test_client.get("/api/v1/meta/versions")
+    payload = response.json
+    payload = cast(Dict[str, Any], payload)
+
+    assert tuple(payload["server"]) == CURRENT_VERSION
+    assert tuple(payload["min_client_supported"]) == MIN_CLIENT_SERVER_SUPPORTS

--- a/sematic/api/endpoints/tests/test_meta.py
+++ b/sematic/api/endpoints/tests/test_meta.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, cast
 # Third-party
 import flask.testing
 import flask
-import pytest
 
 # Sematic
 from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
@@ -20,34 +19,11 @@ from sematic.api.app import sematic_api  # noqa: F401
 from sematic.user_settings import SettingsVar
 
 
-@pytest.mark.parametrize(
-    "authenticate_config, expected_providers",
-    ((True, {"GOOGLE_OAUTH_CLIENT_ID": "ABC123"}), (False, {})),
-)
-def test_authenticate_endpoint(
-    authenticate_config: bool,
-    expected_providers: Dict[str, str],
-    test_client: flask.testing.FlaskClient,  # noqa: F811
-):
-    with mock_user_settings(
-        {
-            SettingsVar.SEMATIC_AUTHENTICATE: authenticate_config,
-            SettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",
-        }
-    ):
-        response = test_client.get("/authenticate")
-
-        assert response.json == {
-            "authenticate": authenticate_config,
-            "providers": expected_providers,
-        }
-
-
 def test_env(test_client: flask.testing.FlaskClient):  # noqa: F811
     with mock_user_settings(
         {SettingsVar.GRAFANA_PANEL_URL: "abc", SettingsVar.SEMATIC_AUTHENTICATE: False}
     ):
-        response = test_client.get("/env")
+        response = test_client.get("/api/v1/meta/env")
         payload = response.json
         payload = cast(Dict[str, Any], payload)
 

--- a/sematic/api/server.py
+++ b/sematic/api/server.py
@@ -18,6 +18,7 @@ import sematic.api.endpoints.runs  # noqa: F401
 import sematic.api.endpoints.notes  # noqa: F401
 import sematic.api.endpoints.edges  # noqa: F401
 import sematic.api.endpoints.artifacts  # noqa: F401
+import sematic.api.endpoints.meta  # noqa: F401
 from sematic.config import (
     get_config,
     switch_env,

--- a/sematic/api/tests/fixtures.py
+++ b/sematic/api/tests/fixtures.py
@@ -17,7 +17,7 @@ import responses  # type: ignore
 
 # Sematic
 from sematic.db.tests.fixtures import test_db, pg_mock  # noqa: F401
-from sematic.config import get_config
+from sematic.config import get_config, switch_env
 import sematic.user_settings as user_settings
 
 # Importing from server instead of app to make sure
@@ -37,6 +37,10 @@ def test_client(test_db):  # noqa: F811
 # Credit to https://github.com/adamtheturtle/requests-mock-flask
 @pytest.fixture  # noqa: F811
 def mock_requests(test_client):
+    # This mock will place calls to an in-memory server, local configurations
+    # are the appropriate match.
+    switch_env("local")
+
     def _request_callback(request):
         environ_builder = werkzeug.test.EnvironBuilder(
             path=request.path_url,
@@ -66,7 +70,7 @@ def mock_requests(test_client):
                     callback=_request_callback, method=method, url=url
                 )
 
-        yield
+        yield request_mock
 
 
 @contextlib.contextmanager

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -32,6 +32,10 @@ class ServerError(Exception):
     pass
 
 
+class InvalidResponseError(Exception):
+    pass
+
+
 class IncompatibleClientError(Exception):
     pass
 
@@ -172,17 +176,21 @@ def _validate_server_compatibility_no_catch() -> None:
         "provide this information. Consider upgrading your server if possible, "
         "or reach out to Sematic for support."
     )
-    response = _request(
-        method=requests.get,
-        endpoint="/meta/versions",
-        attempt_auth=False,
-        validate_version_compatibility=False,  # to avoid recursion
-        error_response_kwarg_overrides=dict(
-            error_4xx=unexpected_server_response_error,
-            error_5xx=ServerError("The Sematic server is not responsive"),
-            error_json_decode_fail=unexpected_server_response_error,
-        ),
-    )
+
+    try:
+        response = _request(
+            method=requests.get,
+            endpoint="/meta/versions",
+            attempt_auth=False,
+            validate_version_compatibility=False,  # to avoid recursion
+            validate_json=True,
+        )
+    except BadRequestError:
+        raise unexpected_server_response_error
+    except ServerError:
+        raise ServerError("The Sematic server is not responsive")
+    except InvalidResponseError:
+        raise unexpected_server_response_error
 
     response_json = response.json()
     server_version = cast(Tuple[int, int, int], tuple(response_json["server"]))
@@ -220,17 +228,16 @@ def _request(
     kwargs: Optional[Dict[str, Any]] = None,
     attempt_auth: bool = True,
     validate_version_compatibility: bool = True,
-    error_response_kwarg_overrides: Dict[str, Any] = None,
+    validate_json: bool = False,
 ):
     """Internal function for wrapping requests.<get/put/etc.>.
 
     validate_version_compatibility indicates whether we should check that the
     Sematic server is compatible with this Sematic client.
 
-    error_response_kwarg_overrides provides overrides for how to handle
-    error HTTP responses in the form of overrides for the kwargs of _raise_for_response
+    validate_json indicates whether the response is expected to contain
+    valid json.
     """
-    error_response_kwarg_overrides = error_response_kwarg_overrides or {}
     if validate_version_compatibility:
         _validate_server_compatibility()
     kwargs = kwargs or {}
@@ -260,7 +267,7 @@ def _request(
 
     _raise_for_response(
         response,
-        **error_response_kwarg_overrides,
+        validate_json,
     )
 
     return response
@@ -268,17 +275,15 @@ def _request(
 
 def _raise_for_response(
     response: requests.Response,
-    error_4xx: Optional[Exception] = None,
-    error_5xx: Optional[Exception] = None,
-    error_json_decode_fail: Optional[Exception] = None,
+    validate_json: bool,
 ) -> None:
-    to_raise = None
+    to_raise: Optional[Exception] = None
     url = response.url
-    error_4xx = error_4xx or BadRequestError(
+    error_4xx = BadRequestError(
         f"The {response.request.method} request to {url} was invalid, "
         f"response was {response.status_code}"
     )
-    error_5xx = error_5xx or ServerError(
+    error_5xx = ServerError(
         f"The Sematic server could not handle the "
         f"{response.request.method} request to {url}",
     )
@@ -287,11 +292,15 @@ def _raise_for_response(
         to_raise = error_4xx
     if response.status_code >= 500:
         to_raise = error_5xx
-    if to_raise is None and error_json_decode_fail is not None:
+    if to_raise is None and validate_json:
         try:
             response.json()
         except Exception:
-            to_raise = error_json_decode_fail
+            to_raise = InvalidResponseError(
+                f"The Sematic server was expected to return json for "
+                f"{response.request.method} request to {url}, but the "
+                f"response was not json."
+            )
     if to_raise is None:
         return
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -185,12 +185,10 @@ def _validate_server_compatibility_no_catch() -> None:
             validate_version_compatibility=False,  # to avoid recursion
             validate_json=True,
         )
-    except BadRequestError:
+    except (BadRequestError, InvalidResponseError):
         raise unexpected_server_response_error
     except ServerError:
         raise ServerError("The Sematic server is not responsive")
-    except InvalidResponseError:
-        raise unexpected_server_response_error
 
     response_json = response.json()
     server_version = cast(Tuple[int, int, int], tuple(response_json["server"]))

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -1,6 +1,4 @@
 # Standard library
-from json import JSONDecodeError
-import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 import logging
 
@@ -15,6 +13,7 @@ from sematic.user_settings import MissingSettingsError, SettingsVar, get_user_se
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.run import Run
+from sematic.utils.retry import retry
 
 
 logger = logging.getLogger(__name__)
@@ -23,6 +22,22 @@ logger = logging.getLogger(__name__)
 # it is talking to before using the API, but we don't want to do that every
 # time. This caches whether we have validated it or not.
 _validated_client_version = False
+
+
+class APIConnectionError(ConnectionError):
+    pass
+
+
+class ServerError(Exception):
+    pass
+
+
+class IncompatibleClientError(Exception):
+    pass
+
+
+class BadRequestError(Exception):
+    pass
 
 
 def get_run(run_id: str) -> Run:
@@ -82,6 +97,13 @@ def _notify_event(namespace: str, event: str, payload: Any = None):
     _post("/events/{}/{}".format(namespace, event), payload)
 
 
+@retry(
+    exceptions=(ServerError, APIConnectionError),
+    tries=4,
+    delay=1,
+    backoff=2,
+    jitter=0.1,
+)
 def _get(endpoint) -> Any:
     response = _request(requests.get, endpoint)
 
@@ -106,18 +128,6 @@ def _put(endpoint, json_payload) -> Any:
     return response.json()
 
 
-class APIConnectionError(ConnectionError):
-    pass
-
-
-class IncompatibleClientError(Exception):
-    pass
-
-
-class ServerError(Exception):
-    pass
-
-
 def _validate_server_compatibility(
     tries: int = 5, seconds_between_tries: int = 10, use_cached: bool = True
 ):
@@ -134,76 +144,39 @@ def _validate_server_compatibility(
         ConnectionError,
         ServerError,
     )
-    response = None
-    error: Optional[Exception] = None
-    for _ in range(tries):
-        response, error = _validate_server_compatibility_no_catch()
-        if error is None:
-            _validated_client_version = True
-            return
-        if not isinstance(error, retriable_errors):
-            break
-        logger.warning(
-            "Unsuccessful at determining version compatibility waiting %s seconds...",
-            seconds_between_tries,
-        )
-        time.sleep(seconds_between_tries)
-    if response is not None and response.status_code != 200:
-        logger.error(
-            "Sematic server returned status code %s when"
-            " asked for version information. Response: %s",
-            response.status_code,
-            response.text,
-        )
-
-    assert error is not None  # should be impossible to fail, but makes mypy happy
-    raise error
+    retry(
+        exceptions=retriable_errors,
+        tries=tries,
+        delay=seconds_between_tries,
+    )(_validate_server_compatibility_no_catch)()
 
 
-def _validate_server_compatibility_no_catch() -> Tuple[
-    Optional[requests.Response], Optional[Exception]
-]:
-    headers = {"Content-Type": "application/json"}
-    response = None
-    error: Optional[Exception] = None
-    try:
-        response = requests.get(_url("/meta/versions"), headers=headers)
-    except ConnectionError:
-        error = APIConnectionError(
-            (
-                f"Unable to connect to the Sematic API at "
-                f"{get_config().server_url}.\n Make sure the "
-                f"correct server address is set with\n"
-                f"\t$ sematic settings set "
-                f"{SettingsVar.SEMATIC_API_ADDRESS.value} <address>"
-            )
-        )
-        return None, error
+def _validate_server_compatibility_no_catch() -> None:
     unexpected_server_response_error = IncompatibleClientError(
         "The Sematic server did not provide information about its version "
         "in the expected format. It could be that the server is too old to "
         "provide this information. Consider upgrading your server if possible, "
         "or reach out to Sematic for support."
     )
-    try:
-        response_json = response.json()
-    except JSONDecodeError:
-        return response, unexpected_server_response_error
-    if 400 <= response.status_code < 500:
-        return response, unexpected_server_response_error
-    if response.status_code >= 500:
-        error = ServerError(
-            f"The Sematic server is not responsive, and returned a status code of "
-            f"{response.status_code}."
-        )
-        return response, error
+    response = _request(
+        method=requests.get,
+        endpoint="/meta/versions",
+        attempt_auth=False,
+        validate_version_compatibility=False,  # to avoid recursion
+        error_response_kwarg_overrides=dict(
+            error_4xx=unexpected_server_response_error,
+            error_5xx=ServerError("The Sematic server is not responsive"),
+            error_json_decode_fail=unexpected_server_response_error,
+        ),
+    )
 
+    response_json = response.json()
     server_version = cast(Tuple[int, int, int], tuple(response_json["server"]))
     server_min_client_version = cast(
         Tuple[int, int, int], tuple(response_json["min_client_supported"])
     )
     if CURRENT_VERSION > server_version:
-        error = IncompatibleClientError(
+        raise IncompatibleClientError(
             f"The Sematic API client is at version "
             f"{version_as_string(CURRENT_VERSION)}, which is newer than "
             f"the Sematic server's version of "
@@ -211,36 +184,47 @@ def _validate_server_compatibility_no_catch() -> Tuple[
             f"to {version_as_string(server_version)}, or ask your server admin "
             f"to upgrade to at least {version_as_string(CURRENT_VERSION)}."
         )
-        return response, error
     if CURRENT_VERSION < server_min_client_version:
-        error = IncompatibleClientError(
+        raise IncompatibleClientError(
             f"The Sematic API client is at version "
             f"{version_as_string(CURRENT_VERSION)}, which is older than the "
             f"minimum version the server supports. Please upgrade your client "
             f"to a version of Sematic of at least "
             f"{version_as_string(server_min_client_version)}"
         )
-        return response, error
 
     logger.info(
         "Sematic client %s is compatible with server %s",
         version_as_string(CURRENT_VERSION),
         version_as_string(server_version),
     )
-    return response, None
 
 
 def _request(
     method: Callable[[Any], requests.Response],
     endpoint: str,
     kwargs: Optional[Dict[str, Any]] = None,
+    attempt_auth: bool = True,
+    validate_version_compatibility: bool = True,
+    error_response_kwarg_overrides: Dict[str, Any] = None,
 ):
-    _validate_server_compatibility()
+    """Internal function for wrapping requests.<get/put/etc.>.
+
+    validate_version_compatibility indicates whether we should check that the
+    Sematic server is compatible with this Sematic client.
+
+    error_response_kwarg_overrides provides overrides for how to handle
+    error HTTP responses in the form of overrides for the kwargs of _raise_for_response
+    """
+    error_response_kwarg_overrides = error_response_kwarg_overrides or {}
+    if validate_version_compatibility:
+        _validate_server_compatibility()
     kwargs = kwargs or {}
 
     headers = kwargs.get("headers", {})
     headers["Content-Type"] = "application/json"
-    headers["X-API-KEY"] = _get_api_key()
+    if attempt_auth:
+        headers["X-API-KEY"] = _get_api_key()
     kwargs["headers"] = headers
 
     try:
@@ -260,9 +244,45 @@ def _request(
     ):
         raise MissingSettingsError(SettingsVar.SEMATIC_API_KEY)
 
-    response.raise_for_status()
+    _raise_for_response(
+        response,
+        **error_response_kwarg_overrides,
+    )
 
     return response
+
+
+def _raise_for_response(
+    response: requests.Response,
+    error_4xx: Optional[Exception] = None,
+    error_5xx: Optional[Exception] = None,
+    error_json_decode_fail: Optional[Exception] = None,
+) -> None:
+    to_raise = None
+    url = response.url
+    error_4xx = error_4xx or BadRequestError(
+        f"The {response.request.method} request to {url} was invalid, "
+        f"response was {response.status_code}"
+    )
+    error_5xx = error_5xx or ServerError(
+        f"The Sematic server could not handle the "
+        f"{response.request.method} request to {url}",
+    )
+
+    if 400 <= response.status_code < 500:
+        to_raise = error_4xx
+    if response.status_code >= 500:
+        to_raise = error_5xx
+    if to_raise is None and error_json_decode_fail is not None:
+        try:
+            response.json()
+        except Exception:
+            to_raise = error_json_decode_fail
+    if to_raise is None:
+        return
+
+    logger.error("Server returned %s: %s", response.status_code, response.text)
+    raise to_raise
 
 
 def _url(endpoint) -> str:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -6,6 +6,7 @@ import logging
 
 # Third party
 import requests
+from requests.exceptions import ConnectionError
 
 # Sematic
 from sematic.versions import CURRENT_VERSION, version_as_string
@@ -105,7 +106,7 @@ def _put(endpoint, json_payload) -> Any:
     return response.json()
 
 
-class APIConnectionError(requests.exceptions.ConnectionError):
+class APIConnectionError(ConnectionError):
     pass
 
 
@@ -117,18 +118,20 @@ class ServerError(Exception):
     pass
 
 
-def _validate_server_compatibility(tries: int = 5, seconds_between_tries: int = 10):
+def _validate_server_compatibility(
+    tries: int = 5, seconds_between_tries: int = 10, use_cached: bool = True
+):
     """Check that the client is compatible with the server.
 
     Raises an error if the server and client are incompatible, or if this can't be
     verified.
     """
     global _validated_client_version
-    if _validated_client_version:
+    if _validated_client_version and use_cached:
         return
 
     retriable_errors = (
-        requests.exceptions.ConnectionError,
+        ConnectionError,
         ServerError,
     )
     response = None
@@ -162,7 +165,7 @@ def _validate_server_compatibility_no_catch() -> Tuple[
     response = None
     try:
         response = requests.get(_url("/meta/versions"), headers=headers)
-    except requests.exceptions.ConnectionError:
+    except ConnectionError:
         error = APIConnectionError(
             (
                 f"Unable to connect to the Sematic API at "
@@ -237,7 +240,7 @@ def _request(
 
     try:
         response = method(_url(endpoint), **kwargs)
-    except requests.exceptions.ConnectionError:
+    except ConnectionError:
         raise APIConnectionError(
             (
                 "Unable to connect to the Sematic API at {}.\n"

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -1,7 +1,7 @@
 # Standard library
 from json import JSONDecodeError
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 import logging
 
 # Third party
@@ -135,7 +135,7 @@ def _validate_server_compatibility(
         ServerError,
     )
     response = None
-    error = None
+    error: Optional[Exception] = None
     for _ in range(tries):
         response, error = _validate_server_compatibility_no_catch()
         if error is None:
@@ -155,6 +155,8 @@ def _validate_server_compatibility(
             response.status_code,
             response.text,
         )
+
+    assert error is not None  # should be impossible to fail, but makes mypy happy
     raise error
 
 
@@ -163,6 +165,7 @@ def _validate_server_compatibility_no_catch() -> Tuple[
 ]:
     headers = {"Content-Type": "application/json"}
     response = None
+    error: Optional[Exception] = None
     try:
         response = requests.get(_url("/meta/versions"), headers=headers)
     except ConnectionError:
@@ -195,8 +198,10 @@ def _validate_server_compatibility_no_catch() -> Tuple[
         )
         return response, error
 
-    server_version = tuple(response_json["server"])
-    server_min_client_version = tuple(response_json["min_client_supported"])
+    server_version = cast(Tuple[int, int, int], tuple(response_json["server"]))
+    server_min_client_version = cast(
+        Tuple[int, int, int], tuple(response_json["min_client_supported"])
+    )
     if CURRENT_VERSION > server_version:
         error = IncompatibleClientError(
             f"The Sematic API client is at version "

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -1,4 +1,6 @@
 # Standard library
+from json import JSONDecodeError
+import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import logging
 
@@ -6,6 +8,7 @@ import logging
 import requests
 
 # Sematic
+from sematic.versions import CURRENT_VERSION, version_as_string
 from sematic.config import get_config
 from sematic.user_settings import MissingSettingsError, SettingsVar, get_user_settings
 from sematic.db.models.artifact import Artifact
@@ -14,6 +17,11 @@ from sematic.db.models.run import Run
 
 
 logger = logging.getLogger(__name__)
+
+# The client should always verify that it is compatible with the server
+# it is talking to before using the API, but we don't want to do that every
+# time. This caches whether we have validated it or not.
+_validated_client_version = False
 
 
 def get_run(run_id: str) -> Run:
@@ -101,11 +109,125 @@ class APIConnectionError(requests.exceptions.ConnectionError):
     pass
 
 
+class IncompatibleClientError(Exception):
+    pass
+
+
+class ServerError(Exception):
+    pass
+
+
+def _validate_server_compatibility(tries: int = 5, seconds_between_tries: int = 10):
+    """Check that the client is compatible with the server.
+
+    Raises an error if the server and client are incompatible, or if this can't be
+    verified.
+    """
+    global _validated_client_version
+    if _validated_client_version:
+        return
+
+    retriable_errors = (
+        requests.exceptions.ConnectionError,
+        ServerError,
+    )
+    response = None
+    error = None
+    for _ in range(tries):
+        response, error = _validate_server_compatibility_no_catch()
+        if error is None:
+            _validated_client_version = True
+            return
+        if not isinstance(error, retriable_errors):
+            break
+        logger.warning(
+            "Unsuccessful at determining version compatibility waiting %s seconds...",
+            seconds_between_tries,
+        )
+        time.sleep(seconds_between_tries)
+    if response is not None and response.status_code != 200:
+        logger.error(
+            "Sematic server returned status code %s when"
+            " asked for version information. Response: %s",
+            response.status_code,
+            response.text,
+        )
+    raise error
+
+
+def _validate_server_compatibility_no_catch() -> Tuple[
+    Optional[requests.Response], Optional[Exception]
+]:
+    headers = {"Content-Type": "application/json"}
+    response = None
+    try:
+        response = requests.get(_url("/meta/versions"), headers=headers)
+    except requests.exceptions.ConnectionError:
+        error = APIConnectionError(
+            (
+                f"Unable to connect to the Sematic API at "
+                f"{get_config().server_url}.\n Make sure the "
+                f"correct server address is set with\n"
+                f"\t$ sematic settings set "
+                f"{SettingsVar.SEMATIC_API_ADDRESS.value} <address>"
+            )
+        )
+        return None, error
+    unexpected_server_response_error = IncompatibleClientError(
+        "The Sematic server did not provide information about its version "
+        "in the expected format. It could be that the server is too old to "
+        "provide this information. Consider upgrading your server if possible, "
+        "or reach out to Sematic for support."
+    )
+    try:
+        response_json = response.json()
+    except JSONDecodeError:
+        return response, unexpected_server_response_error
+    if 400 <= response.status_code < 500:
+        return response, unexpected_server_response_error
+    if response.status_code >= 500:
+        error = ServerError(
+            f"The Sematic server is not responsive, and returned a status code of "
+            f"{response.status_code}."
+        )
+        return response, error
+
+    server_version = tuple(response_json["server"])
+    server_min_client_version = tuple(response_json["min_client_supported"])
+    if CURRENT_VERSION > server_version:
+        error = IncompatibleClientError(
+            f"The Sematic API client is at version "
+            f"{version_as_string(CURRENT_VERSION)}, which is newer than "
+            f"the Sematic server's version of "
+            f"{version_as_string(server_version)}. Please downgrade your client "
+            f"to {version_as_string(server_version)}, or ask your server admin "
+            f"to upgrade to at least {version_as_string(CURRENT_VERSION)}."
+        )
+        return response, error
+    if CURRENT_VERSION < server_min_client_version:
+        error = IncompatibleClientError(
+            f"The Sematic API client is at version "
+            f"{version_as_string(CURRENT_VERSION)}, which is older than the "
+            f"minimum version the server supports. Please upgrade your client "
+            f"to a version of Sematic of at least "
+            f"{version_as_string(server_min_client_version)}"
+        )
+        return response, error
+
+    logger.info(
+        "Sematic client %s is compatible with server %s",
+        version_as_string(CURRENT_VERSION),
+        version_as_string(server_version),
+    )
+    return response, None
+
+
 def _request(
     method: Callable[[Any], requests.Response],
     endpoint: str,
     kwargs: Optional[Dict[str, Any]] = None,
 ):
+    _validate_server_compatibility()
     kwargs = kwargs or {}
 
     headers = kwargs.get("headers", {})

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -193,7 +193,7 @@ def _validate_server_compatibility_no_catch() -> None:
             f"{version_as_string(server_min_client_version)}"
         )
 
-    logger.info(
+    logger.debug(
         "Sematic client %s is compatible with server %s",
         version_as_string(CURRENT_VERSION),
         version_as_string(server_version),

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -110,6 +110,13 @@ def _get(endpoint) -> Any:
     return response.json()
 
 
+@retry(
+    exceptions=APIConnectionError,
+    tries=4,
+    delay=1,
+    backoff=2,
+    jitter=0.1,
+)
 def _post(endpoint, json_payload) -> Any:
     response = _request(requests.post, endpoint, dict(json=json_payload))
 
@@ -119,6 +126,13 @@ def _post(endpoint, json_payload) -> Any:
     return response.json()
 
 
+@retry(
+    exceptions=APIConnectionError,
+    tries=4,
+    delay=1,
+    backoff=2,
+    jitter=0.1,
+)
 def _put(endpoint, json_payload) -> Any:
     response = _request(requests.put, endpoint, dict(json=json_payload))
 

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -13,6 +13,7 @@ pytest_test(
     srcs = ["test_api_client.py"],
     deps = [
         "//sematic:api_client",
+        "//sematic:config",
         "//sematic:versions",
     ],
 )

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -9,6 +9,15 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_api_client",
+    srcs = ["test_api_client.py"],
+    deps = [
+        "//sematic:api_client",
+        "//sematic:versions",
+    ],
+)
+
+pytest_test(
     name = "test_future",
     srcs = ["test_future.py"],
     deps = [

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -1,0 +1,120 @@
+# Standard
+import json
+from typing import Optional, Dict, Any
+from unittest import mock
+from dataclasses import dataclass
+
+# Third party
+import pytest
+
+# Sematic
+from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
+from sematic.api_client import (
+    IncompatibleClientError,
+    _validate_server_compatibility,
+    ServerError,
+)
+
+
+@dataclass
+class MockResponse:
+    status_code: int
+    json_contents: Dict[str, Any]
+    text_contents: Optional[str] = None
+
+    def json(self) -> Dict[str, Any]:
+        return self.json_contents
+
+    @property
+    def text(self) -> str:
+        if self.text_contents is None:
+            return json.dumps(self.json_contents)
+        return self.text_contents
+
+
+class ConnectionError(RuntimeError):
+    pass
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility(mock_requests):
+    mock_requests.get.return_value = MockResponse(
+        status_code=200,
+        json_contents=dict(
+            server=CURRENT_VERSION,
+            min_client_supported=MIN_CLIENT_SERVER_SUPPORTS,
+        ),
+    )
+    _validate_server_compatibility(seconds_between_tries=0, use_cached=False)
+    mock_requests.get.assert_called_with(
+        "https://dev.sematic.cloud/api/v1/meta/versions",
+        headers={"Content-Type": "application/json"},
+    )
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility_retry(mock_requests):
+    mock_requests.get.return_value = MockResponse(status_code=500, json_contents={})
+    with pytest.raises(ServerError):
+        _validate_server_compatibility(
+            tries=5, seconds_between_tries=0, use_cached=False
+        )
+    assert len(mock_requests.get.call_args_list) == 5
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility_bad_json(mock_requests):
+    mock_requests.get.return_value = MockResponse(status_code=500, json_contents={})
+
+    def bad_json(*_):
+        raise json.JSONDecodeError("", "", 1)
+
+    mock_requests.get.return_value.json = bad_json
+    with pytest.raises(IncompatibleClientError):
+        _validate_server_compatibility(
+            tries=5, seconds_between_tries=0, use_cached=False
+        )
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility_old_server(mock_requests):
+    mock_requests.get.return_value = MockResponse(
+        status_code=200,
+        json_contents=dict(
+            server=(0, 1, 0),
+            min_client_supported=(0, 1, 0),
+        ),
+    )
+    with pytest.raises(IncompatibleClientError):
+        _validate_server_compatibility(
+            tries=5, seconds_between_tries=0, use_cached=False
+        )
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility_old_client(mock_requests):
+    mock_requests.get.return_value = MockResponse(
+        status_code=200,
+        json_contents=dict(
+            server=(2**32, 0, 0),
+            # let's HOPE it's safe to assume we will never have billions
+            # of major versions...
+            min_client_supported=(2**32, 0, 0),
+        ),
+    )
+    with pytest.raises(IncompatibleClientError):
+        _validate_server_compatibility(
+            tries=5, seconds_between_tries=0, use_cached=False
+        )
+
+
+@mock.patch("sematic.api_client.requests")
+def test_validate_server_compatibility_new_server_still_supports(mock_requests):
+    mock_requests.get.return_value = MockResponse(
+        status_code=200,
+        json_contents=dict(
+            server=(2**32, 0, 0),
+            min_client_supported=MIN_CLIENT_SERVER_SUPPORTS,
+        ),
+    )
+    _validate_server_compatibility(tries=5, seconds_between_tries=0, use_cached=False)

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import pytest
 
 # Sematic
+from sematic.config import get_config
 from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
 from sematic.api_client import (
     IncompatibleClientError,
@@ -47,7 +48,7 @@ def test_validate_server_compatibility(mock_requests):
     )
     _validate_server_compatibility(seconds_between_tries=0, use_cached=False)
     mock_requests.get.assert_called_with(
-        "https://dev.sematic.cloud/api/v1/meta/versions",
+        f"{get_config().api_url}/meta/versions",
         headers={"Content-Type": "application/json"},
     )
 

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -22,6 +22,8 @@ class MockResponse:
     status_code: int
     json_contents: Dict[str, Any]
     text_contents: Optional[str] = None
+    url: str = "http://example.com"
+    method: str = "GET"
 
     def json(self) -> Dict[str, Any]:
         return self.json_contents
@@ -65,7 +67,7 @@ def test_validate_server_compatibility_retry(mock_requests):
 
 @mock.patch("sematic.api_client.requests")
 def test_validate_server_compatibility_bad_json(mock_requests):
-    mock_requests.get.return_value = MockResponse(status_code=500, json_contents={})
+    mock_requests.get.return_value = MockResponse(status_code=200, json_contents={})
 
     def bad_json(*_):
         raise json.JSONDecodeError("", "", 1)

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -18,6 +18,11 @@ from sematic.api_client import (
 
 
 @dataclass
+class MockRequest:
+    method: str = "GET"
+
+
+@dataclass
 class MockResponse:
     status_code: int
     json_contents: Dict[str, Any]
@@ -33,6 +38,10 @@ class MockResponse:
         if self.text_contents is None:
             return json.dumps(self.json_contents)
         return self.text_contents
+
+    @property
+    def request(self) -> MockRequest:
+        return MockRequest(method=self.method)
 
 
 class ConnectionError(RuntimeError):

--- a/sematic/types/types/pandas/dataframe.py
+++ b/sematic/types/types/pandas/dataframe.py
@@ -1,6 +1,6 @@
 # Standard library
 import json
-from typing import Any
+from typing import Any, List, Dict
 
 # Third party
 import pandas
@@ -29,7 +29,7 @@ def _dataframe_json_encodable_summary(value: pandas.DataFrame, _) -> Any:
         (name, dtype.name) for name, dtype in zip(value.dtypes.index, value.dtypes)
     ]
 
-    describe = []
+    describe: List[Dict[str, Any]] = []
     try:
         describe = value.describe().to_dict()  # type: ignore  # (pandas stubs bug)
     except ValueError:

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -75,7 +75,7 @@ function App() {
       setEnv(new Map());
     }
     fetchJSON({
-      url: "/env",
+      url: "/api/v1/meta/env",
       callback: (payload: EnvPayload) => {
         setEnv(new Map(Object.entries(payload.env)));
       },

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -3,3 +3,9 @@ sematic_py_lib(
     srcs = ["memoized_property.py"],
     deps = []
 )
+
+sematic_py_lib(
+    name = "retry",
+    srcs = ["retry.py"],
+    deps = []
+)

--- a/sematic/utils/retry.py
+++ b/sematic/utils/retry.py
@@ -5,6 +5,7 @@
 # Retrieved on 08/10/22, original source code uses the Apache 2
 # license.
 
+# Standard library
 import logging
 import random
 import time

--- a/sematic/utils/retry.py
+++ b/sematic/utils/retry.py
@@ -1,0 +1,203 @@
+# Credited to invl: https://github.com/invl/retry/blob/master/retry/api.py
+# adapted to follow our linting and docstring style. Used here instead
+# of depending on that library to avoid taking on another explicit
+# third-party dep.
+# Retrieved on 08/10/22, original source code uses the Apache 2
+# license.
+
+import logging
+import random
+import time
+from functools import partial, wraps
+
+logging_logger = logging.getLogger(__name__)
+
+
+def decorator(caller):
+    """Turns caller into a decorator.
+    Unlike decorator module, function signature is not preserved.
+
+    Parameters
+    ----------
+    caller: caller(f, *args, **kwargs)
+    """
+
+    def decor(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return caller(f, *args, **kwargs)
+
+        return wrapper
+
+    return decor
+
+
+def __retry_internal(
+    f,
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logging_logger,
+):
+    """Executes a function and retries it if it failed.
+
+    Parameters
+    ----------
+    f:
+        the function to execute.
+    exceptions:
+        an exception or a tuple of exceptions to catch. default: Exception.
+    tries:
+        the maximum number of attempts. default: -1 (infinite).
+    delay:
+        initial delay between attempts. default: 0.
+    max_delay:
+        the maximum value of delay. default: None (no limit).
+    backoff:
+        multiplier applied to delay between attempts. default: 1 (no backoff).
+    jitter:
+        extra seconds added to delay between attempts. default: 0. fixed if a number,
+        random if a range tuple (min, max).
+    logger:
+        logger.warning(fmt, error, delay) will be called on failed attempts.
+        default: retry.logging_logger. if None, logging is disabled.
+
+    Returns
+    -------
+    the result of the f function.
+    """
+    _tries, _delay = tries, delay
+    while _tries:
+        try:
+            return f()
+        except exceptions as e:
+            _tries -= 1
+            if not _tries:
+                raise
+
+            if logger is not None:
+                logger.warning("%s, retrying in %s seconds...", e, _delay)
+
+            time.sleep(_delay)
+            _delay *= backoff
+
+            if isinstance(jitter, tuple):
+                _delay += random.uniform(*jitter)
+            else:
+                _delay += jitter
+
+            if max_delay is not None:
+                _delay = min(_delay, max_delay)
+
+
+def retry(
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logging_logger,
+):
+    """Returns a retry decorator.
+
+    Parameters
+    ----------
+    exceptions:
+        an exception or a tuple of exceptions to catch. default: Exception.
+    tries:
+        the maximum number of attempts. default: -1 (infinite).
+    delay:
+        initial delay between attempts. default: 0.
+    max_delay:
+        the maximum value of delay. default: None (no limit).
+    backoff:
+        multiplier applied to delay between attempts. default: 1 (no backoff).
+    jitter:
+        extra seconds added to delay between attempts. default: 0.
+        fixed if a number, random if a range tuple (min, max)
+    logger:
+        logger.warning(fmt, error, delay) will be called on failed attempts.
+        default: retry.logging_logger. if None, logging is disabled.
+
+    Returns
+    -------
+    A retry decorator.
+    """
+
+    @decorator
+    def retry_decorator(f, *fargs, **fkwargs):
+        args = fargs if fargs else list()
+        kwargs = fkwargs if fkwargs else dict()
+        return __retry_internal(
+            partial(f, *args, **kwargs),
+            exceptions,
+            tries,
+            delay,
+            max_delay,
+            backoff,
+            jitter,
+            logger,
+        )
+
+    return retry_decorator
+
+
+def retry_call(
+    f,
+    fargs=None,
+    fkwargs=None,
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logging_logger,
+):
+    """Calls a function and re-executes it if it failed.
+
+    Parameters
+    ----------
+    f:
+        the function to execute.
+    fargs:
+        the positional arguments of the function to execute.
+    fkwargs:
+        the named arguments of the function to execute.
+    exceptions:
+        an exception or a tuple of exceptions to catch. default: Exception.
+    tries:
+        the maximum number of attempts. default: -1 (infinite).
+    delay:
+        initial delay between attempts. default: 0.
+    max_delay:
+        the maximum value of delay. default: None (no limit).
+    backoff:
+        multiplier applied to delay between attempts. default: 1 (no backoff).
+    jitter:
+        extra seconds added to delay between attempts. default: 0.
+        fixed if a number, random if a range tuple (min, max)
+    logger:
+        logger.warning(fmt, error, delay) will be called on failed attempts.
+        default: retry.logging_logger. if None, logging is disabled.
+
+    Returns
+    --------
+    the result of the f function.
+    """
+    args = fargs if fargs else list()
+    kwargs = fkwargs if fkwargs else dict()
+    return __retry_internal(
+        partial(f, *args, **kwargs),
+        exceptions,
+        tries,
+        delay,
+        max_delay,
+        backoff,
+        jitter,
+        logger,
+    )

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,3 +1,4 @@
+# Standard library
 import typing
 
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -5,12 +5,12 @@ import typing
 # the sdk. Should be bumped any time a release is made. Should be set
 # to whatever is the version after the most recent one in changelog.md,
 # as well as the version for the sematic wheel in sematic/BUILD
-CURRENT_VERSION = (0, 10, 0)
+CURRENT_VERSION = (0, 9, 0)
 
 # Represents the smallest client version that works with the server
 # at the CURRENT_VERSION. Should be updated any time a breaking change
 # is made to the web API.
-MIN_CLIENT_SERVER_SUPPORTS = (0, 10, 0)
+MIN_CLIENT_SERVER_SUPPORTS = (0, 9, 0)
 
 
 def version_as_string(version: typing.Tuple[int, int, int]) -> str:

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,0 +1,36 @@
+import typing
+
+
+# Represents the version of the client, server, and all other parts of
+# the sdk. Should be bumped any time a release is made. Should be set
+# to whatever is the version after the most recent one in changelog.md,
+# as well as the version for the sematic wheel in sematic/BUILD
+CURRENT_VERSION = (0, 10, 0)
+
+# Represents the smallest client version that works with the server
+# at the CURRENT_VERSION. Should be updated any time a breaking change
+# is made to the web API.
+MIN_CLIENT_SERVER_SUPPORTS = (0, 10, 0)
+
+
+def version_as_string(version: typing.Tuple[int, int, int]) -> str:
+    """Given a version tuple, return its equivalent string.
+
+    Parameters
+    ----------
+    version:
+        A tuple with three integers representing a semantic version
+
+    Returns
+    -------
+    A string formatted as <MAJOR>.<MINOR>.<PATCH>
+    """
+    return ".".join(str(v) for v in version)
+
+
+CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
+
+if __name__ == "__main__":
+    # It can be handy for deployment scripts and similar things to be able to get quick
+    # access to the version. So make `python3 sematic/versions.py` print it out.
+    print(CURRENT_VERSION_STR)


### PR DESCRIPTION
We may make some backwards incompatible changes to the server API, especially in these early days. To save users the trouble of hitting a weird compatibility issue with a cryptic error, let's generate an explicit message telling people when their client code won't work with the server.

Testing
-------
In addition to the unit tests, I ran the server locally and then ran an example pipeline to make sure it worked well. I also (inadvertently) ran the new client code against an old server and confirmed I got an appropriate error.