### PR TITLE
Add link between deploy docs and container docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 * [Type support](type-support.md)
 * [Future algebra](future-algebra.md)
 * [Deploy Sematic](deploy.md)
+* [Container images](container-images.md)
 * [Artifacts](artifacts.md)
 * [Glossary](glossary.md)
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -1,12 +1,12 @@
 # Sematic and Container Images
 
-When Sematic runs your code in the cloud (aka when you are using `CloudResolver`),
-it does so in a Docker container. Your code and all its dependencies need to be in
-that Docker image for it to run. Where does this Docker image come from? There are
-a few options, but a general theme is that Sematic prefers to make the construction
-of the Docker image transparent to you for simple cases, hooking into existing build
-tooling when possible. However, we leave the flexibility to customize for advanced
-usages if needed.
+When Sematic runs your code in the cloud (in other words, when you are using
+`CloudResolver`), it does so in a Docker container. Your code and all its
+dependencies need to be in that Docker image for it to run. Where does this
+Docker image come from? There are a few options, but a general theme is that
+Sematic prefers to make the construction of the Docker image transparent to you
+for simple cases, hooking into existing build tooling when possible. However,
+we leave the flexibility to customize for advanced usages if needed.
 
 ## Image Construction
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -2,11 +2,13 @@
 
 When Sematic runs your code in the cloud (in other words, when you are using
 `CloudResolver`), it does so in a Docker container. Your code and all its
-dependencies need to be in that Docker image for it to run. Where does this
-Docker image come from? There are a few options, but a general theme is that
-Sematic prefers to make the construction of the Docker image transparent to you
-for simple cases, hooking into existing build tooling when possible. However,
-we leave the flexibility to customize for advanced usages if needed.
+dependencies need to be in that Docker image for it to run.
+
+Where does this Docker image come from? There are a few options, but a general
+theme is that Sematic prefers to make the construction of the Docker image
+transparent to you for simple cases, hooking into existing build tooling when
+possible. However, we leave the flexibility to customize for advanced usages
+if needed.
 
 ## Image Construction
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -1,15 +1,17 @@
 # Sematic and Container Images
 
-When Sematic runs your code in the cloud, it does so in a Docker container.
-Your code and all its dependencies need to be in that Docker image for it
-to run. Where does this Docker image come from? There are a few options, but
-a general theme is that Sematic prefers to make the construction of the Docker
-image transparent to you for simple cases, hooking into existing build tooling
-when possible. However, we leave the flexibility to customize for advanced
+When Sematic runs your code in the cloud (aka when you are using `CloudResolver`),
+it does so in a Docker container. Your code and all its dependencies need to be in
+that Docker image for it to run. Where does this Docker image come from? There are
+a few options, but a general theme is that Sematic prefers to make the construction
+of the Docker image transparent to you for simple cases, hooking into existing build
+tooling when possible. However, we leave the flexibility to customize for advanced
 usages if needed.
 
 ## Image Construction
+
 ### Bazel
+
 If you're using [**Bazel**](https://bazel.build), having Sematic create a cloud
 image containing your code is quite straightforward: we have a bazel macro that
 will allow you to create targets for building and pushing your image at the
@@ -22,19 +24,21 @@ a Sematic pipeline (we'll refer to the python script for this target your
 
 1. Include Sematic's GitHub repo as a bazel repository in your bazel WORKSPACE
 2. Load Sematic's base images in your WORKSPACE, using, for example:
+
 ```starlark
 load("@rules_sematic//:pipeline.bzl", "base_images")
 base_images()
 ```
+
 3. Ensure you have a container registry where you can push your Docker images
-to
+   to
 4. In the bazel `BUILD` file where you have defined your launch script, load
-Sematic's pipeline macro:
-`load("@rules_sematic//:pipeline.bzl", "sematic_pipeline")`
+   Sematic's pipeline macro:
+   `load("@rules_sematic//:pipeline.bzl", "sematic_pipeline")`
 5. Replace the python binary target for your launch script with
-`sematic_pipeline`, using the same `deps` as you use for the binary target
+   `sematic_pipeline`, using the same `deps` as you use for the binary target
 6. Fill out the `registry` and `repository` fields of the `sematic_pipeline`
-with information about where to push your image.
+   with information about where to push your image.
 
 When you're done, your `WORKSPACE` should look something like:
 
@@ -104,7 +108,7 @@ sematic_pipeline(
     # Optional base image to use
     base = "<base-image>",
     # Optional environment variables to set in the image
-    env = {"VAR": "VALUE"} 
+    env = {"VAR": "VALUE"}
 )
 ```
 
@@ -112,16 +116,17 @@ With that, you're done! Assuming the target for your launch script was
 `//my_repo/my_package:my_target`, you now have the following targets available:
 
 - `//my_repo/my_package:my_target`: still runs your target, but builds a Docker
-image with your code and its dependencies first
+  image with your code and its dependencies first
 - `//my_repo/my_package:my_target_local`: runs your target WITHOUT building and
-pushing the image. This can help for local development when you don't want the
-overhead of waiting for the build & push.
+  pushing the image. This can help for local development when you don't want the
+  overhead of waiting for the build & push.
 - `//my_repo/my_package:my_target_image`: builds the image, but doesn't push it
-or run your script
+  or run your script
 - `//my_repo/my_package:my_target_push`: builds and pushes the image, but
-doesn't run your script
+  doesn't run your script
 
 #### Custom base images
+
 The `sematic_pipeline` macro also allows you to specify a custom base image to
 cover any dependencies you have that aren't specified in bazel. You can do this
 by setting the `base` field of the `sematic_pipeline` macro:
@@ -152,9 +157,11 @@ what those are. Note that if you are using bazel, requirements 1, 2 & 3 from
 that section will already be taken care of.
 
 ### requirements.txt
+
 Coming soon!
 
 ### Totally Custom Image
+
 If you want full control over how your Docker image is produced, Sematic
 provides a hook to make that possible. Just set the `SEMATIC_CONTAINER_IMAGE`
 environment variable to the URI for the Docker image you want your pipeline to
@@ -162,13 +169,14 @@ use. There are some requirements on this image though:
 
 1. It must contain your source code and its dependencies
 2. It must be pushed to a container registry that can be accessed by the cluster
-where your code is going to run in the cloud
+   where your code is going to run in the cloud
 3. The entrypoint must be set to a script which executes
-`/usr/bin/python3 -m sematic.resolvers.worker "$@"`
+   `/usr/bin/python3 -m sematic.resolvers.worker "$@"`
 4. `/usr/bin/python3` must be a valid python interpreter in the image
 5. The home directory inside the image must be writable
 
 ## Working with images
+
 When launching Sematic pipelines, there is always a python script that submits
 the job (either for local exection or execution in the cloud). We refer to this
 as the "launch script." You may want to have your launch script behave
@@ -195,20 +203,20 @@ speed up the time to start the container for them. However, there are more good
 reasons to put everything in one image than to separate them:
 
 - It can actually speed up container download to re-use the same image, as Kubernetes
-nodes will only download the image once and have it cached for re-use in other steps in
-the pipeline.
+  nodes will only download the image once and have it cached for re-use in other steps in
+  the pipeline.
 - It can quickly become tricky to remember what dependencies are going to be available
-in which step. When you have a single python interpreter executing all your code, all
-the dependencies are available everywhere. We want to bring this intuitive experience
-to the cloud.
+  in which step. When you have a single python interpreter executing all your code, all
+  the dependencies are available everywhere. We want to bring this intuitive experience
+  to the cloud.
 - With different images for different steps comes the potential for variations in what
-versions of libraries are available in which step. For example, if `step_1` returns a
-Scikit-learn model using `scikit-learn==1.1.2`, you'll want to be sure that `step_2`
-isn't trying to use that model with `scikit-learn==0.24.2`
+  versions of libraries are available in which step. For example, if `step_1` returns a
+  Scikit-learn model using `scikit-learn==1.1.2`, you'll want to be sure that `step_2`
+  isn't trying to use that model with `scikit-learn==0.24.2`
 - Image builds are slow, and slow down the iteration loop of change code, push image,
-execute. Sematic aims to make this loop as tight as possible, and having to build multiple
-images every time (or remember which ones you need to rebuild when) would significantly
-damage this workflow.
+  execute. Sematic aims to make this loop as tight as possible, and having to build multiple
+  images every time (or remember which ones you need to rebuild when) would significantly
+  damage this workflow.
 - If you have a step which is really lightweight, there's a better option than having
-a small new container: *no* new container. This is a great case for inline functions.
-See the [execution mode docs](https://docs.sematic.dev/execution-modes) for more.
+  a small new container: _no_ new container. This is a great case for inline functions.
+  See the [execution mode docs](https://docs.sematic.dev/execution-modes) for more.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -6,12 +6,12 @@ and your pipelines run locally.
 Here is how to deploy Sematic to take full advantage of your cloud resources.
 Before you start, you will need to decide how you wish to use Sematic.
 
-* Option 1 is to use Sematic to track and share your pipeline executions, but
-still have the pipelines execute locally. This setup is simpler, but less
-powerful.
-* Option 2 is to deploy Sematic on Kubernetes, where the pipelines
-can have access to more powerful compute by executing in the cloud. This
-setup is a little more complex and has more pre-requisites.
+- Option 1 is to use Sematic to track and share your pipeline executions, but
+  still have the pipelines execute locally. This setup is simpler, but less
+  powerful.
+- Option 2 is to deploy Sematic on Kubernetes, where the pipelines
+  can have access to more powerful compute by executing in the cloud. This
+  setup is a little more complex and has more pre-requisites.
 
 ## Deployment Option 1: Shared Metadata Server
 
@@ -25,9 +25,9 @@ Your pipelines will still execute locally.
 
 Prerequisites:
 
-* A remote instance into which you can SSH
-* A Postgres database
-* [Install Docker](https://docs.docker.com/engine/install/) onto your remote instance
+- A remote instance into which you can SSH
+- A Postgres database
+- [Install Docker](https://docs.docker.com/engine/install/) onto your remote instance
 
 Then, SSH into your remote server:
 
@@ -72,11 +72,11 @@ behavior for your deployed app.
 If you don't pass any of them, your app will be available publicly and users will not need to
 authenticate to use it. Everyone will be the "Anonymous" user.
 
-* `SEMATIC_AUTHENTICATE` activates authentication. Users will need to sign in to user the web app,
+- `SEMATIC_AUTHENTICATE` activates authentication. Users will need to sign in to user the web app,
   and will need to set an API key in their local settings in order to submit jobs.
-* `GOOGLE_OAUTH_CLIENT_ID` is the client ID of your Google OAuth App. We will support more OAuth
+- `GOOGLE_OAUTH_CLIENT_ID` is the client ID of your Google OAuth App. We will support more OAuth
   providers int he future.
-* `SEMATIC_AUTHORIZED_EMAIL_DOMAIN` denies access to users whose email is not of said domain.
+- `SEMATIC_AUTHORIZED_EMAIL_DOMAIN` denies access to users whose email is not of said domain.
 
 ##### SSL
 
@@ -87,6 +87,7 @@ private key files are accessible within the container (e.g. place them in the
 `~/.sematic` directory). Also make sure to add `-p 443:443` to the forwarded ports.
 
 ## Deployment Option 2: Sematic with Cloud Execution
+
 If you wish to not only use your Sematic deployment to share the results
 of pipeline executions, but also to actually execute the pipelines, you
 will need to deploy it on Kubernetes.
@@ -95,12 +96,12 @@ will need to deploy it on Kubernetes.
 
 Prerequisites:
 
-* A Kubernetes cluster running Kubernetes >=1.21
-* A Postgres database
-* [Helm](https://helm.sh/docs/intro/install/#helm) &
+- A Kubernetes cluster running Kubernetes >=1.21
+- A Postgres database
+- [Helm](https://helm.sh/docs/intro/install/#helm) &
   [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and
   able to access your Kubernetes cluster
-* Ingress configured on your cluster that allows accessing services deployed on it
+- Ingress configured on your cluster that allows accessing services deployed on it
 
 Run the following command to deploy a Kubernetes secret containing the database URL:
 
@@ -134,14 +135,14 @@ Once you have set all the values, deploy using `helm install sematic ./` from th
 In the `values.yaml` file above, three settings dictate the
 authentication behavior for your deployed app.
 
-* `auth.enabled` activates authentication. Users will need to sign in to
+- `auth.enabled` activates authentication. Users will need to sign in to
   user the web app, and will need to set an API key in their local settings in
   order to submit jobs.
 
-* `auth.google_oauth_client_id` is the client ID of your Google OAuth App.
+- `auth.google_oauth_client_id` is the client ID of your Google OAuth App.
   We will support more OAuth providers in the future.
 
-* `auth.authorized_email_domain` denies access to users whose email is not of
+- `auth.authorized_email_domain` denies access to users whose email is not of
   said domain.
 
 ##### SSL
@@ -152,6 +153,7 @@ that points to the service (named `sematic-service`) deployed by the helm chart,
 and set up your ingress to use SSL.
 
 ## Using your deployment
+
 ### Run pipelines against the deployed API
 
 At this point you should be able to run pipelines that are tracked by Sematic.
@@ -178,15 +180,26 @@ focuses support on **Amazon Web Services**. Other providers to follow soon.
 
 Before you proceed, the following must be true:
 
-* The Sematic web app is deployed. See
+- The Sematic web app is deployed. See
   [Deploy the web app](#deployment-option-2-sematic-with-cloud-execution).
 
-* You have an S3 bucket and you and nodes in your Kubernetes cluster have read
+- You have an S3 bucket and you and nodes in your Kubernetes cluster have read
   and write permissions to it.
 
-* You have a container registry (e.g. AWS Elastic Container Registry) and you
+- You have a container registry (e.g. AWS Elastic Container Registry) and you
   have write access, and nodes in yout Kubernetes cluster have read access to
   it.
+
+- You have `sematic_pipeline` bazel targets defined as described in
+  [Container Images](./container-images.md). This will enable `bazel run` commands
+  to execute the launch script to start your cloud jobs.
+
+{% hint style="warning" %}
+
+Sematic plans to support other ways to produce container images besides
+bazel, but for now it is required for cloud execution.
+
+{% endhint %}
 
 When you are set, the following settings should be visible to Sematic
 
@@ -203,11 +216,10 @@ SEMATIC_API_ADDRESS: <web-app-server-address>
 If you have chosen to deploy Sematic in such a way that users of Sematic
 will use a different URL for the server from what should be used for
 jobs on your Kubernetes cluster (e.g. users access via a reverse proxy
-that's not needed on Kubernetes), you may also need to set 
+that's not needed on Kubernetes), you may also need to set
 `SEMATIC_WORKER_API_ADDRESS`. That will set the URL to be used from
 Kubernetes, while `SEMATIC_API_ADDRESS` will be used from your machine.
 {% endhint %}
-
 
 #### Cloud storage bucket
 

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -66,7 +66,8 @@ dedicated resources (e.g. GPUs).
 
 {% hint style="info" %}
 
-**Prerequisite:** To learn how to deploy Sematic in your cloud, read [Deploy Sematic](./deploy.md).
+**Prerequisite:** To learn how to deploy Sematic in your cloud, read
+[Deploy Sematic](./deploy.md) and [Container images](./container-images.md).
 
 {% endhint %}
 


### PR DESCRIPTION
Currently it's not obvious to people that after they deploy Sematic, they need to use bazel to run cloud jobs. This change makes that explicit. Also ran `Prettier` on our md to make it more standard formatted