### PR TITLE
Fix GitInfo UI rendering when there is not git info

### DIFF
--- a/sematic/ui/src/components/GitInfo.tsx
+++ b/sematic/ui/src/components/GitInfo.tsx
@@ -80,7 +80,6 @@ function GitInfoBox(props: { resolution: Resolution | undefined }) {
           gridColumn: 3,
           paddingX: 10,
           paddingTop: 3,
-          borderLeft: 1,
           borderColor: theme.palette.grey[200],
         }}
       >


### PR DESCRIPTION
Fixes an extra floating border in the UI.

Before:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/1894533/195714758-b1c0b451-e84e-48a2-a8cb-b1ac4c456f0c.png">

After:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/1894533/195714842-a1576a2c-ff34-4140-b4bb-8f51bfa71a7a.png">
