### PR TITLE
Reduce log ingestion test flake

### DIFF
--- a/sematic/resolvers/tests/test_log_streamer.py
+++ b/sematic/resolvers/tests/test_log_streamer.py
@@ -86,7 +86,7 @@ def test_ingested_logs_uncaught():
         upload_number += 1
 
     assert len(uploads) >= 1
-    assert message in "\n".join(uploads[0])
+    assert message in "\n".join(uploads[-1])
 
 
 def test_tail_log_file():


### PR DESCRIPTION
One of the log ingestion tests raises an error during ingestion and asserts that the error message made it into the first upload. It's actually possible (race condition) that an upload can happen before the error message is done being written to stdout. All we really care about is that the log message makes it by the final upload. This PR makes it so that's what we assert.