### PR TITLE
Inline existing pipeline functions

### DIFF
--- a/sematic/examples/bazel/pipeline.py
+++ b/sematic/examples/bazel/pipeline.py
@@ -26,7 +26,7 @@ def fail_nested() -> float:
     raise ValueError("Some exception")
 
 
-@sematic.func(inline=False)
+@sematic.func(inline=True)
 def pipeline(a: float, b: float, c: float) -> float:
     # return add(add3(a, b, c), add(a, b))
     # return add(a, b)

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -132,7 +132,7 @@ def train_eval(
     return evaluation_results
 
 
-@sematic.func(inline=False)
+@sematic.func(inline=True)
 def pipeline(config: PipelineConfig) -> EvaluationResults:
     """
     # MNIST example in PyTorch


### PR DESCRIPTION
This marks existing top-level pipeline functions as inlined, because we recommend only leaf functions to be non-inlined, and any non-expensive functions which only return other Futures to be inlined.