### PR TITLE
Fix GitInfo generation when git executable not installed

### DIFF
--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -45,6 +45,15 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "git_info",
+    srcs = ["git_info.py"],
+    pip_deps = [],
+    deps = [
+        ":base",
+    ],
+)
+
+sematic_py_lib(
     name = "has_external_jobs_mixin",
     srcs = ["has_external_jobs_mixin.py"],
     deps = [
@@ -89,9 +98,9 @@ sematic_py_lib(
     ],
     deps = [
         ":base",
+        ":git_info",
         ":has_external_jobs_mixin",
         ":json_encodable_mixin",
-        "//sematic/utils:git",
     ],
 )
 

--- a/sematic/db/models/git_info.py
+++ b/sematic/db/models/git_info.py
@@ -1,0 +1,15 @@
+# Standard Library
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class GitInfo:
+    """
+    Information about a git workspace.
+    """
+
+    remote: Optional[str]
+    branch: Optional[str]
+    commit: Optional[str]
+    dirty: Optional[bool]

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -11,13 +11,13 @@ from sqlalchemy.orm import validates
 
 # Sematic
 from sematic.db.models.base import Base
+from sematic.db.models.git_info import GitInfo
 from sematic.db.models.has_external_jobs_mixin import HasExternalJobsMixin
 from sematic.db.models.json_encodable_mixin import (
     ENUM_KEY,
     JSON_KEY,
     JSONEncodableMixin,
 )
-from sematic.utils.git import GitInfo
 
 logger = logging.getLogger(__name__)
 

--- a/sematic/db/models/tests/test_resolution.py
+++ b/sematic/db/models/tests/test_resolution.py
@@ -4,13 +4,13 @@ import re
 import pytest
 
 # Sematic
+from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import (
     InvalidResolution,
     ResolutionKind,
     ResolutionStatus,
 )
 from sematic.db.tests.fixtures import make_resolution
-from sematic.utils.git import GitInfo
 
 
 def test_is_allowed_transition():

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -11,6 +11,7 @@ import testing.postgresql  # type: ignore
 import sematic.db.db as db
 from sematic.abstract_future import FutureState
 from sematic.db.models.factories import make_artifact, make_user
+from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.queries import save_resolution, save_run, save_user
@@ -19,7 +20,6 @@ from sematic.resolvers.resource_requirements import (
     ResourceRequirements,
 )
 from sematic.tests.fixtures import test_storage  # noqa: F401
-from sematic.utils.git import GitInfo
 
 
 def handler(postgresql):

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -5,6 +5,7 @@ import pytest
 
 # Sematic
 from sematic.abstract_future import FutureState
+from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.resolvers.resource_requirements import (
@@ -18,7 +19,6 @@ from sematic.scheduling.job_scheduler import (
     schedule_run,
 )
 from sematic.scheduling.kubernetes import KubernetesExternalJob
-from sematic.utils.git import GitInfo
 
 
 @pytest.fixture

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -27,7 +27,9 @@ sematic_py_lib(
 sematic_py_lib(
     name = "git",
     srcs = ["git.py"],
-    deps = [],
+    deps = [
+        "//sematic/db/models:git_info",
+    ],
     pip_deps = [
         "git-python",
     ],

--- a/sematic/utils/git.py
+++ b/sematic/utils/git.py
@@ -5,27 +5,25 @@ Utility for extracting details about the git workspace.
 import inspect
 import logging
 import os
-from dataclasses import dataclass
 from typing import Any, Optional
 
-# Third-party
-import git  # type: ignore
+# Sematic
+from sematic.db.models.git_info import GitInfo
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class GitInfo:
-    remote: Optional[str]
-    branch: Optional[str]
-    commit: Optional[str]
-    dirty: Optional[bool]
-
-
-def get_git_info(object_: Any):
+def get_git_info(object_: Any) -> Optional["Repo"]:  # type: ignore # noqa: F821
     """
     Returns git repository details for a given Python object.
     """
+    try:
+        # if git is not installed on the user's system, this will fail to import
+        import git  # type: ignore
+    except ImportError as e:
+        logger.warn("Could not get git information", exc_info=e)
+        return None
+
     try:
         source = inspect.getsourcefile(object_)
         logger.debug(f"Found source file for {object_}: '{source}'")
@@ -57,7 +55,7 @@ def get_git_info(object_: Any):
     )
 
 
-def _get_remote(repo: git.Repo):
+def _get_remote(repo: "Repo") -> Optional[str]:  # type: ignore # noqa: F821
     try:
         return repo.remote().config_reader.get_value("url", None)
     except Exception as e:
@@ -65,7 +63,7 @@ def _get_remote(repo: git.Repo):
         return None
 
 
-def _get_commit(repo: git.Repo):
+def _get_commit(repo: "Repo") -> Optional[str]:  # type: ignore # noqa: F821
     try:
         return repo.commit().hexsha
     except Exception as e:
@@ -73,7 +71,7 @@ def _get_commit(repo: git.Repo):
         return None
 
 
-def _get_branch(repo: git.Repo):
+def _get_branch(repo: "Repo") -> Optional[str]:  # type: ignore # noqa: F821
     try:
         return repo.active_branch.name
     except Exception:

--- a/sematic/utils/tests/BUILD
+++ b/sematic/utils/tests/BUILD
@@ -1,4 +1,12 @@
 pytest_test(
+    name = "test_git",
+    srcs = ["test_git.py"],
+    deps = [
+        "//sematic/utils:git",
+    ],
+)
+
+pytest_test(
     name = "test_stdout",
     srcs = ["test_stdout.py"],
     deps = [

--- a/sematic/utils/tests/test_git.py
+++ b/sematic/utils/tests/test_git.py
@@ -1,0 +1,20 @@
+# Standard Library
+import sys
+
+
+def test_import():
+    """
+    Tests that importing `sematic.db.git` does not automatically import the git-python
+    `git` module directly.
+    """
+    assert "git" not in sys.modules.keys()
+    # Sematic
+    import sematic.utils.git  # noqa: F401
+
+    assert "git" not in sys.modules.keys()
+    # Sematic
+    from sematic.utils.git import get_git_info
+
+    assert "git" not in sys.modules.keys()
+    get_git_info(get_git_info)
+    assert "git" in sys.modules.keys()


### PR DESCRIPTION
When the `git` executable is not installed, importing the third party `git-python` package fails. Docker images build without `git` will fail when scheduled in Kubernetes.

This PR removes the dependency of code that would run on the backend server on the `git-python` package, and introduces a local safeguard for users that might submit execution from a workspace that does not have `git` installed.

### Testing

Re-validated basic functionality locally, and [validated it now works on Kubernetes](https://dev.sematic.cloud/pipelines/sematic.examples.mnist.pytorch.pipeline.pipeline/b20024e7779d454aa56f384a8073aaa6).