### PR TITLE
Improve eviction handling

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -279,7 +279,10 @@ def _schedule_job(
     job = kubernetes.client.V1Job(  # type: ignore
         api_version="batch/v1",
         kind="Job",
-        metadata=kubernetes.client.V1ObjectMeta(name=name),  # type: ignore
+        metadata=kubernetes.client.V1ObjectMeta(  # type: ignore
+            name=name,
+            annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
+        ),
         spec=kubernetes.client.V1JobSpec(  # type: ignore
             template=kubernetes.client.V1PodTemplateSpec(  # type: ignore
                 spec=kubernetes.client.V1PodSpec(  # type: ignore

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -275,16 +275,19 @@ def _schedule_job(
         logger.debug("kubernetes resource requests %s", resource_requests)
         logger.debug("kubernetes volumes and mounts: %s, %s", volumes, volume_mounts)
         logger.debug("kubernetes environment secrets: %s", secret_env_vars)
-
     job = kubernetes.client.V1Job(  # type: ignore
         api_version="batch/v1",
         kind="Job",
         metadata=kubernetes.client.V1ObjectMeta(  # type: ignore
             name=name,
-            annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
         ),
         spec=kubernetes.client.V1JobSpec(  # type: ignore
             template=kubernetes.client.V1PodTemplateSpec(  # type: ignore
+                metadata=kubernetes.client.V1ObjectMeta(  # type: ignore
+                    annotations={
+                        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+                    },
+                ),
                 spec=kubernetes.client.V1PodSpec(  # type: ignore
                     node_selector=node_selector,
                     containers=[

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -241,6 +241,15 @@ class LocalResolver(SilentResolver):
 
     def _update_resolution_status(self, status: ResolutionStatus):
         resolution = api_client.get_resolution(self._root_future.id)
+        current_status = ResolutionStatus[resolution.status]  # type: ignore
+        if (
+            status == ResolutionStatus.RUNNING
+            and current_status != ResolutionStatus.SCHEDULED
+        ):
+            raise RuntimeError(
+                "It appears that the resolver has restarted mid-execution. "
+                "The cluster may be under pressure."
+            )
         resolution.status = status
         api_client.save_resolution(resolution)
 


### PR DESCRIPTION
Kubernetes' autoscaler sometimes evicts pods because it wants to restructure how pods are packed in nodes. When this happens to our resolver job, we wind up creating a duplicate copy of the root run. This PR:
(a) changes the failure mode so we crash with an error message instead of duplicating things
(b) adds [an annotation](https://github.com/kubernetes/autoscaler/blob/c127763a4529d7d07961102856afe0ba8781f8ee/cluster-autoscaler/utils/drain/drain.go#L40) that k8s looks at when draining a node for purposed of autoscaling. The annotation will cause k8s to delay the scale-down while the pod is there.

Testing
-------
- Did a normal cloud execution: https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/91d8635765364ab79d1bc420197cf807
- Used `kubectl` to manually delete the driver pod while it was executing. Left the job alive, so Kubernetes replaced the pod. Confirmed that the desired error message showed: https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/251d6635c98545b28ed1d7ea85cfc6b2