### PR TITLE
Add ability to execute local server from a different address

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -21,6 +21,15 @@ This will open the app in your browser.
 {% hint style="info" %}
 This runs the Sematic app on your local machine. To
 deploy it within your cloud see [Deploying Sematic](deployment.md).
+If you want to run the local version of the app for yourself, but
+access it from a different machine (ex: if you are running the
+app from within a docker container or on a cloud development
+machine), you can launch with
+```shell
+$ SEMATIC_SERVER_ADDRESS=0.0.0.0 sematic start
+```
+but this mechanism of running the server is still only
+intended for single-user usage.
 {% endhint %}
 
 To stop the app, simply do

--- a/sematic/config.py
+++ b/sematic/config.py
@@ -90,15 +90,17 @@ _SQLITE_FILE = "db.sqlite3"
 _LOCAL_CONFIG = Config(
     # If choosing localhost, the React app will not be able
     # To proxy requests to the socker io server. Unsure why.
-    server_address="127.0.0.1",
-    port=5001,
+    server_address=os.environ.get("SEMATIC_SERVER_ADDRESS", "127.0.0.1"),
+    port=int(os.environ.get("PORT", 5001)),
     api_version=1,
-    db_url="sqlite:///{}/{}".format(get_config_dir(), _SQLITE_FILE),
+    db_url=os.environ.get(
+        "DATABASE_URL", "sqlite:///{}/{}".format(get_config_dir(), _SQLITE_FILE)
+    ),
 )
 
 
 _CLOUD_CONFIG = Config(
-    server_address="0.0.0.0",
+    server_address=os.environ.get("SEMATIC_SERVER_ADDRESS", "0.0.0.0"),
     api_version=1,
     port=int(os.environ.get("PORT", 80)),
     db_url=os.environ.get("DATABASE_URL", "NO_DB"),
@@ -108,6 +110,13 @@ _CLOUD_CONFIG = Config(
 class UserOverrideConfig(Config):
     @property
     def server_url(self) -> str:
+        # environment vars should take precedence over whatever is in the
+        # users settings file.
+        server_address = os.environ.get("SEMATIC_SERVER_ADDRESS", None)
+        if server_address is not None:
+            port = os.environ.get("PORT", 80)
+            return "http://{}:{}".format(self.server_address, port)
+
         try:
             return get_user_settings(SettingsVar.SEMATIC_API_ADDRESS)
         except MissingSettingsError:


### PR DESCRIPTION
This addresses #112 . Sometimes users may want to serve the local app from inside a docker container or on a cloud development machine, but then connect via their local browser. This only works if we serve from 0.0.0.0. By default the local app serves from 127.0.0.1. We don't want to just switch the default, because serving from 0.0.0.0 can be less secure, and the need for it should be less common than using the same machine for browser & server. The approach to fixing this is also consistent with other configuration logic: for non-local executions we allow usage of env vars to override the server address and port, this just expands that so the same is true for the local server.

Tested manually by using the CLI to start both with and without the env var set, including when using the port.