### PR TITLE
Fix GitInfo for custom Bazel workspaces

### DIFF
--- a/sematic/utils/git.py
+++ b/sematic/utils/git.py
@@ -29,7 +29,12 @@ def get_git_info(object_: Any) -> Optional["Repo"]:  # type: ignore # noqa: F821
         logger.debug(f"Found source file for {object_}: '{source}'")
     except Exception as e:
         logger.debug(f"Could not find source file for object '{object_}'", exc_info=e)
-        return None
+        try:
+            source = os.environ["BUILD_WORKSPACE_DIRECTORY"]
+            logger.debug(f"Trying $BUILD_WORKSPACE_DIRECTORY: {source}")
+        except Exception as e:
+            logger.debug("Could not find $BUILD_WORKSPACE_DIRECTORY", exc_info=e)
+            return None
 
     try:
         repo = git.Repo(source, search_parent_directories=True)


### PR DESCRIPTION
If there are custom changes to the Bazel workspace that make the git repository unreachable on the ancestor path of the executed pipeline file path, the git information will not be retrievable.

This PR adds an attempt to source the Bazel workspace from the `BUILD_WORKSPACE_DIRECTORY` env variable if this is the case.

### Testing

Manually introduced a test exception:

```
[...]
DEBUG:sematic.utils.git:Could not find source file for object '<function pipeline at 0x106d06ca0>'
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add.runfiles/sematic/sematic/utils/git.py", line 28, in get_git_info
    raise Exception("test")
Exception: test
DEBUG:sematic.utils.git:Trying $BUILD_WORKSPACE_DIRECTORY: /Users/tudorscurtu/work/sematic
[...]
```

![image](https://user-images.githubusercontent.com/1894533/196503113-ef1a1f92-5f25-4caa-82e5-7696d16700f4.png)
