### PR TITLE
Fix migrations to not depend on SQLAlchemy models

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Lines for version numbers should always be formatted as `* MAJOR.MINOR.PATCH`
 with nothing else on the line.
 -->
 * HEAD
+    * [bugfix] Remove SQLAlchemy model dependencies from Python migrations
 * 0.18.0
     * [feature] Add ability to limit the number of parallel runs within a pipeline
     * [feature] Support for multiple bazel base container images

--- a/sematic/db/BUILD
+++ b/sematic/db/BUILD
@@ -45,17 +45,15 @@ sematic_py_lib(
     ),
     pip_deps = [
         "click",
+        "sqlalchemy",
     ],
     deps = [
+        # DO NOT add any other dependencies
+        # or it may break the sequence of migrations
+        # Migrations are written at a specific point in time, whereas the
+        # codebase evolves.
         ":db",
         "//sematic:config",
-        "//sematic:container_images",
-        "//sematic/db/models:artifact",
-        "//sematic/db/models:edge",
-        "//sematic/db/models:note",
-        "//sematic/db/models:resolution",
-        "//sematic/db/models:run",
-        "//sematic/db/models:user",
     ],
 )
 

--- a/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
+++ b/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
@@ -1,4 +1,3 @@
-# Third-party
 # Standard Library
 import json
 

--- a/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
+++ b/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
@@ -12,7 +12,7 @@ def up():
             "SELECT root_id, container_image_uri "
             "FROM resolutions "
             "WHERE container_image_uris IS NULL "
-            "AND container_image_uri IS NULL"
+            "AND container_image_uri IS NOT NULL"
         )
 
         for (


### PR DESCRIPTION
Python migrations are part of a sequence of migration. Each migration is written at a particular moment in time and should work with the state of the database at that time. Depending on SQLAlchemy models in those migrations makes them rely on the latest code changes (e.g. DB columns) that were not yet available at the time of writing of the migration.

To solve this, Python migrations should not depend on any of the SQLAlchemy models.