### PR TITLE
Persist resource reqs in DB

### DIFF
--- a/sematic/db/migrations/20220830211101_persist_resource_reqs.sql
+++ b/sematic/db/migrations/20220830211101_persist_resource_reqs.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+ALTER TABLE runs ADD COLUMN resource_requirements_json_encodable JSONB;
+
+-- migrate:down
+
+ALTER TABLE runs DROP COLUMN resource_requirements_json_encodable;

--- a/sematic/db/migrations/20220830211101_persist_resource_reqs.sql
+++ b/sematic/db/migrations/20220830211101_persist_resource_reqs.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 
-ALTER TABLE runs ADD COLUMN resource_requirements_json_encodable JSONB;
+ALTER TABLE runs ADD COLUMN resource_requirements_json JSONB;
 
 -- migrate:down
 
-ALTER TABLE runs DROP COLUMN resource_requirements_json_encodable;
+ALTER TABLE runs DROP COLUMN resource_requirements_json;

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -61,6 +61,7 @@ sematic_py_lib(
         ":base",
         ":json_encodable_mixin",
         "//sematic:abstract_future",
+        "//sematic/types:serialization",
     ],
     pip_deps = [
         "sqlalchemy",

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -44,6 +44,11 @@ def make_run_from_future(future: AbstractFuture) -> Run:
         updated_at=datetime.datetime.utcnow(),
     )
 
+    # Set this outside the constructor because the constructor expects
+    # a json encodable, but this property will auto-update the json
+    # encodable field.
+    run.resource_requirements = future.props.resource_requirements
+
     return run
 
 

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -69,7 +69,7 @@ class Run(Base, JSONEncodableMixin):
         returns a :class:`sematic.Future`.
     failed_at : Optional[datetime]
         Time at which the run has failed.
-    resource_requirements_json_encodable : Optional[Dict[str, Any]]
+    resource_requirements_json : Optional[Dict[str, Any]]
         The compute resources requested for the execution.
     """
 
@@ -105,7 +105,7 @@ class Run(Base, JSONEncodableMixin):
     ended_at: Optional[datetime.datetime] = Column(types.DateTime(), nullable=True)
     resolved_at: Optional[datetime.datetime] = Column(types.DateTime(), nullable=True)
     failed_at: Optional[datetime.datetime] = Column(types.DateTime(), nullable=True)
-    resource_requirements_json_encodable: Optional[Dict[str, Any]] = Column(
+    resource_requirements_json: Optional[str] = Column(
         types.JSON(), nullable=True, info={JSON_KEY: True}
     )
 
@@ -138,16 +138,17 @@ class Run(Base, JSONEncodableMixin):
 
     @property
     def resource_requirements(self) -> Optional[ResourceRequirements]:
-        if self.resource_requirements_json_encodable is None:
+        if self.resource_requirements_json is None:
             return None
-        return value_from_json_encodable(
-            self.resource_requirements_json_encodable, ResourceRequirements
-        )
+
+        json_encodable = json.loads(self.resource_requirements_json)
+        return value_from_json_encodable(json_encodable, ResourceRequirements)
 
     @resource_requirements.setter
     def resource_requirements(self, value: Optional[ResourceRequirements]) -> None:
         if value is None:
-            self.resource_requirements_json_encodable = None
-        self.resource_requirements_json_encodable = value_to_json_encodable(
-            value, ResourceRequirements
+            self.resource_requirements_json = None
+            return
+        self.resource_requirements_json = json.dumps(
+            value_to_json_encodable(value, ResourceRequirements)
         )

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 # Third party
 from sqlalchemy import Column, types

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -14,6 +14,10 @@ from sematic.db.models.factories import (
     make_artifact,
     make_run_from_future,
 )
+from sematic.resolvers.resource_requirements import (
+    KubernetesResourceRequirements,
+    ResourceRequirements,
+)
 from sematic.tests.fixtures import test_storage  # noqa: F401
 from sematic.types.serialization import (
     get_json_encodable_summary,
@@ -34,6 +38,12 @@ def test_make_run_from_future():
     future = f()
     parent_future = f()
     future.parent_future = parent_future
+    resource_reqs = ResourceRequirements(
+        kubernetes=KubernetesResourceRequirements(
+            node_selector={"foo": "bar"},
+        )
+    )
+    future.props.resource_requirements = resource_reqs
     run = make_run_from_future(future)
 
     assert run.id == future.id
@@ -42,6 +52,8 @@ def test_make_run_from_future():
     assert run.name == "f"
     assert run.parent_id == parent_future.id
     assert run.description == "An informative docstring."
+    assert isinstance(run.resource_requirements, ResourceRequirements)
+    assert run.resource_requirements.kubernetes.node_selector == {"foo": "bar"}
     assert (
         run.source_code
         == """@func

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -10,7 +10,7 @@ CREATE TABLE runs (
     ended_at timestamp,
     resolved_at timestamp,
     failed_at timestamp,
-    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), exception TEXT,
+    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), exception TEXT, external_jobs_json_encodable JSONB, resource_requirements_json JSONB,
 
     PRIMARY KEY (id)
 );
@@ -87,4 +87,6 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20220714175433'),
   ('20220723010628'),
   ('20220726001230'),
-  ('20220816235619');
+  ('20220816235619'),
+  ('20220819172555'),
+  ('20220830211101');

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -10,7 +10,7 @@ CREATE TABLE runs (
     ended_at timestamp,
     resolved_at timestamp,
     failed_at timestamp,
-    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), exception TEXT, external_jobs_json_encodable JSONB, resource_requirements_json JSONB,
+    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), exception TEXT, resource_requirements_json JSONB,
 
     PRIMARY KEY (id)
 );
@@ -88,5 +88,4 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20220723010628'),
   ('20220726001230'),
   ('20220816235619'),
-  ('20220819172555'),
   ('20220830211101');

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 # Sematic
 import sematic
-from sematic.resolvers.resource_requirements import KubernetesResourceRequirements
 
 
 @dataclass
@@ -44,12 +43,7 @@ def add3(a: float, b: float, c: float) -> float:
     return add(add(a, b), c)
 
 
-@sematic.func(
-    resource_requirements=sematic.ResourceRequirements(
-        kubernetes=KubernetesResourceRequirements(node_selector={"foo": "bar"})
-    )
-)
-# @sematic.func
+@sematic.func
 def pipeline(a: float, b: float, c: float) -> float:
     """
     ## This is the docstring

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 # Sematic
 import sematic
+from sematic.resolvers.resource_requirements import KubernetesResourceRequirements
 
 
 @dataclass
@@ -43,7 +44,12 @@ def add3(a: float, b: float, c: float) -> float:
     return add(add(a, b), c)
 
 
-@sematic.func
+@sematic.func(
+    resource_requirements=sematic.ResourceRequirements(
+        kubernetes=KubernetesResourceRequirements(node_selector={"foo": "bar"})
+    )
+)
+# @sematic.func
 def pipeline(a: float, b: float, c: float) -> float:
     """
     ## This is the docstring

--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -100,6 +100,8 @@ def _can_cast_to_dataclass(from_type: Any, to_type: Any) -> Tuple[bool, Optional
 
 @register_to_json_encodable(DataclassKey)
 def _dataclass_to_json_encodable(value: Any, type_: Any) -> Any:
+    if value is None:
+        raise ValueError(f"Expected {type_}, got None")
     return _serialize_dataclass(value_to_json_encodable, value, type_)
 
 

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -1,15 +1,17 @@
 # Standard Library
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, get_args
 
 # Sematic
 from sematic.types.casting import safe_cast
 from sematic.types.registry import (
+    register_from_json_encodable,
     register_safe_cast,
     register_to_json_encodable,
     register_to_json_encodable_summary,
 )
 from sematic.types.serialization import (
     get_json_encodable_summary,
+    value_from_json_encodable,
     value_to_json_encodable,
 )
 
@@ -24,7 +26,7 @@ def _dict_safe_cast(value: Dict, type_: Type) -> Tuple[Optional[Dict], Optional[
             repr(value), type_
         )
 
-    key_type, element_type = type_.__args__
+    key_type, element_type = get_args(type_)
 
     cast_value = dict()
 
@@ -60,6 +62,23 @@ def _dict_to_json_encodable(value: Dict, type_: Type) -> List[Tuple[Any, Any]]:
         )
         for key in sorted_keys
     ]
+
+
+@register_from_json_encodable(dict)
+def _dict_from_json_encodable(
+    value: List[Tuple[Any, Any]], type_: Type
+) -> Dict[Any, Any]:
+    """
+    Dict deserialization
+    """
+    key_type, element_type = get_args(type_)
+
+    return {
+        value_from_json_encodable(key, key_type): value_from_json_encodable(
+            element, element_type
+        )
+        for key, element in value
+    }
 
 
 @register_to_json_encodable_summary(dict)

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -55,29 +55,32 @@ def _dict_to_json_encodable(value: Dict, type_: Type) -> List[Tuple[Any, Any]]:
     # Sorting keys for determinism
     sorted_keys = sorted(value.keys())
 
-    return [
-        (
-            value_to_json_encodable(key, key_type),
-            value_to_json_encodable(value[key], element_type),
-        )
-        for key in sorted_keys
-    ]
+    return {
+        "items": [
+            (
+                value_to_json_encodable(key, key_type),
+                value_to_json_encodable(value[key], element_type),
+            )
+            for key in sorted_keys
+        ]
+    }
 
 
 @register_from_json_encodable(dict)
 def _dict_from_json_encodable(
-    value: List[Tuple[Any, Any]], type_: Type
+    value: Dict[str, List[Tuple[Any, Any]]], type_: Type
 ) -> Dict[Any, Any]:
     """
     Dict deserialization
     """
     key_type, element_type = get_args(type_)
+    items = value["items"]
 
     return {
         value_from_json_encodable(key, key_type): value_from_json_encodable(
             element, element_type
         )
-        for key, element in value
+        for key, element in items
     }
 
 

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, get_args
+from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Type, get_args
 
 # Sematic
 from sematic.types.casting import safe_cast
@@ -46,7 +46,9 @@ def _dict_safe_cast(value: Dict, type_: Type) -> Tuple[Optional[Dict], Optional[
 
 
 @register_to_json_encodable(dict)
-def _dict_to_json_encodable(value: Dict, type_: Type) -> List[Tuple[Any, Any]]:
+def _dict_to_json_encodable(
+    value: Dict, type_: Type
+) -> Dict[Literal["items"], List[Tuple[Any, Any]]]:
     """
     Dict serialization
     """


### PR DESCRIPTION
Addresses #98

`ResourceRequirements` let users specify function-specific resource requirements. For example, a function can specify that it needs a particular type of Kubernetes node (e.g. GPU, high-mem).

At this time, these are used at runtime when launching K8s jobs, but they are not persisted in the DB. Persisting them is necessary to enable re-running pipelines from the UI and CLI, as well as to move kubernetes job launches behind the server.

Testing
-------
In addition to the unit tests, I ran the "add" pipeline with resource requirements set and confirmed they were in the DB.