### PR TITLE
Add ability to specify required CPU/Mem

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ Lines for version numbers should always be formatted as `* MAJOR.MINOR.PATCH`
 with nothing else on the line.
 -->
 * HEAD
+    * [feature] Allow specifying resource requirements for Kubernetes jobs.
+    BREAKING CHANGE: `KubernetesResourceRequirements` has a new required field,
+    `requests`
     * [bugfix] Pass API key to request to fetch root run
 * 0.11.0
     * [feature] Add a `get_artifact_value` API to retreive artifacts by ID

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -123,7 +123,16 @@ from sematic import ResourceRequirements, KubernetesRequirements
 
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesRequirements(
-        node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"}
+        # Note: the kind of node selector options that are valid will depend on
+        # your particular deployment of Kubernetes. Talk to the person who manages
+        # your Kubernetes cluster if you think you might need this. It is primarily
+        # useful in Sematic to gain access to nodes with GPUs.
+        node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
+
+        # The resource requirements of the job. Information on the format of valid
+        # values can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        # the dictionary provided here will be used for both "limits" and "requests"
+        requests={"cpu": "1", "memory": "1Gi"},
     )
 )
 

--- a/sematic/config.py
+++ b/sematic/config.py
@@ -98,10 +98,6 @@ class Config:
 
     def server_url_from_env_vars(self):
         server_address = os.environ.get(SEMATIC_SERVER_ADDRESS_ENV_VAR, None)
-        if server_address.startswith("http://") or server_address.startswith(
-            "https://"
-        ):
-            return server_address
         if ON_WORKER_ENV_VAR in os.environ:
             server_address = os.environ.get(
                 SEMATIC_WORKER_SERVER_ADDRESS_ENV_VAR, server_address
@@ -111,6 +107,11 @@ class Config:
                 f"Cannot construct server URL from env vars if "
                 f"{SEMATIC_SERVER_ADDRESS_ENV_VAR} is not set."
             )
+        if server_address is not None and (
+            server_address.startswith("http://")
+            or server_address.startswith("https://")
+        ):
+            return server_address
         port = os.environ.get("PORT", 80)
         return "http://{}:{}".format(server_address, port)
 

--- a/sematic/config.py
+++ b/sematic/config.py
@@ -98,6 +98,10 @@ class Config:
 
     def server_url_from_env_vars(self):
         server_address = os.environ.get(SEMATIC_SERVER_ADDRESS_ENV_VAR, None)
+        if server_address.startswith("http://") or server_address.startswith(
+            "https://"
+        ):
+            return server_address
         if ON_WORKER_ENV_VAR in os.environ:
             server_address = os.environ.get(
                 SEMATIC_WORKER_SERVER_ADDRESS_ENV_VAR, server_address

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -55,7 +55,7 @@ class PipelineConfig:
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesResourceRequirements(
         node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
-        requests={"cpu": 8, "memory": "2Gi"},
+        requests={"cpu": 2, "memory": "2Gi"},
     )
 )
 

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -54,7 +54,8 @@ class PipelineConfig:
 
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesResourceRequirements(
-        node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"}
+        node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
+        requests={"cpu": 8, "memory": "2Gi"},
     )
 )
 

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -55,7 +55,7 @@ class PipelineConfig:
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesResourceRequirements(
         node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
-        requests={"cpu": 2, "memory": "2Gi"},
+        requests={"cpu": "2", "memory": "2Gi"},
     )
 )
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -288,9 +288,11 @@ def _schedule_job(
                                 for name, value in get_all_user_settings().items()
                             ],
                             volume_mounts=[],
-                            resources=kubernetes.V1ResourceRequirements(
-                                limits=resource_requests,
-                                requests=resource_requests,
+                            resources=(
+                                kubernetes.client.V1ResourceRequirements(  # type: ignore
+                                    limits=resource_requests,
+                                    requests=resource_requests,
+                                )
                             ),
                         )
                     ],

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -250,9 +250,12 @@ def _schedule_job(
     image = _get_image()
 
     node_selector = {}
+    resource_requests = {}
     if resource_requirements is not None:
         node_selector = resource_requirements.kubernetes.node_selector
+        resource_requests = resource_requirements.kubernetes.requests
         logger.debug("kubernetes node_selector %s", node_selector)
+        logger.debug("kubernetes resource requests %s", resource_requests)
 
     job = kubernetes.client.V1Job(  # type: ignore
         api_version="batch/v1",
@@ -285,7 +288,10 @@ def _schedule_job(
                                 for name, value in get_all_user_settings().items()
                             ],
                             volume_mounts=[],
-                            resources=None,
+                            resources=kubernetes.V1ResourceRequirements(
+                                limits=resource_requests,
+                                requests=resource_requests,
+                            ),
                         )
                     ],
                     volumes=[],

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -5,7 +5,22 @@ from typing import Dict
 
 @dataclass
 class KubernetesResourceRequirements:
+    """Information on the Kubernetes resources required.
+
+    Attributes
+    ----------
+    node_selector:
+        The kind of Kubernetes node that the job must run on. More detail can
+        be found here: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+        The value of this field will be used as the nodeSelector described there.
+    requests:
+        Requests for resources on a kubernetes pod. More detail can be found
+        here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        The values used here will apply to both the "requests" and the "limits" of the job.
+    """
+
     node_selector: Dict[str, str] = field(default_factory=dict)
+    requests: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -11,12 +11,15 @@ class KubernetesResourceRequirements:
     ----------
     node_selector:
         The kind of Kubernetes node that the job must run on. More detail can
-        be found here: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+        be found here:
+        https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
         The value of this field will be used as the nodeSelector described there.
     requests:
         Requests for resources on a kubernetes pod. More detail can be found
-        here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        The values used here will apply to both the "requests" and the "limits" of the job.
+        here:
+        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        The values used here will apply to both the "requests" and the "limits" of the
+        job.
     """
 
     node_selector: Dict[str, str] = field(default_factory=dict)

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -225,7 +225,7 @@ def test_inline():
 
 def test_resource_requirements():
     resource_requirements = ResourceRequirements(
-        kubernetes=KubernetesResourceRequirements(node_selector={"a": "b"})
+        kubernetes=KubernetesResourceRequirements(node_selector={"a": "b"}, requests={})
     )
 
     @func(resource_requirements=resource_requirements)


### PR DESCRIPTION
Currently you can specify what kind of node your job's pod runs on, but you can't specify how many resources on that node should be allocated to your individual pod. This PR makes it possible to specify resources required for the pod.