### PR TITLE
At least one list element

### DIFF
--- a/sematic/types/types/list.py
+++ b/sematic/types/types/list.py
@@ -1,6 +1,5 @@
 # Standard Library
 import json
-import math
 import typing
 
 # Sematic
@@ -17,6 +16,8 @@ from sematic.types.serialization import (
     value_from_json_encodable,
     value_to_json_encodable,
 )
+
+MAX_SUMMARY_BYTES = 2**20  # 1 MB
 
 
 # Using `list` instead of `typing.List` here because
@@ -110,21 +111,20 @@ def list_to_json_encodable_summary(
         get_json_encodable_summary(item, element_type) for item in value
     ]
 
-    element_char_len = None
+    max_item = 0
     if len(complete_summary) > 0:
-        element_char_len = len(json.dumps(complete_summary[0]))
-
-    estimated_total_char_len = (
-        (0 if element_char_len is None else len(value) * element_char_len)
-        + 2
-        + 2 * len(value)
-    )
-
-    max_item = math.floor((1000 / estimated_total_char_len))
-
-    # ensure that at least one element is shown, if there is
-    # at least one element present.
-    max_item = max(max_item, min(1, len(value)))
+        # this logic doesn't account for the "length" and "summary"
+        # keys or outer wrapping brackets, but those represent roughly
+        # 1 ten-thousandth of the payload in the max case, and thus can
+        # be ignored
+        max_element_byte_len = max(
+            len(json.dumps(element).encode("utf8")) for element in complete_summary
+        )
+        max_element_byte_len += 2  # for the comma and space between elements
+        max_elements = int(MAX_SUMMARY_BYTES / max_element_byte_len)
+        max_item = max(
+            max_elements, 1
+        )  # ensure there's always at least 1 element for non-empty lists
 
     return {
         "length": len(value),

--- a/sematic/types/types/list.py
+++ b/sematic/types/types/list.py
@@ -122,6 +122,10 @@ def list_to_json_encodable_summary(
 
     max_item = math.floor((1000 / estimated_total_char_len))
 
+    # ensure that at least one element is shown, if there is
+    # at least one element present.
+    max_item = max(max_item, min(1, len(value)))
+
     return {
         "length": len(value),
         "summary": complete_summary[:max_item],

--- a/sematic/types/types/list.py
+++ b/sematic/types/types/list.py
@@ -17,7 +17,7 @@ from sematic.types.serialization import (
     value_to_json_encodable,
 )
 
-MAX_SUMMARY_BYTES = 2**20  # 1 MB
+MAX_SUMMARY_BYTES = 2**17  # 128 kB
 
 
 # Using `list` instead of `typing.List` here because
@@ -115,7 +115,7 @@ def list_to_json_encodable_summary(
     if len(complete_summary) > 0:
         # this logic doesn't account for the "length" and "summary"
         # keys or outer wrapping brackets, but those represent roughly
-        # 1 ten-thousandth of the payload in the max case, and thus can
+        # 1 thousandth of the payload in the max case, and thus can
         # be ignored
         max_element_byte_len = max(
             len(json.dumps(element).encode("utf8")) for element in complete_summary

--- a/sematic/types/types/tests/test_list.py
+++ b/sematic/types/types/tests/test_list.py
@@ -45,12 +45,12 @@ def test_summaries():
         "length": 7,
     }
 
-    long_value = 10000 * "h"
-    long_list = [long_value for _ in range(100)]
+    long_value = 2**21 * "h"
+    long_list = [long_value for _ in range(5)]
     summary = get_json_encodable_summary(long_list, List[str])
     assert summary == {
         "summary": [long_value],
-        "length": 100,
+        "length": 5,
     }
 
 

--- a/sematic/types/types/tests/test_list.py
+++ b/sematic/types/types/tests/test_list.py
@@ -7,6 +7,7 @@ import pytest
 # Sematic
 from sematic.types.casting import can_cast_type, safe_cast
 from sematic.types.serialization import (
+    get_json_encodable_summary,
     type_from_json_encodable,
     type_to_json_encodable,
     value_to_json_encodable,
@@ -35,6 +36,22 @@ def test_safe_cast(type_, value, expected_cast_value, expected_error):
 
     assert cast_value == expected_cast_value
     assert error == expected_error
+
+
+def test_summaries():
+    summary = get_json_encodable_summary([1, 2, 3, 4, 5, 6, 7], List[int])
+    assert summary == {
+        "summary": [1, 2, 3, 4, 5, 6, 7],
+        "length": 7,
+    }
+
+    long_value = 10000 * "h"
+    long_list = [long_value for _ in range(100)]
+    summary = get_json_encodable_summary(long_list, List[str])
+    assert summary == {
+        "summary": [long_value],
+        "length": 100,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently we don't guarantee that any list elements will be shown if the elements are "large," with "large" meaning a threshold less than 1kB. This guarantees that no matter how large the elements are, we display at least one (assuming there is at least one element in the first place). It also increases the threshold for max elements displayed to be based on returning roughly 128kB of data for the list.

In addition to unit tests, I also ran this with a list of lots of dataclasses (10k of them) and confirmed the result didn't look too overwhelming.