### PR TITLE
Fix log spam for runs without initial logs

### DIFF
--- a/sematic/ui/src/components/ScrollingLogView.tsx
+++ b/sematic/ui/src/components/ScrollingLogView.tsx
@@ -41,7 +41,11 @@ export default function ScrollingLogView(props: {
     cursor: string | null; // the cursor to continue getting the lines after these ones
     source: string; // the id of the source these log lines are for
     filterString: string; // the filter string that was used to produce these lines
-  }>({ lines: [], cursor: null, source: logSource, filterString: "" });
+
+    // initialize the state to no logs from an unknown source/filter.
+    // An on-render effect will do the first load from the actual source.
+  }>({ lines: [], cursor: null, source: "", filterString: "" });
+
   const [filterString, setFilterString] = useState<string>("");
 
   // display log lines once they have been loaded from the server.
@@ -92,8 +96,7 @@ export default function ScrollingLogView(props: {
   useEffect(() => {
     if (
       lineState.source !== logSource ||
-      lineState.filterString !== filterString ||
-      lineState.lines.length === 0
+      lineState.filterString !== filterString
     ) {
       next();
     }


### PR DESCRIPTION
There is some code in the log view that says "on render, if I don't have any log lines for this run, load some." There's also some code that says "if a run is in a terminal state, don't bother asking for more logs once you've gotten the initial response." It seems I forgot to test the case where a run has no log lines, but is also not in a terminal state. Under these conditions, the existing code just repeatedly spams the server asking for logs. I have changed that by basing the "needs initial load" condition from being based on the number of lines to being based on the log source.

The fix: the code already detects when there is a mismatch between the active run and the source for the current logs. It triggers a load under this circumstance. I now set the initial render to say that the loaded lines are from an empty source, so the mismatch between active run and log source is immediately detected and a log line load triggered. This makes sense, because on render there are no logs, so it makes sense to say the currently loaded logs are from "nowhere." Once the initial load has happened, the source for the currently loaded logs and the active run match, and no more loads happen on renders.

Testing
-------
- Tested that on a run in a non-terminal state with no logs, only one request for logs occurs
- Tested that on a run in a terminal state with no logs, an appropriate message is shown
- Tested that toggling between runs with logs still works
- Tested infinite scroll
- tested that "jump to end" still works
- tested that moving the scroll wheel while at the end of the logs for an active run still loads new logs