### PR TITLE
Add debugpy as automatically available

### DIFF
--- a/developer-docs/tips-for-bazel.md
+++ b/developer-docs/tips-for-bazel.md
@@ -1,0 +1,95 @@
+# Bazel Tips
+
+You can execute most things in this repo with bazel. Here are some particularly useful examples:
+
+## Testing
+
+This will execute all tests, including all supported versions of python.
+```
+bazel test //sematic/...
+```
+
+This will run a specific test (in this case the API client test), on the default python version.
+The target path is the file path to to the python package where the test lives (`sematic.tests`
+in the example below), followed by a colon and the name of the python module for the test
+(`test_api_client` in this example).
+```
+bazel run //sematic/tests:test_api_client
+```
+
+This will run a specific test (in this case the API client test), on the python version indicated
+by the `_py3X` (python 3.9 in the example below).
+```
+bazel run //sematic/tests:test_api_client_py39
+```
+
+If you are using VSCode, you can use the VSCode debugger with bazel while testing. First, you
+need to add this to your VSCode `launch.json` configurations:
+```
+        {
+            "name": "Python: Attach",
+            "type": "python",
+            "request": "attach",
+            "port": 5724,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "."
+                }
+            ]
+        },
+```
+
+Once you've done that, you can debug tests with bazel by:
+- Running your test with `DEBUGPY=1`: `DEBUGPY=1 bazel run //sematic/tests:test_api_client`
+- once the test has paused (should pause very quickly), execute the `Python: Attach` debug
+configuration from your VSCode debug panel. It should attach to the debugger.
+- While the debugger is running, you can use all the debugger features you'd expect: breakpoints,
+stepping, variables and watch views, stack navigation, etc..
+
+
+## IPython
+You can open an iPython shell that contains the dependencies for any `sematic_py_lib`:
+```
+$ bazel run //sematic:api_client_ipython  # build //sematic:api_client and open a shell
+In [1]: from sematic import api_client as api
+```
+
+You can also do this for specific versions of python by adding a `_py3X_` between the
+name of the lib target and the `ipython`:
+```
+$ bazel run //sematic:api_client_py39_ipython  # build target and open a py3.9 shell
+In [1]: from sematic import api_client as api
+```
+
+## Sematic examples
+You can run Sematic examples by running one of the targets created with the
+`sematic_example` build macro:
+```
+$ bazel run //sematic/examples/liver_cirrhosis:liver_cirrhosis
+```
+
+You can do this using a specific interpreter as well with a `_py3X` suffix:
+```
+$ bazel run //sematic/examples/liver_cirrhosis:liver_cirrhosis_py39
+```
+
+You can also open an ipython interpreter into the environment for the example:
+```
+$ bazel run //sematic/examples/liver_cirrhosis:liver_cirrhosis_py39_ipython
+In [1]: from sematic.examples.liver_cirrhosis import *
+```
+
+## Sematic CLI
+For the sematic CLI (as well as any other `sematic_py_binary`), you can run them
+by just running their targets:
+
+```
+$ bazel run //sematic/cli:main -- --help
+```
+
+You can also do *this* with specific python interpreters:
+```
+$ bazel run //sematic/cli:main_py39 -- --help
+```

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -5,3 +5,7 @@ Here are the main ones:
 * [Contribute an example pipeline](./contribute-example.md)
 * Extend type support
 * Contribute core features
+
+As you're working in the code, there are a few resources created specifically
+to help people modifying the codebase
+[here](https://github.com/sematic-ai/sematic/tree/main/developer-docs)

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,6 +2,7 @@
 pytest==7.1.1
 testing-postgresql
 git+https://github.com/ulfjack/coveragepy.git@lcov-support
+debugpy
 
 # System
 ipython==8.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,6 +54,8 @@ cryptography==36.0.2
     #   snowflake-connector-python
 cycler==0.11.0
     # via matplotlib
+debugpy==1.6.3
+    # via -r requirements/requirements.in
 decorator==5.1.1
     # via ipython
 dnspython==1.16.0

--- a/tools/pytest_runner.py
+++ b/tools/pytest_runner.py
@@ -1,8 +1,16 @@
+import os
 import sys
 
+import debugpy
 import pytest
 
 if __name__ == "__main__":
+    if os.environ.get("DEBUGPY", None) is not None:
+        debugpy.listen(5724)
+
+        # blocks execution until client is attached
+        debugpy.wait_for_client()
+
     pytest_args = []
     pytest_args.extend(sys.argv[1:])
 

--- a/tools/sematic_rules.bzl
+++ b/tools/sematic_rules.bzl
@@ -85,7 +85,7 @@ def pytest_test(
         (pyenv, runfiles) = env_and_runfiles_for_python(py3_version)
         final_deps = full_versioned_deps(
             deps = deps,
-            pip_deps = pip_deps + ["pytest"],
+            pip_deps = pip_deps + ["pytest", "debugpy"],
             py_version = py3_version,
         )
 


### PR DESCRIPTION
Because I'm tired of setting up VS code debugging hackily for specific tests when I need it, then undoing all the code changes when I'm done, I thought I'd add it as something automatically available when you execute tests, via only a change on the command line invocation.