### PR TITLE
Capability to limit the parallelism degree of CloudResolver

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -260,8 +260,15 @@ class CloudResolver(LocalResolver):
         """Callback called at the end of an inline execution."""
         logger.info(END_INLINE_RUN_INDICATOR.format(future_id))
 
-    def _can_schedule_future(self, _: AbstractFuture) -> bool:
-        """Returns whether we can schedule an external run."""
+    def _can_schedule_future(self, future: AbstractFuture) -> bool:
+        """Returns whether the specified future can be scheduled.
+
+        Inline futures can always be scheduled. External futures can only be scheduled
+        if the maximum parallelism degree has not been exceeded.
+        """
+        if future.props.inline:
+            return True
+
         if not self._max_parallelism:
             return True
 

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -27,13 +27,13 @@ class SilentResolver(StateMachineResolver):
         finally:
             self._end_inline_execution(future.id)
 
-    def _start_inline_execution(self, future_id):
-        """Callback called before an inline execution"""
+    def _start_inline_execution(self, future_id) -> None:
+        """Callback called before an inline execution."""
         pass
 
-    def _end_inline_execution(self, future_id):
-        """Callback called at the end of an inline execution"""
+    def _end_inline_execution(self, future_id) -> None:
+        """Callback called at the end of an inline execution."""
         pass
 
-    def _wait_for_scheduled_run(self) -> None:
+    def _wait_for_scheduled_runs(self) -> None:
         pass

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -58,7 +58,7 @@ class StateMachineResolver(Resolver, abc.ABC):
                         self._resolve_nested_future(future_)
                         continue
 
-                    # unreachable code
+                    # should be unreachable code, here for a sanity check
                     if (
                         future_.state != FutureState.SCHEDULED
                         and not future_.state.is_terminal()
@@ -68,7 +68,7 @@ class StateMachineResolver(Resolver, abc.ABC):
                             " when it should have been already processed"
                         )
 
-                self._wait_for_scheduled_run()
+                self._wait_for_scheduled_runs()
 
             if future.state == FutureState.RESOLVED:
                 self._resolution_did_succeed()
@@ -117,7 +117,7 @@ class StateMachineResolver(Resolver, abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _wait_for_scheduled_run(self) -> None:
+    def _wait_for_scheduled_runs(self) -> None:
         pass
 
     def _handle_sig_cancel(self, signum, frame):
@@ -250,14 +250,14 @@ class StateMachineResolver(Resolver, abc.ABC):
     def _execute_future(self, future: AbstractFuture) -> None:
         if future.props.inline:
             self._future_will_schedule(future)
-            logger.info("Running inline {}".format(future.calculator))
+            logger.info("Running inline %s", future.calculator)
             self._run_inline(future)
         elif self._can_schedule_future(future):
             self._future_will_schedule(future)
-            logger.info("Scheduling {}".format(future.calculator))
+            logger.info("Scheduling %s", future.calculator)
             self._schedule_future(future)
         else:
-            logger.info("Could not schedule {}".format(future.calculator))
+            logger.info("Currently not scheduling %s", future.calculator)
 
     @typing.final
     def _resolve_nested_future(self, future: AbstractFuture) -> None:

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -105,7 +105,7 @@ class StateMachineResolver(Resolver, abc.ABC):
                 self._enqueue_future(value)
 
     def _can_schedule_future(self, _: AbstractFuture) -> bool:
-        """Return whether the specified future can be scheduled."""
+        """Returns whether the specified future can be scheduled."""
         return True
 
     @abc.abstractmethod
@@ -248,16 +248,18 @@ class StateMachineResolver(Resolver, abc.ABC):
             self._execute_future(future)
 
     def _execute_future(self, future: AbstractFuture) -> None:
+        if not self._can_schedule_future(future):
+            logger.info("Currently not scheduling %s", future.calculator)
+            return
+
+        self._future_will_schedule(future)
+
         if future.props.inline:
-            self._future_will_schedule(future)
             logger.info("Running inline %s", future.calculator)
             self._run_inline(future)
-        elif self._can_schedule_future(future):
-            self._future_will_schedule(future)
+        else:
             logger.info("Scheduling %s", future.calculator)
             self._schedule_future(future)
-        else:
-            logger.info("Currently not scheduling %s", future.calculator)
 
     @typing.final
     def _resolve_nested_future(self, future: AbstractFuture) -> None:

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -30,7 +30,7 @@ def pipeline() -> float:
 
 
 @mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.cloud_resolver.get_image_uri", new=lambda: "some_image")
+@mock.patch("sematic.resolvers.cloud_resolver.get_image_uri", return_value="some_image")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
 @mock_no_auth

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -30,7 +30,7 @@ def pipeline() -> float:
 
 
 @mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.cloud_resolver.get_image_uri", return_value="some_image")
+@mock.patch("sematic.resolvers.cloud_resolver.get_image_uri", new=lambda: "some_image")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
 @mock_no_auth


### PR DESCRIPTION
Introduces a new parameter in the `CloudResolver` init function which controls how many runs can be scheduled in parallel at any given point.

This is a continuation of the work started in #184.

This is done by maintaining an active runs counter and incrementing and decrementing it whenever a run is scheduled or processed as complete when communicating with the backend server. This was chosen over doing these operations in `_future_*` callbacks in order to keep the server as the source of truth and to avoid any possible inconsistent states due to unexpected state transitions.

Scheduling a run is now done only if the active runs would not exceed the configured value.

### Testing

#### Unit Tests

I tried spying the value of the counter in unit tests, but this proved to be challenging due to:
- spying the counter property made it un-additive due to Mock limitations
- even the existing `CloudResolver` unit test only uses a completely inlined pipeline, and mocking all server-side APIs in order to get it to correctly interact with the Resolver proved to be too large of a task to be done as part of this one

So I ended up only adding a value validation test.

#### Manual Tests

On a custom enhancement of the `add` example pipeline I monitored that the number of running pods did not exceed the configured value by using:

```bash
$ watch -n 1 "kubectl get pods | grep sematic-worker | grep Running"
```

And I also monitored the visual representation of the graph - an example for a limit of 2 runs, where you can see 2 functions have completed execution, on is executing, and the rest are pending:

![image](https://user-images.githubusercontent.com/1894533/196304328-629b45df-653f-40a1-8584-f66205365c25.png)


