### PR TITLE
Bind to 0.0.0.0 by default

### DIFF
--- a/sematic/config.py
+++ b/sematic/config.py
@@ -90,7 +90,7 @@ _SQLITE_FILE = "db.sqlite3"
 _LOCAL_CONFIG = Config(
     # If choosing localhost, the React app will not be able
     # To proxy requests to the socker io server. Unsure why.
-    server_address="127.0.0.1",
+    server_address="0.0.0.0",
     port=5001,
     api_version=1,
     db_url="sqlite:///{}/{}".format(get_config_dir(), _SQLITE_FILE),


### PR DESCRIPTION
When trying out sematic, the app is not accessible from another machine by default.
How about binding to 0.0.0.0 by default, so that one can try it out without having to do a full-fletched remote deployment as described in https://docs.sematic.dev/diving-deeper/deploy

or maybe add an option flag to make it accessible externally?
I got stuck on this when onboarding.