### PR TITLE
Add ability to change config dir with env var

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,3 +69,8 @@ Active settings:
 
 SNOWFLAKE_USER: notfoobar
 ```
+
+If you'd like, you can even change which directory Sematic uses to hold its
+settings by setting the environment variable `SEMATIC_CONFIG_DIR`. This can
+be either a relative path (it will be treated as relative to your home directory)
+or an absolute path.

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -11,6 +11,15 @@ pytest_test(
     ],
 )
 
+pytest_test(
+    name = "test_config_dir",
+    srcs = ["test_config_dir.py"],
+    deps = [
+        "//sematic:config_dir",
+        "//sematic/tests:fixtures",
+    ],
+)
+
 # <add python version>: A new test will need to be added when a python version is added
 pytest_test(
     name = "test_38_interpreter",

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -1,3 +1,8 @@
+# Standard Library
+import contextlib
+import os
+from typing import Dict, Optional
+
 # Third-party
 import pytest
 
@@ -39,3 +44,31 @@ def valid_client_version():
         yield
     finally:
         api_client._validated_client_version = current_validated_client_version
+
+
+@contextlib.contextmanager
+def environment_variables(to_set: Dict[str, Optional[str]]):
+    """Context manager to configure the os environ for tests.
+
+    Parameters
+    ----------
+    to_set:
+        A dict from env var name to env var value. If the env var value
+        is None, that will be treated as indicating that the env var should
+        be unset within the managed context.
+    """
+    backup_of_changed_keys = {k: os.environ.get(k, None) for k in to_set.keys()}
+
+    def update_environ_with(env_dict):
+        for key, value in env_dict.items():
+            if value is None:
+                if key in os.environ:
+                    del os.environ[key]
+            else:
+                os.environ[key] = value
+
+    update_environ_with(to_set)
+    try:
+        yield
+    finally:
+        update_environ_with(backup_of_changed_keys)

--- a/sematic/tests/test_config_dir.py
+++ b/sematic/tests/test_config_dir.py
@@ -1,0 +1,38 @@
+# Standard Library
+import pathlib
+
+import pytest
+
+# Sematic
+from sematic.config_dir import _CONFIG_DIR_OVERRIDE_ENV_VAR, get_config_dir
+from sematic.tests.fixtures import environment_variables
+
+
+def test_get_config_dir_default():
+    with environment_variables({_CONFIG_DIR_OVERRIDE_ENV_VAR: None}):
+        config_dir = get_config_dir()
+        assert pathlib.Path(config_dir).is_absolute()
+        assert pathlib.Path.home().as_posix() in config_dir
+        assert pathlib.Path(config_dir).as_posix().endswith("/.sematic")
+
+
+def test_get_config_override():
+    with environment_variables({_CONFIG_DIR_OVERRIDE_ENV_VAR: ".foo"}):
+        config_dir = get_config_dir()
+        assert pathlib.Path(config_dir).is_absolute()
+        assert pathlib.Path.home().as_posix() in config_dir
+        assert pathlib.Path(config_dir).as_posix().endswith("/.foo")
+
+
+def test_get_config_override_absolute():
+    with environment_variables({_CONFIG_DIR_OVERRIDE_ENV_VAR: "/tmp/.foo"}):
+        config_dir = get_config_dir()
+        assert pathlib.Path(config_dir).as_posix() == "/tmp/.foo"
+
+
+def test_get_config_override_bad_parent():
+    with environment_variables(
+        {_CONFIG_DIR_OVERRIDE_ENV_VAR: "/this-doesnt-exist/.foo"}
+    ):
+        with pytest.raises(ValueError, match=r"this-doesnt-exist"):
+            get_config_dir()


### PR DESCRIPTION
Sometimes people want to run Sematic in an environment where they don't have write permission for the home directory. Also, people may wish to maintain multiple sets of Sematic configs at once. We can enable this by allowing an env var to determine where the Sematic config dir should be.

## Testing
In addition to unit tests, I also did `sematic settings show` with this code to ensure that my current settings still show. I also set `SEMATIC_CONFIG_DIR` to absolute and relative paths and ensured that Sematic created and used the specified dirs.