### PR TITLE
Wrap worker.py main more consistently

### DIFF
--- a/bazel/worker.py
+++ b/bazel/worker.py
@@ -5,7 +5,7 @@ We need to do this because we don't want to use the current worker at
 //sematic/resolvers:worker we want to use the one in the wheel that the user has
 installed.
 """
-from sematic.resolvers.worker import main, parse_args
+from sematic.resolvers.worker import wrap_main
 
 if __name__ == "__main__":
-    main(**vars(parse_args()))
+    wrap_main()

--- a/bazel/worker.py
+++ b/bazel/worker.py
@@ -5,7 +5,7 @@ We need to do this because we don't want to use the current worker at
 //sematic/resolvers:worker we want to use the one in the wheel that the user has
 installed.
 """
-from sematic.resolvers.worker import wrap_main
+from sematic.resolvers.worker import wrap_main_with_logging
 
 if __name__ == "__main__":
-    wrap_main()
+    wrap_main_with_logging()

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -325,7 +325,13 @@ def _filter_for_inline(
     found_start = False
     file_line_index = 0
     while True:
-        line = next(buffer_iterator)
+        try:
+            line = next(buffer_iterator)
+        except StopIteration:
+            # if a resolver dies mid-execution of an inline run,
+            # we should treat the end of the existing lines as
+            # the end of whatever inline we were looking for.
+            break
         if expected_start in line:
             found_start = True
             continue

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -184,6 +184,7 @@ def _create_log_file_path(file_name: str) -> str:
 
 
 def wrap_main():
+    """Wrap the main function with log initialization and ingestion"""
     print("Starting Sematic Worker")
     args = parse_args()
     prefix = log_prefix(args.run_id, JobType.driver if args.resolve else JobType.worker)
@@ -201,4 +202,6 @@ def wrap_main():
 
 
 if __name__ == "__main__":
+    # don't put anything here besides wrap_main()! It needs to match
+    # bazel/worker.py
     wrap_main()

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -183,7 +183,7 @@ def _create_log_file_path(file_name: str) -> str:
     return (pathlib.Path(sematic_temp_logs_dir) / pathlib.Path(file_name)).as_posix()
 
 
-def wrap_main():
+def wrap_main_with_logging():
     """Wrap the main function with log initialization and ingestion"""
     print("Starting Sematic Worker")
     args = parse_args()
@@ -204,4 +204,4 @@ def wrap_main():
 if __name__ == "__main__":
     # don't put anything here besides wrap_main()! It needs to match
     # bazel/worker.py
-    wrap_main()
+    wrap_main_with_logging()

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -183,10 +183,9 @@ def _create_log_file_path(file_name: str) -> str:
     return (pathlib.Path(sematic_temp_logs_dir) / pathlib.Path(file_name)).as_posix()
 
 
-if __name__ == "__main__":
+def wrap_main():
     print("Starting Sematic Worker")
     args = parse_args()
-    log_kind = "resolve" if args.resolve else "calculation"
     prefix = log_prefix(args.run_id, JobType.driver if args.resolve else JobType.worker)
     path = _create_log_file_path("worker.log")
 
@@ -199,3 +198,7 @@ if __name__ == "__main__":
         logger.info("Worker CLI args: resolve=%s", args.resolve)
 
         main(args.run_id, args.resolve)
+
+
+if __name__ == "__main__":
+    wrap_main()

--- a/sematic/wheel_version.bzl
+++ b/sematic/wheel_version.bzl
@@ -2,4 +2,4 @@
 # changelog.md.
 # This is the version that will be attached to the
 # wheel that bazel builds for sematic.
-wheel_version_string = "0.15.0dev1"
+wheel_version_string = "0.15.0"

--- a/sematic/wheel_version.bzl
+++ b/sematic/wheel_version.bzl
@@ -2,4 +2,4 @@
 # changelog.md.
 # This is the version that will be attached to the
 # wheel that bazel builds for sematic.
-wheel_version_string = "0.15.0"
+wheel_version_string = "0.15.0dev1"


### PR DESCRIPTION
When people use the `sematic_pipeline` bazel macro and don't use `dev=True`, it points them to the `worker.py` in `bazel/worker.py` rather than `sematic/resolvers/worker.py`. It imported the main from there, but it missed the code that wrapped main to set up logging properly. This PR makes it so both `worker.py` scripts use the same log wrapping for `main`.

Testing
-------
- launched a cloud [run](https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/79dd03cc82044e83a3de9a4ae0f90bc2) on the dev machine from within the Sematic repo, with `dev=True`
- launched a cloud [run](https://dev.sematic.cloud/pipelines/example_bazel.pipeline.pipeline/85c5b1e46fd24343a849d9b0c77115fa) on the dev machine from the `example_bazel` repo (pointing it at this branch), with `dev=False`

Confirmed that logs were ingested and displayed in both cases.