### PR TITLE
Improve empty list handling

### DIFF
--- a/sematic/ui/src/types/Types.tsx
+++ b/sematic/ui/src/types/Types.tsx
@@ -219,28 +219,34 @@ function ListValueView(props: ValueViewProps) {
   }
 
   let elementTypeRepr: TypeRepr = typeRepr[2].args[0].type as TypeRepr;
+  const summaryIsEmpty = props.valueSummary["summary"].length === 0;
 
   const summaryIsComplete =
     props.valueSummary["summary"].length === props.valueSummary["length"];
 
-  const summary = (
-    <Typography display="inline" component="span">
-      [
-      {Array.from(props.valueSummary["summary"])
-        .map<React.ReactNode>((element, index) =>
-          renderSummary(
-            props.typeSerialization,
-            element,
-            elementTypeRepr,
-            index.toString()
+  var summary;
+  if (summaryIsEmpty) {
+    summary = (<Typography display="inline" component="span" fontStyle={"italic"}>Nothing to display</Typography>);
+  } else {
+    summary = (
+      <Typography display="inline" component="span">
+        [
+        {Array.from(props.valueSummary["summary"])
+          .map<React.ReactNode>((element, index) =>
+            renderSummary(
+              props.typeSerialization,
+              element,
+              elementTypeRepr,
+              index.toString()
+            )
           )
-        )
-        .reduce((prev, curr) => [prev, ", ", curr])}
-      ]
-    </Typography>
-  );
+          .reduce((prev, curr) => [prev, ", ", curr])}
+        ]
+      </Typography>
+    );
+  }
 
-  if (summaryIsComplete) return summary;
+  if (summaryIsComplete && !summaryIsEmpty) return summary;
 
   return (
     <Table>


### PR DESCRIPTION
We had a bug when the summary of a list view didn't contain any elements. We were running an array reduce on the summary, but array reductions are undefined for empty lists. This makes it so we handle "empty list" as a special case for display.
![Screen Shot 2022-08-26 at 2 24 29 PM](https://user-images.githubusercontent.com/7181589/186994291-7c6cdd57-7896-45f2-9c59-d898c22d4ddc.png)
![Screen Shot 2022-08-26 at 2 24 42 PM](https://user-images.githubusercontent.com/7181589/186994301-44e8caa3-8c41-48da-b281-634d2f5756f8.png)

