### PR TITLE
Make the MNIST examples runnable in the cloud

### DIFF
--- a/sematic/examples/mnist/pytorch/BUILD
+++ b/sematic/examples/mnist/pytorch/BUILD
@@ -13,7 +13,7 @@ sematic_example(
 )
 
 py_library(
-    name = "mnist_pytorch_lib",
+    name = "mnist_train_lib",
     srcs = glob([
         "*.py",
         "**/*.py",
@@ -30,10 +30,38 @@ py_library(
 )
 
 sematic_pipeline(
-    name = "mnist_pytorch",
+    name = "mnist_train",
     dev = True,
     registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
+    repository = "sematic-dev",
     deps = [
-        ":mnist_pytorch_lib",
+        ":mnist_train_lib",
+    ],
+)
+
+py_library(
+    name = "mnist_learning_rates_lib",
+    srcs = glob([
+        "*.py",
+        "**/*.py",
+    ]),
+    deps = [
+        "//sematic:init",
+        requirement("torch"),
+        requirement("torchvision"),
+        requirement("torchmetrics"),
+        requirement("plotly"),
+        requirement("pandas"),
+        requirement("scikit-learn"),
+    ],
+)
+
+sematic_pipeline(
+    name = "mnist_learning_rates",
+    dev = True,
+    registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
+    repository = "sematic-dev",
+    deps = [
+        ":mnist_learning_rates_lib",
     ],
 )

--- a/sematic/examples/mnist/pytorch/mnist_learning_rates.py
+++ b/sematic/examples/mnist/pytorch/mnist_learning_rates.py
@@ -1,5 +1,6 @@
 """
-This is an example implementation of the MNIST pipeline in PyTorch on sematic.
+This is an example implementation of the MNIST learning rates pipeline in PyTorch
+on Sematic, using the CloudResolver.
 """
 # Standard Library
 # MNIST example
@@ -12,7 +13,6 @@ from sematic.examples.mnist.pytorch.pipeline import (
     DataLoaderConfig,
     PipelineConfig,
     TrainConfig,
-    pipeline,
     scan_learning_rate,
 )
 
@@ -34,7 +34,7 @@ TRAIN_CONFIGS = [
 
 
 def main():
-    parser = argparse.ArgumentParser("MNIST PyTorch example")
+    parser = argparse.ArgumentParser("Scan MNIST learning rates")
     parser.add_argument("--detach", default=False, action="store_true")
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--learning-rates", type=str, default="1")
@@ -50,18 +50,9 @@ def main():
         for learning_rate in learning_rates
     ]
 
-    if len(train_configs) == 1:
-        pipeline(
-            config=PipelineConfig(
-                dataloader_config=DataLoaderConfig(), train_config=train_configs[0]
-            )
-        ).set(name="PyTorch MNIST Example").resolve(CloudResolver(detach=args.detach))
-    else:
-        scan_learning_rate(
-            dataloader_config=DataLoaderConfig(), train_configs=train_configs
-        ).set(name="Scan MNIST learning rates").resolve(
-            CloudResolver(detach=args.detach)
-        )
+    scan_learning_rate(
+        dataloader_config=DataLoaderConfig(), train_configs=train_configs
+    ).set(name="Scan MNIST learning rates").resolve(CloudResolver(detach=args.detach))
 
 
 if __name__ == "__main__":

--- a/sematic/examples/mnist/pytorch/mnist_train.py
+++ b/sematic/examples/mnist/pytorch/mnist_train.py
@@ -1,0 +1,54 @@
+"""
+This is an example implementation of the MNIST training pipeline in PyTorch on
+Sematic, using the CloudResolver.
+
+This is the same pipeline from the local example in __main__.py.
+"""
+# Standard Library
+# MNIST example
+import argparse
+import logging
+
+# Sematic
+from sematic import CloudResolver
+from sematic.examples.mnist.pytorch.pipeline import (
+    DataLoaderConfig,
+    PipelineConfig,
+    TrainConfig,
+    pipeline,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+TRAIN_CONFIGS = [
+    TrainConfig(epochs=1, learning_rate=0.2),
+    TrainConfig(epochs=5, learning_rate=0.4),
+    TrainConfig(epochs=5, learning_rate=0.6),
+    TrainConfig(epochs=5, learning_rate=0.8),
+]
+
+
+def main():
+    parser = argparse.ArgumentParser("PyTorch MNIST Example")
+    parser.add_argument("--detach", default=False, action="store_true")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--learning-rate", type=float, default="1")
+    parser.add_argument("--cuda", default=False, action="store_true")
+
+    args = parser.parse_args()
+
+    train_config = TrainConfig(
+        epochs=args.epochs, learning_rate=args.learning_rate, cuda=args.cuda
+    )
+
+    config = PipelineConfig(
+        dataloader_config=DataLoaderConfig(), train_config=train_config
+    )
+
+    pipeline(config=config).set(
+        name="PyTorch MNIST Example", tags=["pytorch", "example", "mnist"]
+    ).resolve(CloudResolver(detach=args.detach))
+
+
+if __name__ == "__main__":
+    main()

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -154,13 +154,13 @@ def pipeline(config: PipelineConfig) -> EvaluationResults:
         dataset=test_dataset, config=config.dataloader_config
     )
 
-    evaluation_resuts = train_eval(
+    evaluation_results = train_eval(
         train_dataloader=train_dataloader,
         test_dataloader=test_dataloader,
         train_config=config.train_config,
     )
 
-    return evaluation_resuts
+    return evaluation_results
 
 
 @sematic.func(inline=True)


### PR DESCRIPTION
The existing MNIST pipelines were once runnable in the cloud and have support in the BUILD file for this. This PR fixes issues in the BUILD file and also adds a cloud-runnable version of the example pipeline, in addition to the existing learning rates pipelines.