### PR TITLE
Improve bad URL error

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -250,11 +250,16 @@ def _validate_server_compatibility(
 
 
 def _validate_server_compatibility_no_catch() -> None:
+    base_url = get_config().api_url.replace("/api/v1", "")
     unexpected_server_response_error = IncompatibleClientError(
         "The Sematic server did not provide information about its version "
-        "in the expected format. It could be that the server is too old to "
-        "provide this information. Consider upgrading your server if possible, "
-        "or reach out to Sematic for support."
+        "in the expected format. Most likely this means that your "
+        "SEMATIC_API_ADDRESS is pointing to a URL which resolves to something other "
+        "than your Sematic deployment. Please verify your deployment by running the "
+        "following curl command. The response should be html with a '🦊' emoji in it. "
+        "If it is not, please correct your Sematic deployment, networking or "
+        "SEMATIC_API_ADDRESS so that you can reach it from this host. "
+        f"CURL COMMAND: \n\n\tcurl {base_url}\n"
     )
 
     try:


### PR DESCRIPTION
When Sematic tries to verify that the server version is compatible, it's always the first API call that gets made. One failure mode is that the request receives a response, but that response is NOT a valid version metadata response from a Sematic server. This can have basically two causes:
(a) deployment is older than Sematic v0.9.0
(b) the URL points to *something* but it's not a valid Sematic deployment.

(a) shouldn't be worth worrying about at this point; people with cloud deployments seem to be updating regularly. (b) can happen under a variety of circumstances--people point to something random (ex: `http://example.com`) or their Sematic is behind a reverse proxy of some kind and the reverse proxy is broken. In this situation, people should figure out why that is.

The current error message is tailored to people hitting situation (a), but at this point most people getting it are in situation (b), and the percentage of people in (a) vs (b) will only grow over time. So I updated it.

Is this error message verbose? Yes, but given its nature it could be one of the first interactions people have with using Sematic, so it's best to make it as friendly of an experience as possible.