### PR TITLE
Add Sematic version cli command

### DIFF
--- a/sematic/cli/BUILD
+++ b/sematic/cli/BUILD
@@ -9,6 +9,7 @@ sematic_py_lib(
         ":run",
         ":new",
         ":settings",
+        ":version",
         # Examples
         "//sematic/examples/template:template_lib",
         # These do not add dependencies on 3rd party packages
@@ -120,6 +121,18 @@ sematic_py_lib(
     deps = [
         ":cli",
         "//sematic:user_settings",
+    ],
+)
+
+sematic_py_lib(
+    name = "version",
+    srcs = ["version.py"],
+    pip_deps = [
+        "click",
+    ],
+    deps = [
+        ":cli",
+        "//sematic:versions",
     ],
 )
 

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -5,6 +5,7 @@ import sematic.cli.run  # noqa: F401
 import sematic.cli.settings  # noqa: F401
 import sematic.cli.start  # noqa: F401
 import sematic.cli.stop  # noqa: F401
+import sematic.cli.version  # noqa: F401
 from sematic.cli.cli import cli
 
 if __name__ == "__main__":

--- a/sematic/cli/version.py
+++ b/sematic/cli/version.py
@@ -1,0 +1,19 @@
+# Standard Library
+import platform
+
+# Third-party
+import click
+
+# Sematic
+from sematic.cli.cli import cli
+from sematic.versions import CURRENT_VERSION_STR, MIN_CLIENT_SERVER_SUPPORTS_STR
+
+
+@cli.command("version", short_help="Print version information.")
+def version():
+    """
+    Print the Server, Client, and Python versions.
+    """
+    click.echo(f"Sematic server v{CURRENT_VERSION_STR} is installed.")
+    click.echo(f"Client versions >= v{MIN_CLIENT_SERVER_SUPPORTS_STR} are supported.")
+    click.echo(f"Python v{platform.python_version()} is running this binary.")

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -29,6 +29,8 @@ def version_as_string(version: typing.Tuple[int, int, int]) -> str:
 
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
+MIN_CLIENT_SERVER_SUPPORTS_STR = version_as_string(MIN_CLIENT_SERVER_SUPPORTS)
+
 
 if __name__ == "__main__":
     # It can be handy for deployment scripts and similar things to be able to get quick


### PR DESCRIPTION
Adds a cli command to print the Server version, Client minimum version, and Python version.
In addition to being a common-sense option for the cli, this is very useful to validate one's environment while testing the release in virtual envs.

```bash
(3.9.14/envs/3.9.14-testing) ~/work/sematic$ sematic version
Sematic server v0.0.1 is installed.
Client versions >= v0.11.0 are supported.
Python v3.9.14 is running this binary.
(3.9.14/envs/3.9.14-testing) ~/work/sematic$ pyenv activate 3.8.14/envs/3.8.14-testing
(3.8.14/envs/3.8.14-testing) ~/work/sematic$ sematic version
Sematic server v0.0.1 is installed.
Client versions >= v0.11.0 are supported.
Python v3.8.14 is running this binary.
```