### PR TITLE
Have cloud server logs go to stdout

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -23,7 +23,8 @@ sematic run examples/mnist/pytorch
 Do this for all supported versions of python. If everything works fine,
 we are ready to push the release. Once you have pushed it to PyPi,
 ```
-git tag vMAJOR.MINOR.PATCH
+RELEASE_VERSION=v$(python3 ./sematic/versions.py)
+git tag $RELEASE_VERSION
 git push --tags
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Lines for version numbers should always be formatted as `* MAJOR.MINOR.PATCH`
 with nothing else on the line.
 -->
 * HEAD
+    * [feature] When running in cloud mode, have the server log to stdout
 * 0.12.0
     * [feature] BREAKING CHANGE: Allow specifying resource requirements for Kubernetes
     jobs. `KubernetesResourceRequirements` has a new required field, `requests`

--- a/sematic/config.py
+++ b/sematic/config.py
@@ -72,6 +72,7 @@ class Config:
     examples_dir: str = _get_examples_dir()
     project_template_dir: str = "{}/template".format(_get_examples_dir())
     data_dir: str = _get_data_dir()
+    server_log_to_stdout: bool = False
 
     @property
     def server_url(self) -> str:
@@ -129,6 +130,7 @@ _LOCAL_CONFIG = Config(
     db_url=os.environ.get(
         "DATABASE_URL", "sqlite:///{}/{}".format(get_config_dir(), _SQLITE_FILE)
     ),
+    server_log_to_stdout=False,
 )
 
 
@@ -137,6 +139,7 @@ _CLOUD_CONFIG = Config(
     api_version=1,
     port=int(os.environ.get("PORT", 80)),
     db_url=os.environ.get("DATABASE_URL", "NO_DB"),
+    server_log_to_stdout=True,
 )
 
 


### PR DESCRIPTION
When you are running a server in an environment like a container, it is standard for the logs to go to stdout/stderr. This PR makes it so that when running the server using the cloud mode, the logs go to stdout.

Testing
--------
Changed `server_log_to_stdout=True` briefly for the local config, and stopped/started the local server. Confirmed that the logs went to stdout. Then changed it back and stopped/started the local server. Confirmed that the logs didn't show up in stdout, but were still in the log files.