### PR TITLE
Rerun-from-here base mechanism for local execution

### DIFF
--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -169,6 +169,19 @@ sematic_py_lib(
     deps = [],
 )
 
+sematic_py_lib(
+    name = "graph",
+    srcs = ["graph.py"],
+    deps = [
+        ":abstract_future",
+        "//sematic/db/models:artifact",
+        "//sematic/db/models:edge",
+        "//sematic/db/models:factories",
+        "//sematic/db/models:run",
+        "//sematic/utils:memoized_property",
+    ],
+)
+
 sematic_py_wheel(
     name = "wheel",
     author = "Sematic AI, Inc.",

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -58,6 +58,7 @@ sematic_py_lib(
     ],
     deps = [
         ":config",
+        "//sematic:storage",
         "//sematic:versions",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -181,6 +181,7 @@ sematic_py_lib(
         "//sematic/db/models:factories",
         "//sematic/db/models:run",
         "//sematic/utils:memoized_property",
+        "//sematic/utils:sorting",
     ],
 )
 

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -159,6 +159,7 @@ sematic_py_lib(
     ],
     deps = [
         ":user_settings",
+        "//sematic/utils:memoized_property",
         "//sematic/utils:retry",
     ],
 )

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -24,7 +24,6 @@ from sematic.container_images import has_container_image  # noqa: F401,E402
 from sematic.resolver import Resolver  # noqa: F401,E402
 from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
 from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401,E402
-from sematic.resolvers.silent_resolver import SilentResolver  # noqa: F401,E402
 from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
     KubernetesResourceRequirements,
     KubernetesSecretMount,
@@ -33,5 +32,6 @@ from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
     KubernetesTolerationOperator,
     ResourceRequirements,
 )
+from sematic.resolvers.silent_resolver import SilentResolver  # noqa: F401,E402
 from sematic.retry_settings import RetrySettings  # noqa: F401, E402
 from sematic.versions import CURRENT_VERSION_STR as __version__  # noqa: F401,E402

--- a/sematic/abstract_calculator.py
+++ b/sematic/abstract_calculator.py
@@ -45,3 +45,7 @@ class AbstractCalculator(abc.ABC):
     @abc.abstractmethod
     def get_source(self) -> str:
         pass
+
+    @abc.abstractmethod
+    def __call__(self, **kwargs) -> typing.Any:
+        pass

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -147,3 +147,12 @@ class AbstractFuture(abc.ABC):
         TODO: Migrate all future properties to FutureProperties
         """
         return self._props
+
+    def __repr__(self):
+        parent_id = self.parent_future.id if self.parent_future is not None else None
+        nested_id = self.nested_future.id if self.nested_future is not None else None
+        return (
+            f"Future(id={self.id}, func={self.calculator.__name__}, "
+            f"state={self.state.value}, parent_id={parent_id}, "
+            f"nested_id={nested_id}, value={self.value})"
+        )

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -152,7 +152,7 @@ class AbstractFuture(abc.ABC):
         parent_id = self.parent_future.id if self.parent_future is not None else None
         nested_id = self.nested_future.id if self.nested_future is not None else None
         return (
-            f"Future(id={self.id}, func={self.calculator.__name__}, "
+            f"Future(id={self.id}, func={self.calculator}, "
             f"state={self.state.value}, parent_id={parent_id}, "
             f"nested_id={nested_id}, value={self.value})"
         )

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -134,7 +134,7 @@ def schedule_resolution_endpoint(
             rerun_from = flask.request.json["rerun_from"]
 
     resolution = schedule_resolution(
-        resolution, max_parallelism=max_parallelism, rerun_from=rerun_from
+        resolution=resolution, max_parallelism=max_parallelism, rerun_from=rerun_from
     )
 
     save_resolution(resolution)

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -124,12 +124,17 @@ def schedule_resolution_endpoint(
 ) -> flask.Response:
     resolution = get_resolution(resolution_id)
 
-    max_parallelism = None
-    if flask.request.json and "max_parallelism" in flask.request.json:
-        max_parallelism = flask.request.json["max_parallelism"]
+    max_parallelism, rerun_from = None, None
+
+    if flask.request.json:
+        if "max_parallelism" in flask.request.json:
+            max_parallelism = flask.request.json["max_parallelism"]
+
+        if "rerun_from" in flask.request.json:
+            rerun_from = flask.request.json["rerun_from"]
 
     resolution = schedule_resolution(
-        resolution=resolution, max_parallelism=max_parallelism
+        resolution, max_parallelism=max_parallelism, rerun_from=rerun_from
     )
 
     save_resolution(resolution)

--- a/sematic/api/endpoints/tests/BUILD
+++ b/sematic/api/endpoints/tests/BUILD
@@ -27,6 +27,7 @@ pytest_test(
         "//sematic/api/tests:fixtures",
         "//sematic/db:queries",
         "//sematic/db/tests:fixtures",
+        "//sematic/resolvers/tests:fixtures",
         "//sematic/tests:fixtures",
         "//sematic/utils:exceptions",
     ],

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -14,7 +14,6 @@ from google.auth.exceptions import GoogleAuthError
 from sematic.api.app import sematic_api
 from sematic.api.endpoints.auth import authenticate
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
     mock_requests,
     mock_user_settings,
     test_client,

--- a/sematic/api/endpoints/tests/test_meta.py
+++ b/sematic/api/endpoints/tests/test_meta.py
@@ -9,7 +9,6 @@ import flask.testing
 import sematic.api.endpoints.meta  # noqa: F401
 from sematic.api.app import sematic_api  # noqa: F401
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
     mock_requests,
     mock_user_settings,
     test_client,

--- a/sematic/api/endpoints/tests/test_notes.py
+++ b/sematic/api/endpoints/tests/test_notes.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 # Sematic
 from sematic.api.tests.fixtures import (  # noqa: F401
     make_auth_test,
-    mock_no_auth,
+    mock_auth,
     test_client,
 )
 from sematic.db.models.note import Note
@@ -27,16 +27,16 @@ test_list_note_auth = make_auth_test("/api/v1/notes")
 test_create_note_auth = make_auth_test("/api/v1/notes", method="POST")
 
 
-@mock_no_auth
-def test_list_notes_empty(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_list_notes_empty(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
     response = test_client.get("/api/v1/notes")
 
     assert response.json == dict(content=[], authors=[])
 
 
-@mock_no_auth
 def test_create_note(
-    test_client: flask.testing.FlaskClient, persisted_run: Run  # noqa: F811
+    mock_auth, test_client: flask.testing.FlaskClient, persisted_run: Run  # noqa: F811
 ):
     note_payload = {
         "author_id": "test@test.test",
@@ -75,9 +75,10 @@ def persisted_note(note: Note) -> Note:
     return note
 
 
-@mock_no_auth
 def test_list_notes(
-    test_client: flask.testing.FlaskClient, persisted_note: Note  # noqa: F811
+    mock_auth,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    persisted_note: Note,  # noqa: F811
 ):
     filters = {"root_id": {"eq": persisted_note.root_id}}
     response = test_client.get("/api/v1/notes?filters=" + json.dumps(filters))
@@ -90,9 +91,10 @@ def test_list_notes(
     assert response.json["authors"][0]["email"] == persisted_note.author_id
 
 
-@mock_no_auth
 def test_delete_note(
-    test_client: flask.testing.FlaskClient, persisted_note: Note  # noqa: F811
+    mock_auth,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    persisted_note: Note,  # noqa: F811
 ):
 
     response = test_client.delete("/api/v1/notes/{}".format(persisted_note.id))

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -10,7 +10,7 @@ import pytest
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
     make_auth_test,
-    mock_no_auth,
+    mock_auth,
     mock_requests,
     test_client,
 )
@@ -44,8 +44,8 @@ def mock_schedule_resolution():
         yield mock_schedule
 
 
-@mock_no_auth
 def test_get_resolution_endpoint(
+    mock_auth,  # noqa: F811
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
 ):
@@ -62,8 +62,8 @@ def test_get_resolution_endpoint(
     assert payload["content"]["settings_env_vars"] == {}
 
 
-@mock_no_auth
 def test_put_resolution_endpoint(
+    mock_auth,  # noqa: F811
     persisted_run,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
 ):
@@ -86,8 +86,9 @@ def test_put_resolution_endpoint(
     assert read.status == ResolutionStatus.FAILED.value
 
 
-@mock_no_auth
-def test_get_resolution_404(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_get_resolution_404(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
     response = test_client.get("/api/v1/resolutions/unknownid")
 
     assert response.status_code == 404
@@ -98,8 +99,8 @@ def test_get_resolution_404(test_client: flask.testing.FlaskClient):  # noqa: F8
     assert payload == dict(error="No resolutions with id 'unknownid'")
 
 
-@mock_no_auth
 def test_schedule_resolution_endpoint(
+    mock_auth,  # noqa: F811
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
     mock_schedule_resolution: mock.MagicMock,
@@ -135,12 +136,12 @@ def test_schedule_resolution_endpoint(
 
 
 @mock.patch("sematic.api.endpoints.resolutions.cancel_job")
-@mock_no_auth
 def test_cancel_resolution(
     mock_cancel_job: mock.MagicMock,
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
     test_db,  # noqa: F811
+    mock_auth,  # noqa: F811
 ):
     persisted_resolution.external_jobs = (
         KubernetesExternalJob.new(

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -105,7 +105,7 @@ def test_schedule_resolution_endpoint(
     test_client: flask.testing.FlaskClient,  # noqa: F811
     mock_schedule_resolution: mock.MagicMock,
 ):
-    def mock_schedule(resolution, max_parallelism=None):  # noqa: F811
+    def mock_schedule(resolution, max_parallelism=None, rerun_from=None):  # noqa: F811
         resolution.status = ResolutionStatus.SCHEDULED
         resolution.external_jobs = (
             KubernetesExternalJob.new(
@@ -120,7 +120,7 @@ def test_schedule_resolution_endpoint(
     mock_schedule_resolution.side_effect = mock_schedule
     response = test_client.post(
         "/api/v1/resolutions/{}/schedule".format(persisted_resolution.root_id),
-        json={"max_parallelism": 3},
+        json={"max_parallelism": 3, "rerun_from": "rerun_from_run_id"},
     )
 
     payload = response.json
@@ -133,6 +133,9 @@ def test_schedule_resolution_endpoint(
     assert isinstance(scheduled_resolution, Resolution)
     assert scheduled_resolution.root_id == persisted_resolution.root_id
     assert mock_schedule_resolution.call_args.kwargs["max_parallelism"] == 3
+    assert (
+        mock_schedule_resolution.call_args.kwargs["rerun_from"] == "rerun_from_run_id"
+    )
 
 
 @mock.patch("sematic.api.endpoints.resolutions.cancel_job")

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -13,8 +13,9 @@ import pytest
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
     make_auth_test,
-    mock_no_auth,
+    mock_auth,
     mock_requests,
+    mock_socketio,
     test_client,
 )
 from sematic.calculator import func
@@ -30,6 +31,7 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     test_db,
 )
 from sematic.log_reader import LogLineResult
+from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
 from sematic.scheduling.external_job import JobType
 from sematic.scheduling.kubernetes import KubernetesExternalJob
 from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
@@ -51,8 +53,9 @@ def mock_load_log_lines():
         yield mock_load
 
 
-@mock_no_auth
-def test_list_runs_empty(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_list_runs_empty(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
     results = test_client.get("/api/v1/runs?limit=3")
 
     assert results.json == dict(
@@ -65,8 +68,7 @@ def test_list_runs_empty(test_client: flask.testing.FlaskClient):  # noqa: F811
     )
 
 
-@mock_no_auth
-def test_list_runs(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_list_runs(mock_auth, test_client: flask.testing.FlaskClient):  # noqa: F811
     created_runs = [save_run(make_run()) for _ in range(5)]
 
     # Sort by latest
@@ -95,8 +97,7 @@ def test_list_runs(test_client: flask.testing.FlaskClient):  # noqa: F811
     assert payload["content"] == [run_.to_json_encodable() for run_ in created_runs[3:]]
 
 
-@mock_no_auth
-def test_group_by(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_group_by(mock_auth, test_client: flask.testing.FlaskClient):  # noqa: F811
     runs = {key: [make_run(name=key), make_run(name=key)] for key in ("RUN_A", "RUN_B")}
 
     for name, runs_ in runs.items():
@@ -112,8 +113,7 @@ def test_group_by(test_client: flask.testing.FlaskClient):  # noqa: F811
     assert {run_["name"] for run_ in payload["content"]} == set(runs)
 
 
-@mock_no_auth
-def test_filters(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_filters(mock_auth, test_client: flask.testing.FlaskClient):  # noqa: F811
     runs = make_run(), make_run()
     runs[0].parent_id = uuid.uuid4().hex
 
@@ -132,8 +132,7 @@ def test_filters(test_client: flask.testing.FlaskClient):  # noqa: F811
         assert payload["content"][0]["id"] == run_.id
 
 
-@mock_no_auth
-def test_and_filters(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_and_filters(mock_auth, test_client: flask.testing.FlaskClient):  # noqa: F811
     run1 = make_run(name="abc", calculator_path="abc")
     run2 = make_run(name="def", calculator_path="abc")
     run3 = make_run(name="abc", calculator_path="def")
@@ -152,9 +151,8 @@ def test_and_filters(test_client: flask.testing.FlaskClient):  # noqa: F811
     assert payload["content"][0]["id"] == run1.id
 
 
-@mock_no_auth
 def test_get_run_endpoint(
-    persisted_run: Run, test_client: flask.testing.FlaskClient  # noqa: F811
+    mock_auth, persisted_run: Run, test_client: flask.testing.FlaskClient  # noqa: F811
 ):
     response = test_client.get("/api/v1/runs/{}".format(persisted_run.id))
 
@@ -164,8 +162,7 @@ def test_get_run_endpoint(
     assert payload["content"]["id"] == persisted_run.id
 
 
-@mock_no_auth
-def test_get_run_404(test_client: flask.testing.FlaskClient):  # noqa: F811
+def test_get_run_404(mock_auth, test_client: flask.testing.FlaskClient):  # noqa: F811
     response = test_client.get("/api/v1/runs/unknownid")
 
     assert response.status_code == 404
@@ -176,8 +173,8 @@ def test_get_run_404(test_client: flask.testing.FlaskClient):  # noqa: F811
     assert payload == dict(error="No runs with id 'unknownid'")
 
 
-@mock_no_auth
 def test_schedule_run(
+    mock_auth,  # noqa: F811
     persisted_run: Run,  # noqa: F811
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
@@ -216,9 +213,8 @@ def test_schedule_run(
         assert len(run.external_jobs) == 1
 
 
-@mock_no_auth
 def test_update_future_states(
-    persisted_run: Run, test_client: flask.testing.FlaskClient  # noqa: F811
+    mock_auth, persisted_run: Run, test_client: flask.testing.FlaskClient  # noqa: F811
 ):
     with mock.patch("sematic.scheduling.job_scheduler.k8s") as mock_k8s:
         persisted_run.future_state = FutureState.CREATED
@@ -282,8 +278,8 @@ def test_update_future_states(
         )
 
 
-@mock_no_auth
 def test_get_run_logs(
+    mock_auth,  # noqa: F811
     mock_load_log_lines,
     persisted_resolution: Resolution,  # noqa: F811
     persisted_run: Run,  # noqa: F811
@@ -339,15 +335,10 @@ def pipeline(a: float, b: float) -> float:
 @pytest.mark.parametrize(
     "root, run_count, artifact_count, edge_count", ((0, 1, 3, 3), (1, 3, 4, 8))
 )
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch(
-    "sematic.resolvers.local_resolver.LocalStorage",
-    return_value=MockStorage(),
-)
 def test_get_run_graph_endpoint(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     root: int,
     run_count: int,
     artifact_count: int,

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -32,7 +32,7 @@ from sematic.db.tests.fixtures import (  # noqa: F401
 from sematic.log_reader import LogLineResult
 from sematic.scheduling.external_job import JobType
 from sematic.scheduling.kubernetes import KubernetesExternalJob
-from sematic.tests.fixtures import valid_client_version  # noqa: F401
+from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
 from sematic.utils.exceptions import ExceptionMetadata
 
 test_list_runs_auth = make_auth_test("/api/v1/runs")
@@ -341,7 +341,12 @@ def pipeline(a: float, b: float) -> float:
 )
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch(
+    "sematic.resolvers.local_resolver.LocalStorage",
+    return_value=MockStorage(),
+)
 def test_get_run_graph_endpoint(
+    mock_storage,
     mock_socketio,
     root: int,
     run_count: int,

--- a/sematic/api/tests/fixtures.py
+++ b/sematic/api/tests/fixtures.py
@@ -4,6 +4,7 @@ import functools
 import re
 from http import HTTPStatus
 from typing import Any, Callable, Dict
+from unittest import mock
 from urllib.parse import urljoin
 
 import flask.testing
@@ -109,3 +110,15 @@ def make_auth_test(endpoint: str, method: str = "GET"):
             assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     return test_auth
+
+
+@pytest.fixture
+def mock_socketio():
+    with mock.patch("socketio.Client.connect"):
+        yield
+
+
+@pytest.fixture
+def mock_auth():
+    with mock_user_settings({user_settings.SettingsVar.SEMATIC_AUTHENTICATE: False}):
+        yield

--- a/sematic/api/tests/fixtures.py
+++ b/sematic/api/tests/fixtures.py
@@ -1,9 +1,8 @@
 # Standard Library
 import contextlib
-import functools
 import re
 from http import HTTPStatus
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 from unittest import mock
 from urllib.parse import urljoin
 
@@ -90,17 +89,6 @@ def mock_user_settings(settings: Dict[user_settings.SettingsVar, Any]):
         yield settings
     finally:
         user_settings._settings = original_settings
-
-
-def mock_no_auth(fn: Callable) -> Callable:
-    @functools.wraps(fn)
-    def no_auth_fn(*args, **kwargs):
-        with mock_user_settings(
-            {user_settings.SettingsVar.SEMATIC_AUTHENTICATE: False}
-        ):
-            fn(*args, **kwargs)
-
-    return no_auth_fn
 
 
 def make_auth_test(endpoint: str, method: str = "GET"):

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -14,6 +14,7 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.resolution import Resolution
 from sematic.db.models.run import Run
+from sematic.storage import S3Storage, Storage
 from sematic.user_settings import MissingSettingsError, SettingsVar, get_user_settings
 from sematic.utils.retry import retry
 from sematic.versions import CURRENT_VERSION, version_as_string
@@ -50,21 +51,30 @@ class ResourceNotFoundError(BadRequestError):
     pass
 
 
-def get_artifact_value_by_id(artifact_id: str) -> Any:
+def get_artifact_value_by_id(
+    artifact_id: str, storage: Optional[Storage] = None
+) -> Any:
     """
     Retrieve the value of an artifact by ID.
 
     Parameters
     ----------
     artifact_id: str
+    storage: Optional[Storage]
+        Storage from which to retrieve the artifact value. Defaults to S3Storage.
 
     Returns
     -------
     Any
         The value of the requiested artifact.
     """
+    # TODO: Store storage type on artifact
+    if storage is None:
+        storage = S3Storage()
+
     artifact = _get_artifact(artifact_id)
-    return get_artifact_value(artifact)
+
+    return get_artifact_value(artifact, storage)
 
 
 def _get_artifact(artifact_id: str) -> Artifact:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -46,6 +46,10 @@ class BadRequestError(Exception):
     pass
 
 
+class ResourceNotFoundError(BadRequestError):
+    pass
+
+
 def get_artifact_value_by_id(artifact_id: str) -> Any:
     """
     Retrieve the value of an artifact by ID.
@@ -99,14 +103,15 @@ def save_graph(
     notify_graph_update(root_id)
 
 
-def get_graph(run_id: str) -> Tuple[List[Run], List[Artifact], List[Edge]]:
+def get_graph(
+    run_id: str, root: bool = False
+) -> Tuple[List[Run], List[Artifact], List[Edge]]:
     """
     Get a graph for a run.
 
     This will return only the run's direct edges and artifacts
-    TODO: implement root=True option to get all graph for root, not needed currently.
     """
-    response = _get("/runs/{}/graph".format(run_id))
+    response = _get(f"/runs/{run_id}/graph?root={int(root)}")
 
     runs = [Run.from_json_encodable(run) for run in response["runs"]]
     artifacts = [
@@ -373,41 +378,44 @@ def _raise_for_response(
     response: requests.Response,
     validate_json: bool,
 ) -> None:
-    to_raise: Optional[Exception] = None
-    url = response.url
-    error_4xx = BadRequestError(
-        f"The {response.request.method} request to {url} was invalid, "
-        f"response was {response.status_code}"
-    )
-    error_5xx = ServerError(
-        f"The Sematic server could not handle the "
-        f"{response.request.method} request to {url}",
-    )
+    exception: Optional[Exception] = None
+    url, method = response.url, response.request.method
 
-    if 400 <= response.status_code < 500:
-        to_raise = error_4xx
-    if response.status_code >= 500:
-        to_raise = error_5xx
-    if to_raise is None and validate_json:
+    if response.status_code == 404:
+        exception = ResourceNotFoundError(f"Resource {url} was not found")
+
+    elif 400 <= response.status_code < 500:
+        exception = BadRequestError(
+            f"The {method} request to {url} was invalid, "
+            f"response was {response.status_code}"
+        )
+
+    elif response.status_code >= 500:
+        exception = ServerError(
+            f"The Sematic server could not handle the " f"{method} request to {url}",
+        )
+
+    if exception is None and validate_json:
         try:
             response.json()
         except Exception:
-            to_raise = InvalidResponseError(
+            exception = InvalidResponseError(
                 f"The Sematic server was expected to return json for "
-                f"{response.request.method} request to {url}, but the "
+                f"{method} request to {url}, but the "
                 f"response was not json."
             )
-    if to_raise is None:
+
+    if exception is None:
         return
 
     logger.error(
         "Server returned %s for %s %s: %s",
         response.status_code,
-        response.request.method,
+        method,
         url,
         response.text,
     )
-    raise to_raise
+    raise exception
 
 
 def _url(endpoint) -> str:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -176,7 +176,7 @@ def schedule_resolution(
     rerun_from: Optional[str] = None,
 ) -> Resolution:
     """Ask the server to start a detached resolution execution."""
-    payload = {}
+    payload: Dict[str, Any] = {}
 
     if max_parallelism is not None:
         payload["max_parallelism"] = max_parallelism

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -120,6 +120,16 @@ def get_graph(
     Get a graph for a run.
 
     This will return only the run's direct edges and artifacts
+
+    Parameters
+    ----------
+    run_id: str
+        The ID whose graph to retrieve
+
+    root: bool
+        Defaults to `False`. If `True`, `run_id` is presumed to be a root run's ID
+        and the whole graph is retrieved. If `False`, only the immediate graph around
+        the run is retrieved (i.e. immediate edges and their artifacts).
     """
     response = _get(f"/runs/{run_id}/graph?root={int(root)}")
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -161,13 +161,18 @@ def schedule_run(run_id: str) -> Run:
 
 
 def schedule_resolution(
-    resolution_id: str, max_parallelism: Optional[int] = None
+    resolution_id: str,
+    max_parallelism: Optional[int] = None,
+    rerun_from: Optional[str] = None,
 ) -> Resolution:
     """Ask the server to start a detached resolution execution."""
     payload = {}
 
     if max_parallelism is not None:
         payload["max_parallelism"] = max_parallelism
+
+    if rerun_from is not None:
+        payload["rerun_from"] = rerun_from
 
     response = _post(f"/resolutions/{resolution_id}/schedule", json_payload=payload)
     return Resolution.from_json_encodable(response["content"])

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -83,6 +83,7 @@ sematic_py_lib(
         ":base",
         ":has_external_jobs_mixin",
         ":json_encodable_mixin",
+        "//sematic:abstract_calculator",
         "//sematic:abstract_future",
         "//sematic/scheduling:external_job",
         "//sematic/types:serialization",

--- a/sematic/db/models/edge.py
+++ b/sematic/db/models/edge.py
@@ -67,3 +67,12 @@ class Edge(Base, JSONEncodableMixin):
                 map(str, [getattr(self, field) for field in self._EQUALITY_FIELDS])
             )
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"Edge(source_run_id={self.source_run_id}, "
+            f"destination_run_id={self.destination_run_id}, "
+            f"destination_name={self.destination_name}, "
+            f"artifact_id={self.artifact_id}, "
+            f"parent_id={self.parent_id})"
+        )

--- a/sematic/db/models/edge.py
+++ b/sematic/db/models/edge.py
@@ -69,10 +69,15 @@ class Edge(Base, JSONEncodableMixin):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"Edge(source_run_id={self.source_run_id}, "
-            f"destination_run_id={self.destination_run_id}, "
-            f"destination_name={self.destination_name}, "
-            f"artifact_id={self.artifact_id}, "
-            f"parent_id={self.parent_id})"
+        fields = ", ".join(
+            f"{field}={getattr(self, field)}"
+            for field in (
+                "id",
+                "source_run_id",
+                "destination_run_id",
+                "destination_name",
+                "artifact_id",
+                "parent_id",
+            )
         )
+        return f"Edge({fields})"

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -59,9 +59,6 @@ def make_artifact(
 ) -> Artifact:
     """
     Create an Artifact model instance from a value and type.
-
-    `store` set to `True` will persist the artifact's serialization.
-    TODO: replace with modular storage engine.
     """
     type_serialization = type_to_json_encodable(type_)
     value_serialization = value_to_json_encodable(value, type_)

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -55,7 +55,7 @@ def make_func_path(future: AbstractFuture) -> str:
 
 
 def make_artifact(
-    value: typing.Any, type_: typing.Any, storage: typing.Optional[Storage]
+    value: typing.Any, type_: typing.Any, storage: typing.Optional[Storage] = None
 ) -> Artifact:
     """
     Create an Artifact model instance from a value and type.

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -9,11 +9,11 @@ import secrets
 import typing
 
 # Sematic
-import sematic.storage as storage
 from sematic.abstract_future import AbstractFuture
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.run import Run
 from sematic.db.models.user import User
+from sematic.storage import Storage
 from sematic.types.serialization import (
     get_json_encodable_summary,
     type_from_json_encodable,
@@ -31,9 +31,7 @@ def make_run_from_future(future: AbstractFuture) -> Run:
         id=future.id,
         future_state=future.state,
         name=future.props.name,
-        calculator_path="{}.{}".format(
-            future.calculator.__module__, future.calculator.__name__
-        ),
+        calculator_path=make_func_path(future),
         parent_id=(
             future.parent_future.id if future.parent_future is not None else None
         ),
@@ -52,8 +50,12 @@ def make_run_from_future(future: AbstractFuture) -> Run:
     return run
 
 
+def make_func_path(future: AbstractFuture) -> str:
+    return f"{future.calculator.__module__}.{future.calculator.__name__}"
+
+
 def make_artifact(
-    value: typing.Any, type_: typing.Any, store: bool = False
+    value: typing.Any, type_: typing.Any, storage: typing.Optional[Storage]
 ) -> Artifact:
     """
     Create an Artifact model instance from a value and type.
@@ -77,7 +79,7 @@ def make_artifact(
         updated_at=datetime.datetime.utcnow(),
     )
 
-    if store:
+    if storage is not None:
         storage.set(
             _make_artifact_storage_key(artifact),
             json.dumps(value_serialization, sort_keys=True).encode("utf-8"),
@@ -86,7 +88,7 @@ def make_artifact(
     return artifact
 
 
-def get_artifact_value(artifact: Artifact) -> typing.Any:
+def get_artifact_value(artifact: Artifact, storage: Storage) -> typing.Any:
     """
     Fetch artifact serialization from storage and deserialize.
     """

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -1,5 +1,6 @@
 # Standard Library
 import datetime
+import importlib
 import json
 import re
 from dataclasses import asdict
@@ -10,6 +11,7 @@ from sqlalchemy import Column, types
 from sqlalchemy.orm import validates
 
 # Sematic
+from sematic.abstract_calculator import AbstractCalculator
 from sematic.abstract_future import FutureState
 from sematic.db.models.base import Base
 from sematic.db.models.has_external_jobs_mixin import HasExternalJobsMixin
@@ -202,3 +204,12 @@ class Run(Base, JSONEncodableMixin, HasExternalJobsMixin):
         self.resource_requirements_json = json.dumps(
             value_to_json_encodable(value, ResourceRequirements)
         )
+
+    def get_func(self) -> AbstractCalculator:
+        split_calculator_path = self.calculator_path.split(".")
+        import_path, func_name = (
+            ".".join(split_calculator_path[:-1]),
+            split_calculator_path[-1],
+        )
+        func = getattr(importlib.import_module(import_path), func_name)
+        return func

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -213,3 +213,13 @@ class Run(Base, JSONEncodableMixin, HasExternalJobsMixin):
         )
         func = getattr(importlib.import_module(import_path), func_name)
         return func
+
+    def __repr__(self):
+        return ", ".join(
+            (
+                f"Run(id={self.id}",
+                f"calculator_path={self.calculator_path}",
+                f"future_state={self.future_state}",
+                f"parent_id={self.parent_id})",
+            )
+        )

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -211,7 +211,14 @@ class Run(Base, JSONEncodableMixin, HasExternalJobsMixin):
             ".".join(split_calculator_path[:-1]),
             split_calculator_path[-1],
         )
-        func = getattr(importlib.import_module(import_path), func_name)
+        try:
+            func = getattr(importlib.import_module(import_path), func_name)
+        except (ImportError, AttributeError) as e:
+            raise type(e)(
+                f"Unable to find this run's function at {import_path}.{func_name}, "
+                f"did it change location? {e}"
+            )
+
         return func
 
     def __repr__(self):

--- a/sematic/db/models/tests/BUILD
+++ b/sematic/db/models/tests/BUILD
@@ -6,7 +6,6 @@ pytest_test(
         "//sematic:calculator",
         "//sematic:storage",
         "//sematic/db/models:factories",
-        "//sematic/tests:fixtures",
     ],
 )
 

--- a/sematic/db/tests/BUILD
+++ b/sematic/db/tests/BUILD
@@ -9,6 +9,7 @@ sematic_py_lib(
         "testing.postgresql",
         "psycopg2-binary",
     ],
+    # buildifier: leave-alone
     deps = [
         "//sematic:abstract_future",
         "//sematic/db:db",
@@ -33,6 +34,7 @@ pytest_test(
 pytest_test(
     name = "test_queries",
     srcs = ["test_queries.py"],
+    # buildifier: leave-alone
     deps = [
         ":fixtures",
         "//sematic:calculator",
@@ -44,6 +46,7 @@ pytest_test(
         "//sematic/db/models:factories",
         "//sematic/db/models:resolution",
         "//sematic/db/models:run",
+        "//sematic/resolvers/tests:fixtures",
         "//sematic/tests:fixtures",
         "//sematic/types:init",
     ],
@@ -53,6 +56,7 @@ pytest_test(
     name = "test_migrate",
     srcs = ["test_migrate.py"],
     pip_deps = ["sqlalchemy"],
+    # buildifier: leave-alone
     deps = [
         "//sematic/db:db",
         "//sematic/db:migrate_lib",

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -187,7 +187,7 @@ def persisted_artifact(test_db, test_storage):  # noqa: F811
     """
     Persisted artifact fixture.
     """
-    artifact = make_artifact(42, int, True)
+    artifact = make_artifact(42, int, storage=test_storage)
 
     with db.db().get_session() as session:
         session.add(artifact)

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -1,13 +1,11 @@
-# Standard Library
-from unittest import mock
-
 # Third-party
 import pytest
 
 # Sematic
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
+    mock_auth,
     mock_requests,
+    mock_socketio,
     test_client,
 )
 from sematic.calculator import func
@@ -33,11 +31,8 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     run,
     test_db,
 )
-from sematic.tests.fixtures import (  # noqa: F401
-    MockStorage,
-    test_storage,
-    valid_client_version,
-)
+from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
+from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
 
 
 def test_count_runs(test_db, run: Run):  # noqa: F811
@@ -120,12 +115,10 @@ def pipeline(a: float, b: float) -> float:
     "fn, run_count, artifact_count, edge_count",
     ((get_run_graph, 1, 3, 3), (get_root_graph, 3, 4, 8)),
 )
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_get_run_graph(
-    mock_storage,
-    mock_socketio,
+    mock_auth,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
     fn,
     run_count: int,
     artifact_count: int,

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -33,7 +33,11 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     run,
     test_db,
 )
-from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
+from sematic.tests.fixtures import (  # noqa: F401
+    MockStorage,
+    test_storage,
+    valid_client_version,
+)
 
 
 def test_count_runs(test_db, run: Run):  # noqa: F811
@@ -118,7 +122,9 @@ def pipeline(a: float, b: float) -> float:
 )
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_get_run_graph(
+    mock_storage,
     mock_socketio,
     fn,
     run_count: int,
@@ -127,6 +133,7 @@ def test_get_run_graph(
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
 ):
+
     future = pipeline(1, 2)
     future.resolve()
 

--- a/sematic/examples/add/__main__.py
+++ b/sematic/examples/add/__main__.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Sematic add example")
     parser.add_argument("--cloud", action="store_true", default=False)
     parser.add_argument("--detach", action="store_true", default=False)
+    parser.add_argument("--rerun_from", default=None)
 
     args = parser.parse_args()
 
@@ -19,7 +20,11 @@ if __name__ == "__main__":
         name="Basic add example pipeline", tags=["example", "basic", "final"]
     )
 
-    resolver = CloudResolver(detach=args.detach) if args.cloud else LocalResolver()
+    resolver = (
+        CloudResolver(detach=args.detach, rerun_from=args.rerun_from)
+        if args.cloud
+        else LocalResolver(rerun_from=args.rerun_from)
+    )
 
     result = future.resolve(resolver)
 

--- a/sematic/examples/add/__main__.py
+++ b/sematic/examples/add/__main__.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Sematic add example")
     parser.add_argument("--cloud", action="store_true", default=False)
     parser.add_argument("--detach", action="store_true", default=False)
-    parser.add_argument("--rerun_from", default=None)
+    parser.add_argument("--rerun-from", default=None)
 
     args = parser.parse_args()
 

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -11,7 +11,7 @@ def add(a: float, b: float) -> float:
     Adds two numbers.
     """
     time.sleep(5)
-    return a + b + 1
+    return a + b
 
 
 @sematic.func

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -1,3 +1,6 @@
+# Standard Library
+import time
+
 # Sematic
 import sematic
 
@@ -7,6 +10,7 @@ def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
+    time.sleep(5)
     return a + b + 1
 
 

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -7,7 +7,7 @@ def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
-    return a + b
+    return a + b + 1
 
 
 @sematic.func

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -1,8 +1,9 @@
 # Standard Library
-import collections
-from collections import defaultdict
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import OrderedDict as OrderedDictType
+from typing import Tuple
 
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState
@@ -18,6 +19,55 @@ RunsByID = Dict[RunID, Run]
 RunsByParentID = Dict[Optional[RunID], List[Run]]
 EdgesByRunID = Dict[RunID, List[Edge]]
 EdgesByID = Dict[str, Edge]
+
+
+@dataclass
+class ClonedFutureGraph:
+    """
+    A cloned future graph. This graph is potentially partial, as it is meant to
+    be used as a resolution seed.
+    """
+
+    futures_by_original_id: OrderedDictType[RunID, AbstractFuture] = field(
+        init=False, default_factory=OrderedDict
+    )
+    input_artifacts: Dict[RunID, Dict[str, Artifact]] = field(
+        init=False, default_factory=lambda: defaultdict(dict)
+    )
+    output_artifacts: Dict[RunID, Artifact] = field(init=False, default_factory=dict)
+
+    def sort_by(self, run_ids: List[RunID]):
+        """
+        Sort futures according to the order of run_ids.
+        """
+        ordered_futures = OrderedDict(
+            (
+                (run_id, self.futures_by_original_id[run_id])
+                for run_id in run_ids
+                if run_id in self.futures_by_original_id
+            )
+        )
+        self.futures_by_original_id = ordered_futures
+
+    def set_root_future_id(self, root_id: str):
+        """
+        Set the root future ID
+        """
+        root_future = next(
+            future
+            for future in self.futures_by_original_id.values()
+            if future.parent_future is None
+        )
+
+        if root_future.id in self.input_artifacts:
+            self.input_artifacts[root_id] = self.input_artifacts[root_future.id]
+            del self.input_artifacts[root_future.id]
+
+        if root_future.id in self.output_artifacts:
+            self.output_artifacts[root_id] = self.output_artifacts[root_future.id]
+            del self.output_artifacts[root_future.id]
+
+        root_future.id = root_id
 
 
 @dataclass
@@ -55,9 +105,17 @@ class Graph:
         Artifacts attached to edges. Unordered.
     """
 
-    runs: List[Run]
-    edges: List[Edge]
-    artifacts: List[Artifact]
+    # Using Iterable to satisfy mypy when passing a list to __init__
+    # but post_init forces tuples for safety
+    runs: Iterable[Run]
+    edges: Iterable[Edge]
+    artifacts: Iterable[Artifact]
+    storage: Storage
+
+    def __post_init__(self):
+        self.runs = tuple(self.runs)
+        self.edges = tuple(self.edges)
+        self.artifacts = tuple(self.artifacts)
 
     @memoized_property
     def _run_mappings(self) -> Tuple[RunsByID, RunsByParentID]:
@@ -303,13 +361,111 @@ class Graph:
 
         return skip_run_ids, reset_run_ids
 
-    def clone_futures(
-        self, storage: Storage, reset_from: Optional[RunID] = None
-    ) -> Tuple[
-        OrderedDict[RunID, AbstractFuture],
-        Dict[RunID, Dict[str, Artifact]],
-        Dict[RunID, Artifact],
-    ]:
+    @memoized_indexed
+    def _get_artifact_value(self, artifact_id: str) -> Any:
+        artifact = self._artifacts_by_id[artifact_id]
+        return get_artifact_value(artifact, self.storage)
+
+    def _get_cloned_future_inputs(
+        self, run_id: RunID, cloned_graph: ClonedFutureGraph
+    ) -> Tuple[Dict[str, Any], Dict[str, Artifact]]:
+        kwargs: Dict[str, Any] = {}
+
+        input_edges = self._edges_by_destination_id[run_id]
+
+        run_input_artifacts: Dict[str, Artifact] = {}
+
+        for input_edge in input_edges:
+            if input_edge.destination_name is None:
+                raise RuntimeError("Input edge misses destination name")
+
+            value = None
+
+            if input_edge.artifact_id is not None:
+                artifact = self._artifacts_by_id[input_edge.artifact_id]
+                run_input_artifacts[input_edge.destination_name] = artifact
+                value = self._get_artifact_value(artifact.id)
+
+            if input_edge.source_run_id is not None:
+                # We set the input as the upstream future to mimick what
+                # happens in a greenfield resolution.
+                kwargs[
+                    input_edge.destination_name
+                ] = cloned_graph.futures_by_original_id[input_edge.source_run_id]
+            elif input_edge.artifact_id is not None:
+                kwargs[input_edge.destination_name] = value
+            else:
+                raise RuntimeError(
+                    "Invalid input edge had no source run or associated artifact"
+                )
+
+        return kwargs, run_input_artifacts
+
+    def _get_run_output(self, run_id: RunID) -> Tuple[Any, Optional[Artifact]]:
+        output_edges = self._edges_by_source_id[run_id]
+
+        for output_edge in output_edges:
+            if output_edge.artifact_id is None:
+                return None, None
+
+            artifact = self._artifacts_by_id[output_edge.artifact_id]
+            value = self._get_artifact_value(artifact.id)
+            return value, artifact
+
+        return None, None
+
+    def _set_cloned_parent_future(
+        self,
+        future: AbstractFuture,
+        run: Run,
+        cloned_graph: ClonedFutureGraph,
+        reset_run_ids: List[RunID],
+    ):
+        if run.parent_id is None:
+            return
+
+        parent_future = cloned_graph.futures_by_original_id[run.parent_id]
+
+        future.parent_future = parent_future
+
+        # Is future parent_future's nested future?
+        if self._runs_by_id[run.parent_id].nested_future_id == run.id:
+            parent_future.nested_future = future
+
+            if run.id in reset_run_ids:
+                parent_future.state = FutureState.RAN
+
+    def _clone_run(
+        self, run_id: RunID, cloned_graph: ClonedFutureGraph, reset_run_ids: List[RunID]
+    ) -> AbstractFuture:
+        run = self._runs_by_id[run_id]
+
+        kwargs, run_input_artifacts = self._get_cloned_future_inputs(
+            run_id, cloned_graph
+        )
+
+        func = run.get_func()
+
+        future = func(**kwargs)
+
+        cloned_graph.input_artifacts[future.id] = run_input_artifacts
+
+        if run_id not in reset_run_ids:
+            value, output_artifact = self._get_run_output(run_id)
+            if output_artifact is not None:
+                cloned_graph.output_artifacts[future.id] = output_artifact
+                future.value = value
+
+        self._set_cloned_parent_future(future, run, cloned_graph, reset_run_ids)
+
+        # Settings state for resolved runs unless reset
+        if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
+            if run.id not in reset_run_ids:
+                future.state = FutureState.RESOLVED
+
+        return future
+
+    def clone_futures(self, reset_from: Optional[RunID] = None) -> ClonedFutureGraph:
         """
         Clones the current graph into new futures.
 
@@ -349,11 +505,7 @@ class Graph:
             to output artifacts.
 
         """
-        value_by_artifact_id: Dict[str, Any] = {}
-
-        futures_by_original_id: Dict[RunID, AbstractFuture] = {}
-        input_artifacts: Dict[RunID, Dict[str, Artifact]] = defaultdict(dict)
-        output_artifacts: Dict[RunID, Artifact] = {}
+        cloned_graph = ClonedFutureGraph()
 
         skip_run_ids, reset_run_ids = (
             ([], []) if reset_from is None else self._get_skip_reset_run_ids(reset_from)
@@ -367,114 +519,17 @@ class Graph:
             run_sorter=self._execution_order
         )
 
-        def _get_artifact_value(artifact: Artifact) -> Any:
-            if artifact.id not in value_by_artifact_id:
-                value_by_artifact_id[artifact.id] = get_artifact_value(
-                    artifact, storage
-                )
-
-            return value_by_artifact_id[artifact.id]
-
-        def _get_run_inputs(
-            run_id: RunID,
-        ) -> Tuple[Dict[str, Any], Dict[str, Artifact]]:
-            kwargs: Dict[str, Any] = {}
-
-            input_edges = self._edges_by_destination_id[run_id]
-
-            run_input_artifacts: Dict[str, Artifact] = {}
-
-            for input_edge in input_edges:
-                if input_edge.destination_name is None:
-                    raise RuntimeError("Input edge misses destination name")
-
-                value = None
-
-                if input_edge.artifact_id is not None:
-                    artifact = self._artifacts_by_id[input_edge.artifact_id]
-                    run_input_artifacts[input_edge.destination_name] = artifact
-                    value = _get_artifact_value(artifact)
-
-                if input_edge.source_run_id is not None:
-                    kwargs[input_edge.destination_name] = futures_by_original_id[
-                        input_edge.source_run_id
-                    ]
-                elif input_edge.artifact_id is not None:
-                    kwargs[input_edge.destination_name] = value
-                else:
-                    raise RuntimeError(
-                        "Invalid input edge had no source run or associated artifact"
-                    )
-
-            return kwargs, run_input_artifacts
-
-        def _get_run_output(run_id: RunID) -> Tuple[Any, Optional[Artifact]]:
-            output_edges = self._edges_by_source_id[run_id]
-
-            for output_edge in output_edges:
-                if output_edge.artifact_id is None:
-                    return None, None
-
-                artifact = self._artifacts_by_id[output_edge.artifact_id]
-                value = _get_artifact_value(artifact)
-                return value, artifact
-
-            return None, None
-
-        def _set_parent_nested(future: AbstractFuture, run: Run):
-            if run.parent_id is None:
-                return None, None
-
-            parent_future = futures_by_original_id[run.parent_id]
-
-            future.parent_future = parent_future
-
-            for output_edge in self._edges_by_source_id[run_id]:
-                if output_edge.parent_id is not None:
-                    if (
-                        self._edges_by_id[output_edge.parent_id].source_run_id
-                        == run.parent_id
-                    ):
-                        parent_future.nested_future = future
-
-                        if run.id in reset_run_ids:
-                            parent_future.state = FutureState.RAN
-
-                        return
-
-        def _clone_run(run_id: RunID):
-            run = self._runs_by_id[run_id]
-
-            kwargs, run_input_artifacts = _get_run_inputs(run_id)
-
-            func = run.get_func()
-
-            future = func(**kwargs)
-
-            input_artifacts[future.id] = run_input_artifacts
-
-            if run_id not in reset_run_ids:
-                value, output_artifact = _get_run_output(run_id)
-                if output_artifact is not None:
-                    output_artifacts[future.id] = output_artifact
-                    future.value = value
-
-            _set_parent_nested(future, run)
-
-            # Settings state for resolved runs unless reset
-            if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
-                if run.id not in reset_run_ids:
-                    future.state = FutureState.RESOLVED
-
-            futures_by_original_id[run.id] = future
-
         for run_id in run_ids_by_execution_order:
             if run_id in skip_run_ids:
                 continue
 
-            _clone_run(run_id)
+            cloned_graph.futures_by_original_id[run_id] = self._clone_run(
+                run_id, cloned_graph, reset_run_ids
+            )
 
-        if reset_from is None and len(futures_by_original_id) != len(self.runs):
+        if reset_from is None and len(cloned_graph.futures_by_original_id) != len(
+            list(self.runs)
+        ):
             raise RuntimeError("Not all futures duplicated")
 
         # We return future sorted by how they would be sorted for a resolution
@@ -484,17 +539,9 @@ class Graph:
             run_sorter=self._reverse_execution_order
         )
 
-        return (
-            collections.OrderedDict(
-                (
-                    (run_id, futures_by_original_id[run_id])
-                    for run_id in run_ids_by_reverse_execution_order
-                    if run_id in futures_by_original_id
-                )
-            ),
-            input_artifacts,
-            output_artifacts,
-        )
+        cloned_graph.sort_by(run_ids_by_reverse_execution_order)
+
+        return cloned_graph
 
 
 EdgeFilterCallable = Callable[[List[Optional[RunID]], RunID], bool]

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -31,7 +31,7 @@ class Graph:
             _runs_by_parent_ids[run.parent_id].append(run)
 
         setattr(self, make_cache_name("runs_by_id"), _runs_by_id)
-        setattr(self, make_cache_name("runs_by_parent_ids"), _runs_by_parent_ids)
+        setattr(self, make_cache_name("runs_by_parent_id"), _runs_by_parent_ids)
 
     @memoized_property
     def runs_by_id(self) -> Dict[str, Run]:
@@ -173,6 +173,7 @@ class Graph:
         reset_run_ids: List[str] = []
 
         if reset_from is not None:
+            reset_run_ids.append(reset_from)
             # We will skip descendants of all downstream of reset point
             # plus descendants of downstreams of ancestors
             ancestor_run_ids = self.get_run_ancestor_ids(reset_from)
@@ -193,6 +194,14 @@ class Graph:
             run_sorter=self._execution_order
         )
 
+        def _get_artifact_value(artifact: Artifact) -> Any:
+            if artifact.id not in value_by_artifact_id:
+                value_by_artifact_id[artifact.id] = get_artifact_value(
+                    artifact, storage
+                )
+
+            return value_by_artifact_id[artifact.id]
+
         for run_id in run_ids_by_execution_order:
 
             if run_id in skip_run_ids:
@@ -207,23 +216,19 @@ class Graph:
 
             run_input_artifacts: Dict[str, Artifact] = {}
 
-            for edge in input_edges:
+            for input_edge in input_edges:
                 value = None
-                if edge.artifact_id is not None:
-                    artifact = self.artifacts_by_id[edge.artifact_id]
-                    if edge.artifact_id not in value_by_artifact_id:
-                        value_by_artifact_id[edge.artifact_id] = get_artifact_value(
-                            artifact, storage
-                        )
-                    value = value_by_artifact_id[edge.artifact_id]
-                    run_input_artifacts[edge.destination_name] = artifact
+                if input_edge.artifact_id is not None:
+                    artifact = self.artifacts_by_id[input_edge.artifact_id]
+                    run_input_artifacts[input_edge.destination_name] = artifact
+                    value = _get_artifact_value(artifact)
 
-                if edge.source_run_id is not None:
-                    kwargs[edge.destination_name] = futures_by_original_id[
-                        edge.source_run_id
+                if input_edge.source_run_id is not None:
+                    kwargs[input_edge.destination_name] = futures_by_original_id[
+                        input_edge.source_run_id
                     ]
-                elif edge.artifact_id is not None:
-                    kwargs[edge.destination_name] = value
+                elif input_edge.artifact_id is not None:
+                    kwargs[input_edge.destination_name] = value
                 else:
                     raise RuntimeError("Should not happen")
 
@@ -236,19 +241,14 @@ class Graph:
             # Figuring out future output values and artifacts
             output_edges = self.edges_by_source_id[run.id]
 
-            for output_edge in output_edges:
-                if output_edge.artifact_id is not None:
-                    artifact = self.artifacts_by_id[output_edge.artifact_id]
-                    output_artifacts[future.id] = artifact
-                    value = value_by_artifact_id.get(
-                        edge.artifact_id,
-                        get_artifact_value(
-                            self.artifacts_by_id[edge.artifact_id], storage
-                        ),
-                    )
-                    future.value = value
-                    value_by_artifact_id[output_edge.artifact_id] = value
-                break
+            if run_id not in reset_run_ids:
+                for output_edge in output_edges:
+                    if output_edge.artifact_id is not None:
+                        artifact = self.artifacts_by_id[output_edge.artifact_id]
+                        output_artifacts[future.id] = artifact
+                        value = _get_artifact_value(artifact)
+                        future.value = value
+                    break
 
             if run.parent_id is not None:
                 parent_future = futures_by_original_id[run.parent_id]

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -127,10 +127,9 @@ class Graph:
         """
         For a given graph layer (all runs have the same parent_id), this will
         return run_ids in order of execution, i.e. upstream runs first,
-        downstream runs next. This is not deterministic, as multiple runs may
-        have the same set of upstream runs, and thus can be executed in
-        parallel. It thus is not suitable to determine whether one run is a
-        dependency of another.
+        downstream runs next. Parallelizable run IDs are sorted alphabetically for
+        determinism. Returns a flat list, thus is not suitable to determine
+        whether one run is a dependency of another.
 
         Parameters
         ----------
@@ -149,9 +148,9 @@ class Graph:
         """
         For a given graph layer (all runs have the same parent_id), this will
         return run_ids in order of reverse execution, i.e. downstream first,
-        upstream runs next. This is not deterministic, as runs may have multiple
-        upstream runs. It thus is not suitable to determine whether one run is a
-        dependency of another.
+        upstream runs next. Parallelizable run IDs are sorted alphabetically for
+        determinism. Returns a flat list, thus is not suitable to determine
+        whether one run is a dependency of another.
 
         Parameters
         ----------
@@ -171,8 +170,7 @@ class Graph:
     ) -> List[RunID]:
         """
         Run IDs grouped by parent_ids, with parent_ids sorted from outermost
-        (None) to innermost. This is not deterministic as multiple layers may
-        have the same parent_id. Breadth-first sorting.
+        (None) to innermost. Breadth-first sorting.
 
         Within a layer, runs are sorted with the run_sorter input callable.
 
@@ -530,7 +528,8 @@ def _sort_layer_runs(
     layer_run_ids: List[RunID], edge_filter: EdgeFilterCallable
 ) -> List[str]:
     """
-    Sort runs within layer.
+    Sort runs topologically within layer. The order (upstream first or
+    downstream first) depends on edge_filter.
 
     Parameters
     ----------
@@ -541,11 +540,15 @@ def _sort_layer_runs(
     """
 
     def _find_next_runs(previous_run_ids: List[Optional[RunID]]):
-        next_run_ids = [
-            run_id
-            for run_id in layer_run_ids
-            if edge_filter(previous_run_ids, run_id) and run_id not in previous_run_ids
-        ]
+        # Sorting for determinism.
+        next_run_ids = sorted(
+            [
+                run_id
+                for run_id in layer_run_ids
+                if edge_filter(previous_run_ids, run_id)
+                and run_id not in previous_run_ids
+            ]
+        )
 
         if len(next_run_ids) == 0:
             return []

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -13,6 +13,7 @@ from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.run import Run
 from sematic.storage import Storage
 from sematic.utils.memoized_property import memoized_indexed, memoized_property
+from sematic.utils.sorting import topological_sort
 
 RunID = str
 RunsByID = Dict[RunID, Run]
@@ -198,9 +199,13 @@ class Graph:
         if len({self._runs_by_id[run_id].parent_id for run_id in layer_run_ids}) > 1:
             raise ValueError("Runs are not all from the same layer")
 
-        return _sort_layer_runs(
-            layer_run_ids, _upstream_edge_filter(self._edges_by_destination_id)
-        )
+        dependencies = {
+            run_id: [
+                edge.source_run_id for edge in self._edges_by_destination_id[run_id]
+            ]
+            for run_id in layer_run_ids
+        }
+        return topological_sort(dependencies)
 
     def _reverse_execution_order(self, layer_run_ids: List[RunID]) -> List[RunID]:
         """
@@ -219,9 +224,13 @@ class Graph:
         if len({self._runs_by_id[run_id].parent_id for run_id in layer_run_ids}) > 1:
             raise ValueError("Runs are not all from the same layer")
 
-        return _sort_layer_runs(
-            layer_run_ids, _downstream_edge_filter(self._edges_by_source_id)
-        )
+        dependencies = {
+            run_id: [
+                edge.destination_run_id for edge in self._edges_by_source_id[run_id]
+            ]
+            for run_id in layer_run_ids
+        }
+        return topological_sort(dependencies)
 
     def _sorted_run_ids_by_layer(
         self, run_sorter: Callable[[List[RunID]], List[RunID]]
@@ -542,66 +551,3 @@ class Graph:
         cloned_graph.sort_by(run_ids_by_reverse_execution_order)
 
         return cloned_graph
-
-
-EdgeFilterCallable = Callable[[List[Optional[RunID]], RunID], bool]
-
-
-def _upstream_edge_filter(
-    edges_by_destination_id: Dict[RunID, List[Edge]]
-) -> EdgeFilterCallable:
-    def _edge_filter(upstream_run_ids: List[Optional[RunID]], run_id: RunID):
-        return all(
-            edge.source_run_id in upstream_run_ids
-            for edge in edges_by_destination_id[run_id]
-        )
-
-    return _edge_filter
-
-
-def _downstream_edge_filter(
-    edges_by_source_id: Dict[RunID, List[Edge]]
-) -> EdgeFilterCallable:
-    def _edge_filter(downstream_run_ids: List[Optional[RunID]], run_id: RunID):
-        return all(
-            edge.destination_run_id in downstream_run_ids
-            for edge in edges_by_source_id[run_id]
-        )
-
-    return _edge_filter
-
-
-def _sort_layer_runs(
-    layer_run_ids: List[RunID], edge_filter: EdgeFilterCallable
-) -> List[str]:
-    """
-    Sort runs topologically within layer. The order (upstream first or
-    downstream first) depends on edge_filter.
-
-    Parameters
-    ----------
-    layer_run_ids: List[RunID]
-        All run IDs in the layer
-    edge_filter: EdgeFilterCallable
-        A callable to determine the next set of run IDs based on their edges.
-    """
-
-    def _find_next_runs(previous_run_ids: List[Optional[RunID]]):
-        # Sorting for determinism.
-        next_run_ids = sorted(
-            [
-                run_id
-                for run_id in layer_run_ids
-                if edge_filter(previous_run_ids, run_id)
-                and run_id not in previous_run_ids
-            ]
-        )
-
-        if len(next_run_ids) == 0:
-            return []
-
-        return next_run_ids + _find_next_runs(
-            previous_run_ids + next_run_ids  # type: ignore
-        )
-
-    return _find_next_runs([None])

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -1,0 +1,263 @@
+# Standard Library
+import collections
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, OrderedDict, Tuple
+
+# Sematic
+from sematic.abstract_future import AbstractFuture
+from sematic.db.models.artifact import Artifact
+from sematic.db.models.edge import Edge
+from sematic.db.models.factories import get_artifact_value
+from sematic.db.models.run import Run
+from sematic.storage import Storage
+from sematic.utils.memoized_property import make_cache_name, memoized_property
+
+
+@dataclass
+class Graph:
+
+    runs: List[Run]
+    edges: List[Edge]
+    artifacts: List[Artifact]
+    parent_id: Optional[str] = None
+
+    @memoized_property
+    def runs_by_id(self) -> Dict[str, Run]:
+        return {run.id: run for run in self.runs}
+
+    @memoized_property
+    def runs_by_parent_id(self) -> Dict[Optional[str], List[Run]]:
+        _runs_by_parent_id: Dict[Optional[str], List[Run]] = defaultdict(list)
+
+        for run in self.runs:
+            _runs_by_parent_id[run.parent_id].append(run)
+
+        return _runs_by_parent_id
+
+    def _populate_edge_mappings(self):
+        _edges_by_destination_id: Dict[str, Dict[str, Edge]] = defaultdict(dict)
+
+        _edges_by_source_id: Dict[str, List[Edge]] = defaultdict(list)
+
+        _edges_by_id: Dict[str, Edge] = {}
+
+        for edge in self.edges:
+            _edges_by_id[edge.id] = edge
+
+            if edge.destination_run_id is not None:
+                _edges_by_destination_id[edge.destination_run_id][
+                    edge.destination_name
+                ] = edge
+
+            if edge.source_run_id is not None:
+                _edges_by_source_id[edge.source_run_id].append(edge)
+
+        setattr(
+            self, make_cache_name("edges_by_destination_id"), _edges_by_destination_id
+        )
+        setattr(self, make_cache_name("edges_by_source_id"), _edges_by_source_id)
+        setattr(self, make_cache_name("edges_by_id"), _edges_by_id)
+
+    @memoized_property
+    def edges_by_destination_id(
+        self,
+    ) -> Dict[str, Dict[str, Edge]]:
+        self._populate_edge_mappings()
+        return getattr(self, make_cache_name("edges_by_destination_id"))
+
+    @memoized_property
+    def edges_by_source_id(self) -> Dict[str, List[Edge]]:
+        self._populate_edge_mappings()
+        return getattr(self, make_cache_name("edges_by_source_id"))
+
+    @memoized_property
+    def edges_by_id(self) -> Dict[str, Edge]:
+        self._populate_edge_mappings()
+        return getattr(self, make_cache_name("edges_id"))
+
+    @memoized_property
+    def artifacts_by_id(self) -> Dict[str, Artifact]:
+        return {artifact.id: artifact for artifact in self.artifacts}
+
+    def input_artifacts_ready(self, run_id: str) -> bool:
+        return all(
+            edge.artifact_id is not None
+            for edge in self.edges_by_destination_id[run_id].values()
+        )
+
+    def run_input_edges(self, run_id: str) -> Dict[str, Edge]:
+        return self.edges_by_destination_id[run_id]
+
+    @memoized_property
+    def runs_sorted_by_layer(self) -> List[Run]:
+        runs: List[Run] = []
+
+        def _add_layer_runs(parent_id: Optional[str]):
+            layer_runs: List[Run] = self.runs_by_parent_id[parent_id]
+            runs.extend(layer_runs)
+            for run in layer_runs:
+                _add_layer_runs(run.id)
+
+        _add_layer_runs(None)
+
+        return runs
+
+    def get_run_ancestor_ids(self, run_id: str) -> List[str]:
+        run = self.runs_by_id[run_id]
+
+        ancestor_ids: List[str] = []
+
+        while run.parent_id is not None:
+            ancestor_ids.append(run.parent_id)
+            run = self.runs_by_id[run.parent_id]
+
+        return ancestor_ids
+
+    def get_run_descendant_ids(self, run_id: str) -> List[str]:
+        descendant_ids: List[str] = []
+
+        child_runs: List[Run] = self.runs_by_parent_id[run_id]
+
+        for child_run in child_runs:
+            descendant_ids.append(child_run.id)
+            descendant_ids += self.get_run_descendant_ids(child_run.id)
+
+        return descendant_ids
+
+    def get_run_downstream_ids(self, run_id: str) -> List[str]:
+        output_edges: List[Edge] = self.edges_by_source_id.get(run_id, [])
+
+        downstream_ids: List[str] = []
+
+        for output_edge in output_edges:
+            if output_edge.destination_run_id is not None:
+                downstream_ids.append(output_edge.destination_run_id)
+                run_id = output_edge.destination_run_id
+                output_edge = self.edges_by_source_id.get(run_id)
+
+        return list(set(downstream_ids))
+
+    def get_duplicate_futures_by_original_run_id(
+        self, storage: Storage, reset_from: Optional[str] = None
+    ) -> OrderedDict[str, AbstractFuture]:
+        # First we create func/kwargs pairs
+        # Some kwargs may be resolved (an artifact exists)
+        # Some may be unresolved, we store the source run id to replace
+        # later with the corresponding future
+        func_kwargs_by_original_id = collections.OrderedDict()
+
+        # Map to find kwargs easily once the source is a future
+        unresolved_kwargs_by_source_id: Dict[
+            str, List[Tuple[str, str, Dict[str, Any]]]
+        ] = collections.defaultdict(list)
+
+        # Map to keep track of what func is not ready to become a future
+        # yet
+        unresolved_sources_by_run_id: Dict[
+            str, Dict[str, str]
+        ] = collections.defaultdict(dict)
+
+        # """
+        skip_run_ids: List[str] = []
+
+        if reset_from is not None:
+            # We will skip descendants of all downstream of reset point
+            # plus descendants of downstreams of ancestors
+            ancestor_run_ids = self.get_run_ancestor_ids(reset_from)
+            for ancestor_run_id in [reset_from] + ancestor_run_ids:
+                downstream_run_ids = self.get_run_downstream_ids(ancestor_run_id)
+                for downstream_run_id in downstream_run_ids:
+                    downstream_descendant_ids = self.get_run_descendant_ids(
+                        downstream_run_id
+                    )
+                    skip_run_ids += downstream_descendant_ids
+
+        # """
+        # runs order guarantees parents come first
+        for run in self.runs_sorted_by_layer:
+
+            if run.id in skip_run_ids:
+                continue
+
+            kwargs: Dict[str, Any] = {}
+
+            for name, edge in self.run_input_edges(run.id).items():
+                if edge.source_run_id is not None:
+                    unresolved_kwargs_by_source_id[edge.source_run_id].append(
+                        (run.id, name, kwargs)
+                    )
+                    unresolved_sources_by_run_id[run.id][name] = edge.source_run_id
+                elif edge.artifact_id is not None:
+                    kwargs[name] = get_artifact_value(
+                        self.artifacts_by_id[edge.artifact_id], storage
+                    )
+                else:
+                    raise RuntimeError("Should not happen")
+
+            func = run.get_func()
+            func_kwargs_by_original_id[run.id] = (func, kwargs)
+
+        # Now we recreate the future graph
+
+        futures_by_original_id: OrderedDict[str, AbstractFuture] = OrderedDict()
+
+        some_unresolved = True
+
+        while some_unresolved:
+            some_unresolved = False
+            for original_run_id, (
+                func,
+                kwargs,
+            ) in func_kwargs_by_original_id.items():
+                if original_run_id in futures_by_original_id:
+                    continue
+
+                if len(unresolved_sources_by_run_id[original_run_id]) != 0:
+                    some_unresolved = True
+                    continue
+
+                # This func is ready to be converted to a future
+                # All inputs are either artifacts or other futures
+
+                future = func(**kwargs)
+
+                # This future is ready to be added to the graph
+                # and its func can be removed from the working map
+                futures_by_original_id[original_run_id] = future
+                # del func_kwargs_by_original_id[original_run_id]
+
+                # We also set this future as kwarg of whoever needs it
+                for run_id, name, kwargs in unresolved_kwargs_by_source_id[
+                    original_run_id
+                ]:
+                    kwargs[name] = future
+                    del unresolved_sources_by_run_id[run_id][name]
+
+                del unresolved_kwargs_by_source_id[original_run_id]
+
+        # Now we need to figure out the parent future,
+        # and whether this future is a nested future
+        for original_run_id, future in futures_by_original_id.items():
+            parent_id = self.runs_by_id[original_run_id].parent_id
+
+            if parent_id is not None:
+                # guaranteed to exist because we sort runs by layers
+                parent_future = futures_by_original_id[parent_id]
+                future.parent_future = parent_future
+
+                # Is `future` its parent's nested_future?
+                output_edges = self.edges_by_source_id[original_run_id]
+                for output_edge in output_edges:
+                    if output_edge.parent_id is not None:
+                        if (
+                            self.edges_by_id[output_edge.parent_id].source_run_id
+                            == parent_id
+                        ):
+                            parent_future.nested_future = future
+                            break
+
+        if reset_from is None and len(futures_by_original_id) != len(self.runs):
+            raise RuntimeError("Not all futures duplicated")
+
+        return futures_by_original_id

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -2,7 +2,7 @@
 import collections
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, OrderedDict, Tuple
+from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple
 
 # Sematic
 from sematic.abstract_future import AbstractFuture
@@ -36,7 +36,7 @@ class Graph:
         return _runs_by_parent_id
 
     def _populate_edge_mappings(self):
-        _edges_by_destination_id: Dict[str, Dict[str, Edge]] = defaultdict(dict)
+        _edges_by_destination_id: Dict[str, List[Edge]] = defaultdict(list)
 
         _edges_by_source_id: Dict[str, List[Edge]] = defaultdict(list)
 
@@ -46,9 +46,7 @@ class Graph:
             _edges_by_id[edge.id] = edge
 
             if edge.destination_run_id is not None:
-                _edges_by_destination_id[edge.destination_run_id][
-                    edge.destination_name
-                ] = edge
+                _edges_by_destination_id[edge.destination_run_id].append(edge)
 
             if edge.source_run_id is not None:
                 _edges_by_source_id[edge.source_run_id].append(edge)
@@ -62,7 +60,7 @@ class Graph:
     @memoized_property
     def edges_by_destination_id(
         self,
-    ) -> Dict[str, Dict[str, Edge]]:
+    ) -> Dict[str, List[Edge]]:
         self._populate_edge_mappings()
         return getattr(self, make_cache_name("edges_by_destination_id"))
 
@@ -83,37 +81,70 @@ class Graph:
     def input_artifacts_ready(self, run_id: str) -> bool:
         return all(
             edge.artifact_id is not None
-            for edge in self.edges_by_destination_id[run_id].values()
+            for edge in self.edges_by_destination_id[run_id]
         )
 
     def run_input_edges(self, run_id: str) -> Dict[str, Edge]:
         return self.edges_by_destination_id[run_id]
 
-    @memoized_property
-    def runs_sorted_by_layer(self) -> List[Run]:
-        runs: List[Run] = []
+    def _reverse_execution_order(
+        self, runs: List[Run], downstream_run_ids: Optional[List[Optional[str]]] = None
+    ):
+        if downstream_run_ids is None:
+            downstream_run_ids = [None]
 
-        def _reverse_execution_order(layer_runs, downstream_run_ids):
-            if len(downstream_run_ids) == 0:
-                return []
-            runs_ = [
-                run
-                for run in layer_runs
-                if all(
-                    edge.destination_run_id in downstream_run_ids
-                    for edge in self.edges_by_source_id[run.id]
-                )
-            ]
-            return runs_ + _reverse_execution_order(
-                layer_runs, [run.id for run in runs_]
+        upstream_runs = [
+            run
+            for run in runs
+            if all(
+                edge.destination_run_id in downstream_run_ids
+                for edge in self.edges_by_source_id[run.id]
             )
+            and run.id not in downstream_run_ids
+        ]
+
+        if len(upstream_runs) == 0:
+            return []
+
+        return upstream_runs + self._reverse_execution_order(
+            runs, downstream_run_ids + [run.id for run in upstream_runs]
+        )
+
+    def _execution_order(
+        self, runs: List[Run], upstream_run_ids: Optional[List[Optional[str]]] = None
+    ):
+        if upstream_run_ids is None:
+            upstream_run_ids = [None]
+
+        downstream_runs = [
+            run
+            for run in runs
+            if all(
+                edge.source_run_id in upstream_run_ids
+                for edge in self.edges_by_destination_id[run.id]
+            )
+            and run.id not in upstream_run_ids
+        ]
+        if len(downstream_runs) == 0:
+            return []
+
+        return downstream_runs + self._execution_order(
+            runs, upstream_run_ids + [run.id for run in downstream_runs]
+        )
+
+    def runs_sorted_by_layer(
+        self, run_sorter: Callable[[List[Run]], List[Run]]
+    ) -> List[Run]:
+        runs: List[Run] = []
 
         def _add_layer_runs(parent_id: Optional[str]):
             layer_runs: List[Run] = self.runs_by_parent_id[parent_id]
-            runs.extend(_reverse_execution_order(layer_runs, [None]))
+            ordered_layer_runs = run_sorter(layer_runs)
+            if len(ordered_layer_runs) != len(layer_runs):
+                raise RuntimeError("Missing runs in ordered layer runs list")
+            runs.extend(ordered_layer_runs)
 
-            # runs.extend(layer_runs)
-            for run in layer_runs:
+            for run in ordered_layer_runs:
                 _add_layer_runs(run.id)
 
         _add_layer_runs(None)
@@ -157,25 +188,16 @@ class Graph:
 
     def get_duplicate_futures_by_original_run_id(
         self, storage: Storage, reset_from: Optional[str] = None
-    ) -> OrderedDict[str, AbstractFuture]:
-        # First we create func/kwargs pairs
-        # Some kwargs may be resolved (an artifact exists)
-        # Some may be unresolved, we store the source run id to replace
-        # later with the corresponding future
-        func_kwargs_by_original_id = collections.OrderedDict()
-
-        # Map to find kwargs easily once the source is a future
-        unresolved_kwargs_by_source_id: Dict[
-            str, List[Tuple[str, str, Dict[str, Any]]]
-        ] = collections.defaultdict(list)
-
-        # Map to keep track of what func is not ready to become a future
-        # yet
-        unresolved_sources_by_run_id: Dict[
-            str, Dict[str, str]
-        ] = collections.defaultdict(dict)
-
+    ) -> Tuple[
+        OrderedDict[str, AbstractFuture],
+        Dict[str, Dict[str, Artifact]],
+        Dict[str, Artifact],
+    ]:
         value_by_artifact_id: Dict[str, Any] = {}
+
+        futures_by_original_id: Dict[str, AbstractFuture] = {}
+        input_artifacts: Dict[str, Dict[str, Artifact]] = defaultdict(dict)
+        output_artifacts: Dict[str, Artifact] = {}
 
         skip_run_ids: List[str] = []
 
@@ -191,103 +213,93 @@ class Graph:
                     )
                     skip_run_ids += downstream_descendant_ids
 
-        # """
         # runs order guarantees parents come first
-        sorted_runs = self.runs_sorted_by_layer
+        run_by_execution_order = self.runs_sorted_by_layer(self._execution_order)
 
-        for run in sorted_runs:
+        def _get_edge_artifact(edge: Edge):
+            if edge.artifact_id is None:
+                return None
+
+            return value_by_artifact_id.get(
+                edge.artifact_id,
+                get_artifact_value(self.artifacts_by_id[edge.artifact_id], storage),
+            )
+
+        for run in run_by_execution_order:
 
             if run.id in skip_run_ids:
                 continue
 
             kwargs: Dict[str, Any] = {}
+            func = run.get_func()
 
-            for name, edge in self.run_input_edges(run.id).items():
+            input_edges = self.edges_by_destination_id[run.id]
+            output_edges = self.edges_by_source_id[run.id]
+
+            run_input_artifacts: Dict[str, Artifact] = {}
+
+            for edge in input_edges:
+                value = None
+                if edge.artifact_id is not None:
+                    artifact = self.artifacts_by_id[edge.artifact_id]
+                    run_input_artifacts[edge.destination_name] = artifact
+                    if edge.artifact_id not in value_by_artifact_id:
+                        value_by_artifact_id[edge.artifact_id] = get_artifact_value(
+                            artifact, storage
+                        )
+                    value = value_by_artifact_id[edge.artifact_id]
+
                 if edge.source_run_id is not None:
-                    unresolved_kwargs_by_source_id[edge.source_run_id].append(
-                        (run.id, name, kwargs)
-                    )
-                    unresolved_sources_by_run_id[run.id][name] = edge.source_run_id
+                    kwargs[edge.destination_name] = futures_by_original_id[
+                        edge.source_run_id
+                    ]
                 elif edge.artifact_id is not None:
-                    value = value_by_artifact_id.get(
-                        edge.artifact_id,
-                        get_artifact_value(
-                            self.artifacts_by_id[edge.artifact_id], storage
-                        ),
-                    )
-                    value_by_artifact_id[edge.artifact_id] = value
-
-                    kwargs[name] = value
+                    kwargs[edge.destination_name] = value
                 else:
                     raise RuntimeError("Should not happen")
 
-            func = run.get_func()
-            func_kwargs_by_original_id[run.id] = (func, kwargs)
+            future = func(**kwargs)
 
-        # Now we recreate the future graph
+            input_artifacts[future.id] = run_input_artifacts
 
-        futures_by_original_id: OrderedDict[str, AbstractFuture] = OrderedDict()
+            for output_edge in output_edges:
+                if output_edge.artifact_id is not None:
+                    artifact = self.artifacts_by_id[output_edge.artifact_id]
+                    output_artifacts[future.id] = artifact
+                    value = _get_edge_artifact(output_edge)
+                    future.value = value
+                    value_by_artifact_id[output_edge.artifact_id] = value
+                break
 
-        some_unresolved = True
-
-        while some_unresolved:
-            some_unresolved = False
-            for original_run_id, (
-                func,
-                kwargs,
-            ) in func_kwargs_by_original_id.items():
-                if original_run_id in futures_by_original_id:
-                    continue
-
-                if len(unresolved_sources_by_run_id[original_run_id]) != 0:
-                    some_unresolved = True
-                    continue
-
-                # This func is ready to be converted to a future
-                # All inputs are either artifacts or other futures
-
-                future = func(**kwargs)
-
-                # This future is ready to be added to the graph
-                # and its func can be removed from the working map
-                futures_by_original_id[original_run_id] = future
-                # del func_kwargs_by_original_id[original_run_id]
-
-                # We also set this future as kwarg of whoever needs it
-                for run_id, name, kwargs in unresolved_kwargs_by_source_id[
-                    original_run_id
-                ]:
-                    kwargs[name] = future
-                    del unresolved_sources_by_run_id[run_id][name]
-
-                del unresolved_kwargs_by_source_id[original_run_id]
-
-        # Now we need to figure out the parent future,
-        # and whether this future is a nested future
-        for original_run_id, future in futures_by_original_id.items():
-            parent_id = self.runs_by_id[original_run_id].parent_id
-
-            if parent_id is not None:
-                # guaranteed to exist because we sort runs by layers
-                parent_future = futures_by_original_id[parent_id]
+            if run.parent_id is not None:
+                parent_future = futures_by_original_id[run.parent_id]
                 future.parent_future = parent_future
-
-                # Is `future` its parent's nested_future?
-                output_edges = self.edges_by_source_id[original_run_id]
                 for output_edge in output_edges:
                     if output_edge.parent_id is not None:
                         if (
                             self.edges_by_id[output_edge.parent_id].source_run_id
-                            == parent_id
+                            == run.parent_id
                         ):
                             parent_future.nested_future = future
                             break
 
+            futures_by_original_id[run.id] = future
+
         if reset_from is None and len(futures_by_original_id) != len(self.runs):
             raise RuntimeError("Not all futures duplicated")
 
-        return collections.OrderedDict(
-            ((run.id, futures_by_original_id[run.id]) for run in sorted_runs)
+        run_by_reverse_execution_order = self.runs_sorted_by_layer(
+            self._reverse_execution_order
         )
 
-        # return {run.id: futures_by_original_id
+        return (
+            collections.OrderedDict(
+                (
+                    (run.id, futures_by_original_id[run.id])
+                    for run in run_by_reverse_execution_order
+                    if run.id in futures_by_original_id
+                )
+            ),
+            input_artifacts,
+            output_artifacts,
+        )

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -260,7 +260,10 @@ class Graph:
                             == run.parent_id
                         ):
                             parent_future.nested_future = future
-                            parent_future.state = FutureState.RAN
+
+                            if run.id in reset_run_ids:
+                                parent_future.state = FutureState.RAN
+
                             break
 
             if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -83,6 +83,8 @@ class Graph:
     Child run
         The run corresponding to the function being called by the current run's
         function
+    Layer
+        Sibling runs. All runs with same parent.
     Ancestor runs
         All parents going up to the root
     Descendant runs

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -11,11 +11,13 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.run import Run
 from sematic.storage import Storage
-from sematic.utils.memoized_property import (
-    make_cache_name,
-    memoized_indexed,
-    memoized_property,
-)
+from sematic.utils.memoized_property import memoized_indexed, memoized_property
+
+RunID = str
+RunsByID = Dict[RunID, Run]
+RunsByParentID = Dict[Optional[RunID], List[Run]]
+EdgesByRunID = Dict[RunID, List[Edge]]
+EdgesByID = Dict[str, Edge]
 
 
 @dataclass
@@ -25,33 +27,32 @@ class Graph:
     edges: List[Edge]
     artifacts: List[Artifact]
 
-    def _populate_run_mappings(self):
-        _runs_by_id: Dict[str, Run] = {}
-        _runs_by_parent_ids: Dict[Optional[str], List[Run]] = defaultdict(list)
+    @memoized_property
+    def _run_mappings(self) -> Tuple[RunsByID, RunsByParentID]:
+        _runs_by_id: RunsByID = dict()
+        _runs_by_parent_ids: RunsByParentID = defaultdict(list)
 
         for run in self.runs:
             _runs_by_id[run.id] = run
             _runs_by_parent_ids[run.parent_id].append(run)
 
-        setattr(self, make_cache_name("runs_by_id"), _runs_by_id)
-        setattr(self, make_cache_name("runs_by_parent_id"), _runs_by_parent_ids)
+        return _runs_by_id, _runs_by_parent_ids
+
+    @property
+    def _runs_by_id(self) -> RunsByID:
+        return self._run_mappings[0]
+
+    @property
+    def _runs_by_parent_id(self) -> RunsByParentID:
+        return self._run_mappings[1]
 
     @memoized_property
-    def runs_by_id(self) -> Dict[str, Run]:
-        self._populate_run_mappings()
-        return self.runs_by_id
+    def _edge_mappings(self) -> Tuple[EdgesByID, EdgesByRunID, EdgesByRunID]:
+        _edges_by_destination_id: EdgesByRunID = defaultdict(list)
 
-    @memoized_property
-    def runs_by_parent_id(self) -> Dict[Optional[str], List[Run]]:
-        self._populate_run_mappings()
-        return self.runs_by_parent_id
+        _edges_by_source_id: EdgesByRunID = defaultdict(list)
 
-    def _populate_edge_mappings(self):
-        _edges_by_destination_id: Dict[str, List[Edge]] = defaultdict(list)
-
-        _edges_by_source_id: Dict[str, List[Edge]] = defaultdict(list)
-
-        _edges_by_id: Dict[str, Edge] = {}
+        _edges_by_id: EdgesByID = {}
 
         for edge in self.edges:
             _edges_by_id[edge.id] = edge
@@ -62,44 +63,35 @@ class Graph:
             if edge.source_run_id is not None:
                 _edges_by_source_id[edge.source_run_id].append(edge)
 
-        setattr(
-            self, make_cache_name("edges_by_destination_id"), _edges_by_destination_id
-        )
-        setattr(self, make_cache_name("edges_by_source_id"), _edges_by_source_id)
-        setattr(self, make_cache_name("edges_by_id"), _edges_by_id)
+        return _edges_by_id, _edges_by_source_id, _edges_by_destination_id
+
+    @property
+    def _edges_by_destination_id(self) -> EdgesByRunID:
+        return self._edge_mappings[2]
+
+    @property
+    def _edges_by_source_id(self) -> EdgesByRunID:
+        return self._edge_mappings[1]
+
+    @property
+    def edges_by_id(self) -> EdgesByID:
+        return self._edge_mappings[0]
 
     @memoized_property
-    def edges_by_destination_id(
-        self,
-    ) -> Dict[str, List[Edge]]:
-        self._populate_edge_mappings()
-        return self.edges_by_destination_id
-
-    @memoized_property
-    def edges_by_source_id(self) -> Dict[str, List[Edge]]:
-        self._populate_edge_mappings()
-        return self.edges_by_source_id
-
-    @memoized_property
-    def edges_by_id(self) -> Dict[str, Edge]:
-        self._populate_edge_mappings()
-        return self.edges_by_id
-
-    @memoized_property
-    def artifacts_by_id(self) -> Dict[str, Artifact]:
+    def _artifacts_by_id(self) -> Dict[str, Artifact]:
         return {artifact.id: artifact for artifact in self.artifacts}
 
-    def input_artifacts_ready(self, run_id: str) -> bool:
+    def input_artifacts_ready(self, run_id: RunID) -> bool:
         """
         Does run have all input artifacts ready, i.e. upstream runs have
         resolved?
         """
         return all(
             edge.artifact_id is not None
-            for edge in self.edges_by_destination_id[run_id]
+            for edge in self._edges_by_destination_id[run_id]
         )
 
-    def _execution_order(self, layer_run_ids: List[str]) -> List[str]:
+    def _execution_order(self, layer_run_ids: List[RunID]) -> List[RunID]:
         """
         For a given graph layer (all runs have the same parent_id), this will
         return run_ids in order of execution, i.e. upstream runs first,
@@ -114,10 +106,10 @@ class Graph:
             parent_id.
         """
         return _sort_layer_runs(
-            layer_run_ids, _upstream_edge_filter(self.edges_by_destination_id)
+            layer_run_ids, _upstream_edge_filter(self._edges_by_destination_id)
         )
 
-    def _reverse_execution_order(self, layer_run_ids: List[str]):
+    def _reverse_execution_order(self, layer_run_ids: List[RunID]):
         """
         For a given graph layer (all runs have the same parent_id), this will
         return run_ids in order of reverse execution, i.e. downstream first,
@@ -131,12 +123,12 @@ class Graph:
             parent_id.
         """
         return _sort_layer_runs(
-            layer_run_ids, _downstream_edge_filter(self.edges_by_source_id)
+            layer_run_ids, _downstream_edge_filter(self._edges_by_source_id)
         )
 
     def _run_ids_sorted_by_layer(
-        self, run_sorter: Callable[[List[str]], List[str]]
-    ) -> List[str]:
+        self, run_sorter: Callable[[List[RunID]], List[RunID]]
+    ) -> List[RunID]:
         """
         Run IDs grouped by parent_ids, with parent_ids sorted from outermost
         (None) to innermost. This is not deterministic as multiple layers may
@@ -156,9 +148,9 @@ class Graph:
         """
         run_ids: List[str] = []
 
-        def _add_layer_runs(parent_id: Optional[str]):
-            layer_run_ids: List[str] = [
-                run.id for run in self.runs_by_parent_id[parent_id]
+        def _add_layer_runs(parent_id: Optional[RunID]):
+            layer_run_ids: List[RunID] = [
+                run.id for run in self._runs_by_parent_id[parent_id]
             ]
             ordered_layer_run_ids = run_sorter(layer_run_ids)
             run_ids.extend(ordered_layer_run_ids)
@@ -171,7 +163,7 @@ class Graph:
         return run_ids
 
     @memoized_indexed
-    def _get_run_ancestor_ids(self, run_id: str) -> List[str]:
+    def _get_run_ancestor_ids(self, run_id: RunID) -> List[RunID]:
         """
         Get a run's ancestor IDs, sorter by increasing proximity, i.e. direct
         parent first, and going up.
@@ -186,24 +178,24 @@ class Graph:
         List[str]
             List of ancestor run IDs
         """
-        run = self.runs_by_id[run_id]
+        run = self._runs_by_id[run_id]
 
-        ancestor_ids: List[str] = []
+        ancestor_ids: List[RunID] = []
 
         while run.parent_id is not None:
             ancestor_ids.append(run.parent_id)
-            run = self.runs_by_id[run.parent_id]
+            run = self._runs_by_id[run.parent_id]
 
         return ancestor_ids
 
     @memoized_indexed
-    def _get_run_descendant_ids(self, run_id: str) -> List[str]:
+    def _get_run_descendant_ids(self, run_id: RunID) -> List[RunID]:
         """
         Get a run's descendant IDs, depth-first.
         """
-        descendant_ids: List[str] = []
+        descendant_ids: List[RunID] = []
 
-        child_runs: List[Run] = self.runs_by_parent_id[run_id]
+        child_runs: List[Run] = self._runs_by_parent_id[run_id]
 
         for child_run in child_runs:
             descendant_ids.append(child_run.id)
@@ -212,13 +204,13 @@ class Graph:
         return descendant_ids
 
     @memoized_indexed
-    def _get_run_downstream_ids(self, run_id: str) -> List[str]:
+    def _get_run_downstream_ids(self, run_id: RunID) -> List[RunID]:
         """
         Within a given layer, get a run's downstream run IDs, depth-first.
         """
-        output_edges: List[Edge] = self.edges_by_source_id.get(run_id, [])
+        output_edges: List[Edge] = self._edges_by_source_id.get(run_id, [])
 
-        downstream_ids: List[str] = []
+        downstream_ids: List[RunID] = []
 
         for output_edge in output_edges:
             if output_edge.destination_run_id is not None:
@@ -230,11 +222,11 @@ class Graph:
         return list(set(downstream_ids))
 
     def clone_futures(
-        self, storage: Storage, reset_from: Optional[str] = None
+        self, storage: Storage, reset_from: Optional[RunID] = None
     ) -> Tuple[
-        OrderedDict[str, AbstractFuture],
-        Dict[str, Dict[str, Artifact]],
-        Dict[str, Artifact],
+        OrderedDict[RunID, AbstractFuture],
+        Dict[RunID, Dict[str, Artifact]],
+        Dict[RunID, Artifact],
     ]:
         """
         Clones the current graph into new futures.
@@ -275,20 +267,20 @@ class Graph:
         """
         value_by_artifact_id: Dict[str, Any] = {}
 
-        futures_by_original_id: Dict[str, AbstractFuture] = {}
-        input_artifacts: Dict[str, Dict[str, Artifact]] = defaultdict(dict)
-        output_artifacts: Dict[str, Artifact] = {}
+        futures_by_original_id: Dict[RunID, AbstractFuture] = {}
+        input_artifacts: Dict[RunID, Dict[str, Artifact]] = defaultdict(dict)
+        output_artifacts: Dict[RunID, Artifact] = {}
 
         # We skip descendants of all downstream of reset point
         # plus descendants of downstreams of ancestors
         # The skipped futures will be naturally re-created by the new graph
         # resolution
-        skip_run_ids: List[str] = []
+        skip_run_ids: List[RunID] = []
 
         # reset = forcing future state to CREATED or RAN
         # Considering reset_from and ancestors runs, we reset the run and
         # all downstream
-        reset_run_ids: List[str] = []
+        reset_run_ids: List[RunID] = []
 
         if reset_from is not None:
             reset_run_ids.append(reset_from)
@@ -321,24 +313,23 @@ class Graph:
 
             return value_by_artifact_id[artifact.id]
 
-        for run_id in run_ids_by_execution_order:
-
-            if run_id in skip_run_ids:
-                continue
-
-            run = self.runs_by_id[run_id]
-
-            # Figuring out input kwargs and artifacts
+        def _get_run_inputs(
+            run_id: RunID,
+        ) -> Tuple[Dict[str, Any], Dict[str, Artifact]]:
             kwargs: Dict[str, Any] = {}
 
-            input_edges = self.edges_by_destination_id[run.id]
+            input_edges = self._edges_by_destination_id[run_id]
 
             run_input_artifacts: Dict[str, Artifact] = {}
 
             for input_edge in input_edges:
+                if input_edge.destination_name is None:
+                    raise RuntimeError("Input edge misses destination name")
+
                 value = None
+
                 if input_edge.artifact_id is not None:
-                    artifact = self.artifacts_by_id[input_edge.artifact_id]
+                    artifact = self._artifacts_by_id[input_edge.artifact_id]
                     run_input_artifacts[input_edge.destination_name] = artifact
                     value = _get_artifact_value(artifact)
 
@@ -351,40 +342,60 @@ class Graph:
                 else:
                     raise RuntimeError("Should not happen")
 
+            return kwargs, run_input_artifacts
+
+        def _get_run_output(run_id: RunID) -> Tuple[Any, Optional[Artifact]]:
+            output_edges = self._edges_by_source_id[run_id]
+
+            for output_edge in output_edges:
+                if output_edge.artifact_id is None:
+                    return None, None
+
+                artifact = self._artifacts_by_id[output_edge.artifact_id]
+                value = _get_artifact_value(artifact)
+                return value, artifact
+
+            return None, None
+
+        def _set_parent_nested(future: AbstractFuture, run: Run):
+            if run.parent_id is None:
+                return None, None
+
+            parent_future = futures_by_original_id[run.parent_id]
+
+            future.parent_future = parent_future
+
+            for output_edge in self._edges_by_source_id[run_id]:
+                if output_edge.parent_id is not None:
+                    if (
+                        self.edges_by_id[output_edge.parent_id].source_run_id
+                        == run.parent_id
+                    ):
+                        parent_future.nested_future = future
+
+                        if run.id in reset_run_ids:
+                            parent_future.state = FutureState.RAN
+
+                        return
+
+        def _clone_run(run_id: RunID):
+            run = self._runs_by_id[run_id]
+
+            kwargs, run_input_artifacts = _get_run_inputs(run_id)
+
             func = run.get_func()
 
             future = func(**kwargs)
 
             input_artifacts[future.id] = run_input_artifacts
 
-            # Figuring out future output values and artifacts
-            output_edges = self.edges_by_source_id[run.id]
-
             if run_id not in reset_run_ids:
-                for output_edge in output_edges:
-                    if output_edge.artifact_id is not None:
-                        artifact = self.artifacts_by_id[output_edge.artifact_id]
-                        output_artifacts[future.id] = artifact
-                        value = _get_artifact_value(artifact)
-                        future.value = value
-                    break
+                value, output_artifact = _get_run_output(run_id)
+                if output_artifact is not None:
+                    output_artifacts[future.id] = output_artifact
+                    future.value = value
 
-            # Figuring out parent and nested futures
-            if run.parent_id is not None:
-                parent_future = futures_by_original_id[run.parent_id]
-                future.parent_future = parent_future
-                for output_edge in output_edges:
-                    if output_edge.parent_id is not None:
-                        if (
-                            self.edges_by_id[output_edge.parent_id].source_run_id
-                            == run.parent_id
-                        ):
-                            parent_future.nested_future = future
-
-                            if run.id in reset_run_ids:
-                                parent_future.state = FutureState.RAN
-
-                            break
+            _set_parent_nested(future, run)
 
             # Settings state for resolved runs unless reset
             if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
@@ -392,6 +403,12 @@ class Graph:
                     future.state = FutureState.RESOLVED
 
             futures_by_original_id[run.id] = future
+
+        for run_id in run_ids_by_execution_order:
+            if run_id in skip_run_ids:
+                continue
+
+            _clone_run(run_id)
 
         if reset_from is None and len(futures_by_original_id) != len(self.runs):
             raise RuntimeError("Not all futures duplicated")
@@ -416,13 +433,13 @@ class Graph:
         )
 
 
-EdgeFilterCallable = Callable[[List[Optional[str]], str], bool]
+EdgeFilterCallable = Callable[[List[Optional[RunID]], RunID], bool]
 
 
 def _upstream_edge_filter(
-    edges_by_destination_id: Dict[str, List[Edge]]
+    edges_by_destination_id: Dict[RunID, List[Edge]]
 ) -> EdgeFilterCallable:
-    def _edge_filter(upstream_run_ids: List[Optional[str]], run_id: str):
+    def _edge_filter(upstream_run_ids: List[Optional[RunID]], run_id: RunID):
         return all(
             edge.source_run_id in upstream_run_ids
             for edge in edges_by_destination_id[run_id]
@@ -432,9 +449,9 @@ def _upstream_edge_filter(
 
 
 def _downstream_edge_filter(
-    edges_by_source_id: Dict[str, List[Edge]]
+    edges_by_source_id: Dict[RunID, List[Edge]]
 ) -> EdgeFilterCallable:
-    def _edge_filter(downstream_run_ids: List[Optional[str]], run_id: str):
+    def _edge_filter(downstream_run_ids: List[Optional[RunID]], run_id: RunID):
         return all(
             edge.destination_run_id in downstream_run_ids
             for edge in edges_by_source_id[run_id]
@@ -444,9 +461,9 @@ def _downstream_edge_filter(
 
 
 def _sort_layer_runs(
-    layer_run_ids: List[str], edge_filter: EdgeFilterCallable
+    layer_run_ids: List[RunID], edge_filter: EdgeFilterCallable
 ) -> List[str]:
-    def _find_next_runs(previous_run_ids: List[Optional[str]]):
+    def _find_next_runs(previous_run_ids: List[Optional[RunID]]):
         next_run_ids = [
             run_id
             for run_id in layer_run_ids

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -156,7 +156,7 @@ class Graph:
 
         return list(set(downstream_ids))
 
-    def get_duplicate_futures_by_original_run_id(
+    def clone_futures_by_original_run_id(
         self, storage: Storage, reset_from: Optional[str] = None
     ) -> Tuple[
         OrderedDict[str, AbstractFuture],

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -11,7 +11,11 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.run import Run
 from sematic.storage import Storage
-from sematic.utils.memoized_property import make_cache_name, memoized_property
+from sematic.utils.memoized_property import (
+    make_cache_name,
+    memoized_indexed,
+    memoized_property,
+)
 
 
 @dataclass
@@ -20,7 +24,6 @@ class Graph:
     runs: List[Run]
     edges: List[Edge]
     artifacts: List[Artifact]
-    parent_id: Optional[str] = None
 
     def _populate_run_mappings(self):
         _runs_by_id: Dict[str, Run] = {}
@@ -87,24 +90,70 @@ class Graph:
         return {artifact.id: artifact for artifact in self.artifacts}
 
     def input_artifacts_ready(self, run_id: str) -> bool:
+        """
+        Does run have all input artifacts ready, i.e. upstream runs have
+        resolved?
+        """
         return all(
             edge.artifact_id is not None
             for edge in self.edges_by_destination_id[run_id]
         )
 
-    def _reverse_execution_order(self, layer_run_ids: List[str]):
-        return _sort_layer_runs(
-            layer_run_ids, _downstream_edge_filter(self.edges_by_source_id)
-        )
-
     def _execution_order(self, layer_run_ids: List[str]) -> List[str]:
+        """
+        For a given graph layer (all runs have the same parent_id), this will
+        return run_ids in order of execution, i.e. upstream runs first,
+        downstream runs next. This is not deterministic, as multiple runs may
+        have the same set of upstream runs, and thus can be executed in
+        parallel.
+
+        Parameters
+        ----------
+        layer_run_ids: List[str]
+            IDs of runs in the layer. All runs are epxected to have the same
+            parent_id.
+        """
         return _sort_layer_runs(
             layer_run_ids, _upstream_edge_filter(self.edges_by_destination_id)
         )
 
-    def run_ids_sorted_by_layer(
+    def _reverse_execution_order(self, layer_run_ids: List[str]):
+        """
+        For a given graph layer (all runs have the same parent_id), this will
+        return run_ids in order of reverse execution, i.e. downstream first,
+        upstream runs next. This is not deterministic, as runs may have multiple
+        upstream runs.
+
+        Parameters
+        ----------
+        layer_run_ids: List[str]
+            IDs of runs in the layer. All runs are epxected to have the same
+            parent_id.
+        """
+        return _sort_layer_runs(
+            layer_run_ids, _downstream_edge_filter(self.edges_by_source_id)
+        )
+
+    def _run_ids_sorted_by_layer(
         self, run_sorter: Callable[[List[str]], List[str]]
     ) -> List[str]:
+        """
+        Run IDs grouped by parent_ids, with parent_ids sorted from outermost
+        (None) to innermost. This is not deterministic as multiple layers may
+        have the same parent_id.
+
+        Within a layer, runs are sorted with the run_sorter input callable.
+
+        Parameters
+        ----------
+        run_sorter: Callable[[List[str]], List[str]]
+            Callable to sort run_ids within a layer
+
+        Returns
+        -------
+        List[str]
+            A flat list of run IDs.
+        """
         run_ids: List[str] = []
 
         def _add_layer_runs(parent_id: Optional[str]):
@@ -121,7 +170,22 @@ class Graph:
 
         return run_ids
 
-    def get_run_ancestor_ids(self, run_id: str) -> List[str]:
+    @memoized_indexed
+    def _get_run_ancestor_ids(self, run_id: str) -> List[str]:
+        """
+        Get a run's ancestor IDs, sorter by increasing proximity, i.e. direct
+        parent first, and going up.
+
+        Parameters
+        ----------
+        run_id: str
+            ID of child run
+
+        Returns
+        -------
+        List[str]
+            List of ancestor run IDs
+        """
         run = self.runs_by_id[run_id]
 
         ancestor_ids: List[str] = []
@@ -132,18 +196,26 @@ class Graph:
 
         return ancestor_ids
 
-    def get_run_descendant_ids(self, run_id: str) -> List[str]:
+    @memoized_indexed
+    def _get_run_descendant_ids(self, run_id: str) -> List[str]:
+        """
+        Get a run's descendant IDs, depth-first.
+        """
         descendant_ids: List[str] = []
 
         child_runs: List[Run] = self.runs_by_parent_id[run_id]
 
         for child_run in child_runs:
             descendant_ids.append(child_run.id)
-            descendant_ids += self.get_run_descendant_ids(child_run.id)
+            descendant_ids += self._get_run_descendant_ids(child_run.id)
 
         return descendant_ids
 
-    def get_run_downstream_ids(self, run_id: str) -> List[str]:
+    @memoized_indexed
+    def _get_run_downstream_ids(self, run_id: str) -> List[str]:
+        """
+        Within a given layer, get a run's downstream run IDs, depth-first.
+        """
         output_edges: List[Edge] = self.edges_by_source_id.get(run_id, [])
 
         downstream_ids: List[str] = []
@@ -151,46 +223,93 @@ class Graph:
         for output_edge in output_edges:
             if output_edge.destination_run_id is not None:
                 downstream_ids.append(output_edge.destination_run_id)
-                run_id = output_edge.destination_run_id
-                output_edge = self.edges_by_source_id.get(run_id)
+                downstream_ids += self._get_run_downstream_ids(
+                    output_edge.destination_run_id
+                )
 
         return list(set(downstream_ids))
 
-    def clone_futures_by_original_run_id(
+    def clone_futures(
         self, storage: Storage, reset_from: Optional[str] = None
     ) -> Tuple[
         OrderedDict[str, AbstractFuture],
         Dict[str, Dict[str, Artifact]],
         Dict[str, Artifact],
     ]:
+        """
+        Clones the current graph into new futures.
+
+        Future state is set as follows:
+
+        - If run is RAN or RESOLVED, future state is set accordingly. If
+          reset_from, see behavior below.
+
+        - If run is FAILED, NESTED_FAILED, or CANCELED, future state is set to
+          CREATED
+
+        If reset_from is not None, all ancestor runs are set to RAN or CREATED
+        depending on original run status. Cloned futures of all downstream runs
+        of reset_from are set to CREATED. All descendant runs of all downstream
+        runs of all ancestors are set to CREATED.
+
+        If reset_from is None, only FAILED, NESTED_FAILED, and CANCELED runs
+        will be reset.
+
+        Parameters
+        ----------
+        storage: Storage
+            The storage class to retrieve artifact values and set future.value
+            and future.kwargs appropriately.
+
+        reset_from: Optional[str]
+            Force reset other runs than only failed ones.
+
+        Returns
+        -------
+        Tuple[List[AbstractFuture], Dict[str, Dict[str, Artifact]], Dict[str,
+        Artifact]]
+            A tuple whose first element is a list of cloned futures, grouped by
+            nested layers (outermost first), and sorted by reverse execution
+            order within each layer. The second element is
+
+        """
         value_by_artifact_id: Dict[str, Any] = {}
 
         futures_by_original_id: Dict[str, AbstractFuture] = {}
         input_artifacts: Dict[str, Dict[str, Artifact]] = defaultdict(dict)
         output_artifacts: Dict[str, Artifact] = {}
 
+        # We skip descendants of all downstream of reset point
+        # plus descendants of downstreams of ancestors
+        # The skipped futures will be naturally re-created by the new graph
+        # resolution
         skip_run_ids: List[str] = []
+
+        # reset = forcing future state to CREATED or RAN
+        # Considering reset_from and ancestors runs, we reset the run and
+        # all downstream
         reset_run_ids: List[str] = []
 
         if reset_from is not None:
             reset_run_ids.append(reset_from)
-            # We will skip descendants of all downstream of reset point
-            # plus descendants of downstreams of ancestors
-            ancestor_run_ids = self.get_run_ancestor_ids(reset_from)
+            ancestor_run_ids = self._get_run_ancestor_ids(reset_from)
             reset_run_ids += ancestor_run_ids
 
             for ancestor_run_id in [reset_from] + ancestor_run_ids:
-                downstream_run_ids = self.get_run_downstream_ids(ancestor_run_id)
+                downstream_run_ids = self._get_run_downstream_ids(ancestor_run_id)
                 reset_run_ids += downstream_run_ids
 
                 for downstream_run_id in downstream_run_ids:
-                    downstream_descendant_ids = self.get_run_descendant_ids(
+                    downstream_descendant_ids = self._get_run_descendant_ids(
                         downstream_run_id
                     )
                     skip_run_ids += downstream_descendant_ids
 
         # run order guarantees parents and upstream come first
-        run_ids_by_execution_order = self.run_ids_sorted_by_layer(
+        # This is necessary because we want upstream cloned futures
+        # to be created before downstreams so that the appropriate
+        # kwargs can be built
+        run_ids_by_execution_order = self._run_ids_sorted_by_layer(
             run_sorter=self._execution_order
         )
 
@@ -250,6 +369,7 @@ class Graph:
                         future.value = value
                     break
 
+            # Figuring out parent and nested futures
             if run.parent_id is not None:
                 parent_future = futures_by_original_id[run.parent_id]
                 future.parent_future = parent_future
@@ -266,6 +386,7 @@ class Graph:
 
                             break
 
+            # Settings state for resolved runs unless reset
             if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
                 if run.id not in reset_run_ids:
                     future.state = FutureState.RESOLVED
@@ -275,7 +396,10 @@ class Graph:
         if reset_from is None and len(futures_by_original_id) != len(self.runs):
             raise RuntimeError("Not all futures duplicated")
 
-        run_ids_by_reverse_execution_order = self.run_ids_sorted_by_layer(
+        # We return future sorted by how they would be sorted for a resolution
+        # from scratch: grouped by layer (outermost first), and sorter in reverse
+        # execution order within each layer
+        run_ids_by_reverse_execution_order = self._run_ids_sorted_by_layer(
             run_sorter=self._reverse_execution_order
         )
 

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -22,6 +22,18 @@ EdgesByID = Dict[str, Edge]
 
 @dataclass
 class Graph:
+    """
+    Represents an existing immutable graph.
+
+    Parameters
+    ----------
+    runs: List[Run]
+        The runs in the graph. Unordered.
+    edges: List[Edge]
+        Edges between runs. Unordered.
+    artifacts: List[Artifact]
+        Artifacts attached to edges. Unordered.
+    """
 
     runs: List[Run]
     edges: List[Edge]
@@ -74,7 +86,7 @@ class Graph:
         return self._edge_mappings[1]
 
     @property
-    def edges_by_id(self) -> EdgesByID:
+    def _edges_by_id(self) -> EdgesByID:
         return self._edge_mappings[0]
 
     @memoized_property
@@ -262,7 +274,9 @@ class Graph:
         Artifact]]
             A tuple whose first element is a list of cloned futures, grouped by
             nested layers (outermost first), and sorted by reverse execution
-            order within each layer. The second element is
+            order within each layer. The second element is a mapping of future
+            IDs to input artifacts. The third element is a mapping of future IDs
+            to output artifacts.
 
         """
         value_by_artifact_id: Dict[str, Any] = {}
@@ -368,7 +382,7 @@ class Graph:
             for output_edge in self._edges_by_source_id[run_id]:
                 if output_edge.parent_id is not None:
                     if (
-                        self.edges_by_id[output_edge.parent_id].source_run_id
+                        self._edges_by_id[output_edge.parent_id].source_run_id
                         == run.parent_id
                     ):
                         parent_future.nested_future = future

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -93,9 +93,26 @@ class Graph:
     def runs_sorted_by_layer(self) -> List[Run]:
         runs: List[Run] = []
 
+        def _reverse_execution_order(layer_runs, downstream_run_ids):
+            if len(downstream_run_ids) == 0:
+                return []
+            runs_ = [
+                run
+                for run in layer_runs
+                if all(
+                    edge.destination_run_id in downstream_run_ids
+                    for edge in self.edges_by_source_id[run.id]
+                )
+            ]
+            return runs_ + _reverse_execution_order(
+                layer_runs, [run.id for run in runs_]
+            )
+
         def _add_layer_runs(parent_id: Optional[str]):
             layer_runs: List[Run] = self.runs_by_parent_id[parent_id]
-            runs.extend(layer_runs)
+            runs.extend(_reverse_execution_order(layer_runs, [None]))
+
+            # runs.extend(layer_runs)
             for run in layer_runs:
                 _add_layer_runs(run.id)
 
@@ -158,7 +175,8 @@ class Graph:
             str, Dict[str, str]
         ] = collections.defaultdict(dict)
 
-        # """
+        value_by_artifact_id: Dict[str, Any] = {}
+
         skip_run_ids: List[str] = []
 
         if reset_from is not None:
@@ -175,7 +193,9 @@ class Graph:
 
         # """
         # runs order guarantees parents come first
-        for run in self.runs_sorted_by_layer:
+        sorted_runs = self.runs_sorted_by_layer
+
+        for run in sorted_runs:
 
             if run.id in skip_run_ids:
                 continue
@@ -189,9 +209,15 @@ class Graph:
                     )
                     unresolved_sources_by_run_id[run.id][name] = edge.source_run_id
                 elif edge.artifact_id is not None:
-                    kwargs[name] = get_artifact_value(
-                        self.artifacts_by_id[edge.artifact_id], storage
+                    value = value_by_artifact_id.get(
+                        edge.artifact_id,
+                        get_artifact_value(
+                            self.artifacts_by_id[edge.artifact_id], storage
+                        ),
                     )
+                    value_by_artifact_id[edge.artifact_id] = value
+
+                    kwargs[name] = value
                 else:
                     raise RuntimeError("Should not happen")
 
@@ -260,4 +286,8 @@ class Graph:
         if reset_from is None and len(futures_by_original_id) != len(self.runs):
             raise RuntimeError("Not all futures duplicated")
 
-        return futures_by_original_id
+        return collections.OrderedDict(
+            ((run.id, futures_by_original_id[run.id]) for run in sorted_runs)
+        )
+
+        # return {run.id: futures_by_original_id

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple
 
 # Sematic
-from sematic.abstract_future import AbstractFuture
+from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value
@@ -22,18 +22,26 @@ class Graph:
     artifacts: List[Artifact]
     parent_id: Optional[str] = None
 
+    def _populate_run_mappings(self):
+        _runs_by_id: Dict[str, Run] = {}
+        _runs_by_parent_ids: Dict[Optional[str], List[Run]] = defaultdict(list)
+
+        for run in self.runs:
+            _runs_by_id[run.id] = run
+            _runs_by_parent_ids[run.parent_id].append(run)
+
+        setattr(self, make_cache_name("runs_by_id"), _runs_by_id)
+        setattr(self, make_cache_name("runs_by_parent_ids"), _runs_by_parent_ids)
+
     @memoized_property
     def runs_by_id(self) -> Dict[str, Run]:
-        return {run.id: run for run in self.runs}
+        self._populate_run_mappings()
+        return self.runs_by_id
 
     @memoized_property
     def runs_by_parent_id(self) -> Dict[Optional[str], List[Run]]:
-        _runs_by_parent_id: Dict[Optional[str], List[Run]] = defaultdict(list)
-
-        for run in self.runs:
-            _runs_by_parent_id[run.parent_id].append(run)
-
-        return _runs_by_parent_id
+        self._populate_run_mappings()
+        return self.runs_by_parent_id
 
     def _populate_edge_mappings(self):
         _edges_by_destination_id: Dict[str, List[Edge]] = defaultdict(list)
@@ -62,17 +70,17 @@ class Graph:
         self,
     ) -> Dict[str, List[Edge]]:
         self._populate_edge_mappings()
-        return getattr(self, make_cache_name("edges_by_destination_id"))
+        return self.edges_by_destination_id
 
     @memoized_property
     def edges_by_source_id(self) -> Dict[str, List[Edge]]:
         self._populate_edge_mappings()
-        return getattr(self, make_cache_name("edges_by_source_id"))
+        return self.edges_by_source_id
 
     @memoized_property
     def edges_by_id(self) -> Dict[str, Edge]:
         self._populate_edge_mappings()
-        return getattr(self, make_cache_name("edges_id"))
+        return self.edges_by_id
 
     @memoized_property
     def artifacts_by_id(self) -> Dict[str, Artifact]:
@@ -84,72 +92,34 @@ class Graph:
             for edge in self.edges_by_destination_id[run_id]
         )
 
-    def run_input_edges(self, run_id: str) -> Dict[str, Edge]:
-        return self.edges_by_destination_id[run_id]
-
-    def _reverse_execution_order(
-        self, runs: List[Run], downstream_run_ids: Optional[List[Optional[str]]] = None
-    ):
-        if downstream_run_ids is None:
-            downstream_run_ids = [None]
-
-        upstream_runs = [
-            run
-            for run in runs
-            if all(
-                edge.destination_run_id in downstream_run_ids
-                for edge in self.edges_by_source_id[run.id]
-            )
-            and run.id not in downstream_run_ids
-        ]
-
-        if len(upstream_runs) == 0:
-            return []
-
-        return upstream_runs + self._reverse_execution_order(
-            runs, downstream_run_ids + [run.id for run in upstream_runs]
+    def _reverse_execution_order(self, layer_run_ids: List[str]):
+        return _sort_layer_runs(
+            layer_run_ids, _downstream_edge_filter(self.edges_by_source_id)
         )
 
-    def _execution_order(
-        self, runs: List[Run], upstream_run_ids: Optional[List[Optional[str]]] = None
-    ):
-        if upstream_run_ids is None:
-            upstream_run_ids = [None]
-
-        downstream_runs = [
-            run
-            for run in runs
-            if all(
-                edge.source_run_id in upstream_run_ids
-                for edge in self.edges_by_destination_id[run.id]
-            )
-            and run.id not in upstream_run_ids
-        ]
-        if len(downstream_runs) == 0:
-            return []
-
-        return downstream_runs + self._execution_order(
-            runs, upstream_run_ids + [run.id for run in downstream_runs]
+    def _execution_order(self, layer_run_ids: List[str]) -> List[str]:
+        return _sort_layer_runs(
+            layer_run_ids, _upstream_edge_filter(self.edges_by_destination_id)
         )
 
-    def runs_sorted_by_layer(
-        self, run_sorter: Callable[[List[Run]], List[Run]]
-    ) -> List[Run]:
-        runs: List[Run] = []
+    def run_ids_sorted_by_layer(
+        self, run_sorter: Callable[[List[str]], List[str]]
+    ) -> List[str]:
+        run_ids: List[str] = []
 
         def _add_layer_runs(parent_id: Optional[str]):
-            layer_runs: List[Run] = self.runs_by_parent_id[parent_id]
-            ordered_layer_runs = run_sorter(layer_runs)
-            if len(ordered_layer_runs) != len(layer_runs):
-                raise RuntimeError("Missing runs in ordered layer runs list")
-            runs.extend(ordered_layer_runs)
+            layer_run_ids: List[str] = [
+                run.id for run in self.runs_by_parent_id[parent_id]
+            ]
+            ordered_layer_run_ids = run_sorter(layer_run_ids)
+            run_ids.extend(ordered_layer_run_ids)
 
-            for run in ordered_layer_runs:
-                _add_layer_runs(run.id)
+            for run_id in ordered_layer_run_ids:
+                _add_layer_runs(run_id)
 
         _add_layer_runs(None)
 
-        return runs
+        return run_ids
 
     def get_run_ancestor_ids(self, run_id: str) -> List[str]:
         run = self.runs_by_id[run_id]
@@ -200,41 +170,40 @@ class Graph:
         output_artifacts: Dict[str, Artifact] = {}
 
         skip_run_ids: List[str] = []
+        reset_run_ids: List[str] = []
 
         if reset_from is not None:
             # We will skip descendants of all downstream of reset point
             # plus descendants of downstreams of ancestors
             ancestor_run_ids = self.get_run_ancestor_ids(reset_from)
+            reset_run_ids += ancestor_run_ids
+
             for ancestor_run_id in [reset_from] + ancestor_run_ids:
                 downstream_run_ids = self.get_run_downstream_ids(ancestor_run_id)
+                reset_run_ids += downstream_run_ids
+
                 for downstream_run_id in downstream_run_ids:
                     downstream_descendant_ids = self.get_run_descendant_ids(
                         downstream_run_id
                     )
                     skip_run_ids += downstream_descendant_ids
 
-        # runs order guarantees parents come first
-        run_by_execution_order = self.runs_sorted_by_layer(self._execution_order)
+        # run order guarantees parents and upstream come first
+        run_ids_by_execution_order = self.run_ids_sorted_by_layer(
+            run_sorter=self._execution_order
+        )
 
-        def _get_edge_artifact(edge: Edge):
-            if edge.artifact_id is None:
-                return None
+        for run_id in run_ids_by_execution_order:
 
-            return value_by_artifact_id.get(
-                edge.artifact_id,
-                get_artifact_value(self.artifacts_by_id[edge.artifact_id], storage),
-            )
-
-        for run in run_by_execution_order:
-
-            if run.id in skip_run_ids:
+            if run_id in skip_run_ids:
                 continue
 
+            run = self.runs_by_id[run_id]
+
+            # Figuring out input kwargs and artifacts
             kwargs: Dict[str, Any] = {}
-            func = run.get_func()
 
             input_edges = self.edges_by_destination_id[run.id]
-            output_edges = self.edges_by_source_id[run.id]
 
             run_input_artifacts: Dict[str, Artifact] = {}
 
@@ -242,12 +211,12 @@ class Graph:
                 value = None
                 if edge.artifact_id is not None:
                     artifact = self.artifacts_by_id[edge.artifact_id]
-                    run_input_artifacts[edge.destination_name] = artifact
                     if edge.artifact_id not in value_by_artifact_id:
                         value_by_artifact_id[edge.artifact_id] = get_artifact_value(
                             artifact, storage
                         )
                     value = value_by_artifact_id[edge.artifact_id]
+                    run_input_artifacts[edge.destination_name] = artifact
 
                 if edge.source_run_id is not None:
                     kwargs[edge.destination_name] = futures_by_original_id[
@@ -258,15 +227,25 @@ class Graph:
                 else:
                     raise RuntimeError("Should not happen")
 
+            func = run.get_func()
+
             future = func(**kwargs)
 
             input_artifacts[future.id] = run_input_artifacts
+
+            # Figuring out future output values and artifacts
+            output_edges = self.edges_by_source_id[run.id]
 
             for output_edge in output_edges:
                 if output_edge.artifact_id is not None:
                     artifact = self.artifacts_by_id[output_edge.artifact_id]
                     output_artifacts[future.id] = artifact
-                    value = _get_edge_artifact(output_edge)
+                    value = value_by_artifact_id.get(
+                        edge.artifact_id,
+                        get_artifact_value(
+                            self.artifacts_by_id[edge.artifact_id], storage
+                        ),
+                    )
                     future.value = value
                     value_by_artifact_id[output_edge.artifact_id] = value
                 break
@@ -281,25 +260,77 @@ class Graph:
                             == run.parent_id
                         ):
                             parent_future.nested_future = future
+                            parent_future.state = FutureState.RAN
                             break
+
+            if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
+                if run.id not in reset_run_ids:
+                    future.state = FutureState.RESOLVED
 
             futures_by_original_id[run.id] = future
 
         if reset_from is None and len(futures_by_original_id) != len(self.runs):
             raise RuntimeError("Not all futures duplicated")
 
-        run_by_reverse_execution_order = self.runs_sorted_by_layer(
-            self._reverse_execution_order
+        run_ids_by_reverse_execution_order = self.run_ids_sorted_by_layer(
+            run_sorter=self._reverse_execution_order
         )
 
         return (
             collections.OrderedDict(
                 (
-                    (run.id, futures_by_original_id[run.id])
-                    for run in run_by_reverse_execution_order
-                    if run.id in futures_by_original_id
+                    (run_id, futures_by_original_id[run_id])
+                    for run_id in run_ids_by_reverse_execution_order
+                    if run_id in futures_by_original_id
                 )
             ),
             input_artifacts,
             output_artifacts,
         )
+
+
+EdgeFilterCallable = Callable[[List[Optional[str]], str], bool]
+
+
+def _upstream_edge_filter(
+    edges_by_destination_id: Dict[str, List[Edge]]
+) -> EdgeFilterCallable:
+    def _edge_filter(upstream_run_ids: List[Optional[str]], run_id: str):
+        return all(
+            edge.source_run_id in upstream_run_ids
+            for edge in edges_by_destination_id[run_id]
+        )
+
+    return _edge_filter
+
+
+def _downstream_edge_filter(
+    edges_by_source_id: Dict[str, List[Edge]]
+) -> EdgeFilterCallable:
+    def _edge_filter(downstream_run_ids: List[Optional[str]], run_id: str):
+        return all(
+            edge.destination_run_id in downstream_run_ids
+            for edge in edges_by_source_id[run_id]
+        )
+
+    return _edge_filter
+
+
+def _sort_layer_runs(
+    layer_run_ids: List[str], edge_filter: EdgeFilterCallable
+) -> List[str]:
+    def _find_next_runs(previous_run_ids: List[Optional[str]]):
+        next_run_ids = [
+            run_id
+            for run_id in layer_run_ids
+            if edge_filter(previous_run_ids, run_id) and run_id not in previous_run_ids
+        ]
+
+        if len(next_run_ids) == 0:
+            return []
+
+        return next_run_ids + _find_next_runs(
+            previous_run_ids + next_run_ids  # type: ignore
+        )
+
+    return _find_next_runs([None])

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -323,8 +323,8 @@ class Graph:
         """
         Figures out what run IDs to skip or reset based on rerun_from.
 
-        We skip descendants of all downstream of reset point plus descendants of
-        downstreams of ancestors. The skipped futures will be naturally
+        We skip descendants of reset point and descendants of downstreams of
+        reset point and ancestors. The skipped futures will be naturally
         re-created by the new graph resolution.
 
         reset = forcing future state to CREATED or RAN. Considering reset_from
@@ -342,7 +342,7 @@ class Graph:
             cloning the graph. The second element is the list of run IDs whose
             cloned future's state to reset to CREATED.
         """
-        skip_run_ids: List[RunID] = []
+        skip_run_ids: List[RunID] = self._get_run_descendant_ids(reset_from)
 
         reset_run_ids: List[RunID] = [reset_from]
 

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -25,6 +25,26 @@ class Graph:
     """
     Represents an existing immutable graph.
 
+    Nomenclature
+    ------------
+    Parent run
+        The run corresponding to the function calling the current run's function
+    Child run
+        The run corresponding to the function being called by the current run's
+        function
+    Ancestor runs
+        All parents going up to the root
+    Descendant runs
+        All children down to the leaves
+    Upstream runs
+        Within a given layer, runs corresponding to functions being called prior
+        to the current run's function. Current function depends on outputs of
+        upstream runs.
+    Downstream runs
+        Within a given layer, runs corresponding to functions being called after
+        the current run's function. Downstream runs depend on outputs of current
+        function.
+
     Parameters
     ----------
     runs: List[Run]
@@ -96,7 +116,7 @@ class Graph:
     def input_artifacts_ready(self, run_id: RunID) -> bool:
         """
         Does run have all input artifacts ready, i.e. upstream runs have
-        resolved?
+        resolved? Uses in-memory graph artifacts, does not fetch them from the DB.
         """
         return all(
             edge.artifact_id is not None
@@ -109,7 +129,8 @@ class Graph:
         return run_ids in order of execution, i.e. upstream runs first,
         downstream runs next. This is not deterministic, as multiple runs may
         have the same set of upstream runs, and thus can be executed in
-        parallel.
+        parallel. It thus is not suitable to determine whether one run is a
+        dependency of another.
 
         Parameters
         ----------
@@ -117,16 +138,20 @@ class Graph:
             IDs of runs in the layer. All runs are epxected to have the same
             parent_id.
         """
+        if len({self._runs_by_id[run_id].parent_id for run_id in layer_run_ids}) > 1:
+            raise ValueError("Runs are not all from the same layer")
+
         return _sort_layer_runs(
             layer_run_ids, _upstream_edge_filter(self._edges_by_destination_id)
         )
 
-    def _reverse_execution_order(self, layer_run_ids: List[RunID]):
+    def _reverse_execution_order(self, layer_run_ids: List[RunID]) -> List[RunID]:
         """
         For a given graph layer (all runs have the same parent_id), this will
         return run_ids in order of reverse execution, i.e. downstream first,
         upstream runs next. This is not deterministic, as runs may have multiple
-        upstream runs.
+        upstream runs. It thus is not suitable to determine whether one run is a
+        dependency of another.
 
         Parameters
         ----------
@@ -134,17 +159,20 @@ class Graph:
             IDs of runs in the layer. All runs are epxected to have the same
             parent_id.
         """
+        if len({self._runs_by_id[run_id].parent_id for run_id in layer_run_ids}) > 1:
+            raise ValueError("Runs are not all from the same layer")
+
         return _sort_layer_runs(
             layer_run_ids, _downstream_edge_filter(self._edges_by_source_id)
         )
 
-    def _run_ids_sorted_by_layer(
+    def _sorted_run_ids_by_layer(
         self, run_sorter: Callable[[List[RunID]], List[RunID]]
     ) -> List[RunID]:
         """
         Run IDs grouped by parent_ids, with parent_ids sorted from outermost
         (None) to innermost. This is not deterministic as multiple layers may
-        have the same parent_id.
+        have the same parent_id. Breadth-first sorting.
 
         Within a layer, runs are sorted with the run_sorter input callable.
 
@@ -233,6 +261,50 @@ class Graph:
 
         return list(set(downstream_ids))
 
+    def _get_skip_reset_run_ids(
+        self, reset_from: RunID
+    ) -> Tuple[List[RunID], List[RunID]]:
+        """
+        Figures out what run IDs to skip or reset based on rerun_from.
+
+        We skip descendants of all downstream of reset point plus descendants of
+        downstreams of ancestors. The skipped futures will be naturally
+        re-created by the new graph resolution.
+
+        reset = forcing future state to CREATED or RAN. Considering reset_from
+        and ancestors runs, we reset the run and all downstream.
+
+        Parameters
+        ----------
+        reset_from: RunID
+            ID of run from which to reset the graph
+
+        Returns
+        -------
+        Tuple[List[RunID], List[RunID]]
+            A tuple whose first element is the list of run IDs to skip when
+            cloning the graph. The second element is the list of run IDs whose
+            cloned future's state to reset to CREATED.
+        """
+        skip_run_ids: List[RunID] = []
+
+        reset_run_ids: List[RunID] = [reset_from]
+
+        ancestor_run_ids = self._get_run_ancestor_ids(reset_from)
+        reset_run_ids += ancestor_run_ids
+
+        for ancestor_run_id in [reset_from] + ancestor_run_ids:
+            downstream_run_ids = self._get_run_downstream_ids(ancestor_run_id)
+            reset_run_ids += downstream_run_ids
+
+            for downstream_run_id in downstream_run_ids:
+                downstream_descendant_ids = self._get_run_descendant_ids(
+                    downstream_run_id
+                )
+                skip_run_ids += downstream_descendant_ids
+
+        return skip_run_ids, reset_run_ids
+
     def clone_futures(
         self, storage: Storage, reset_from: Optional[RunID] = None
     ) -> Tuple[
@@ -246,7 +318,7 @@ class Graph:
         Future state is set as follows:
 
         - If run is RAN or RESOLVED, future state is set accordingly. If
-          reset_from, see behavior below.
+          reset_from is not None, see behavior below.
 
         - If run is FAILED, NESTED_FAILED, or CANCELED, future state is set to
           CREATED
@@ -285,37 +357,15 @@ class Graph:
         input_artifacts: Dict[RunID, Dict[str, Artifact]] = defaultdict(dict)
         output_artifacts: Dict[RunID, Artifact] = {}
 
-        # We skip descendants of all downstream of reset point
-        # plus descendants of downstreams of ancestors
-        # The skipped futures will be naturally re-created by the new graph
-        # resolution
-        skip_run_ids: List[RunID] = []
-
-        # reset = forcing future state to CREATED or RAN
-        # Considering reset_from and ancestors runs, we reset the run and
-        # all downstream
-        reset_run_ids: List[RunID] = []
-
-        if reset_from is not None:
-            reset_run_ids.append(reset_from)
-            ancestor_run_ids = self._get_run_ancestor_ids(reset_from)
-            reset_run_ids += ancestor_run_ids
-
-            for ancestor_run_id in [reset_from] + ancestor_run_ids:
-                downstream_run_ids = self._get_run_downstream_ids(ancestor_run_id)
-                reset_run_ids += downstream_run_ids
-
-                for downstream_run_id in downstream_run_ids:
-                    downstream_descendant_ids = self._get_run_descendant_ids(
-                        downstream_run_id
-                    )
-                    skip_run_ids += downstream_descendant_ids
+        skip_run_ids, reset_run_ids = (
+            ([], []) if reset_from is None else self._get_skip_reset_run_ids(reset_from)
+        )
 
         # run order guarantees parents and upstream come first
         # This is necessary because we want upstream cloned futures
         # to be created before downstreams so that the appropriate
         # kwargs can be built
-        run_ids_by_execution_order = self._run_ids_sorted_by_layer(
+        run_ids_by_execution_order = self._sorted_run_ids_by_layer(
             run_sorter=self._execution_order
         )
 
@@ -354,7 +404,9 @@ class Graph:
                 elif input_edge.artifact_id is not None:
                     kwargs[input_edge.destination_name] = value
                 else:
-                    raise RuntimeError("Should not happen")
+                    raise RuntimeError(
+                        "Invalid input edge had no source run or associated artifact"
+                    )
 
             return kwargs, run_input_artifacts
 
@@ -430,7 +482,7 @@ class Graph:
         # We return future sorted by how they would be sorted for a resolution
         # from scratch: grouped by layer (outermost first), and sorter in reverse
         # execution order within each layer
-        run_ids_by_reverse_execution_order = self._run_ids_sorted_by_layer(
+        run_ids_by_reverse_execution_order = self._sorted_run_ids_by_layer(
             run_sorter=self._reverse_execution_order
         )
 
@@ -477,6 +529,17 @@ def _downstream_edge_filter(
 def _sort_layer_runs(
     layer_run_ids: List[RunID], edge_filter: EdgeFilterCallable
 ) -> List[str]:
+    """
+    Sort runs within layer.
+
+    Parameters
+    ----------
+    layer_run_ids: List[RunID]
+        All run IDs in the layer
+    edge_filter: EdgeFilterCallable
+        A callable to determine the next set of run IDs based on their edges.
+    """
+
     def _find_next_runs(previous_run_ids: List[Optional[RunID]]):
         next_run_ids = [
             run_id

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -13,7 +13,7 @@ from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.run import Run
 from sematic.storage import Storage
 from sematic.utils.memoized_property import memoized_indexed, memoized_property
-from sematic.utils.sorting import topological_sort
+from sematic.utils.sorting import breadth_first, topological_sort
 
 RunID = str
 RunsByID = Dict[RunID, Run]
@@ -251,21 +251,12 @@ class Graph:
         List[str]
             A flat list of run IDs.
         """
-        run_ids: List[str] = []
+        layers = {
+            parent_id: [run.id for run in runs]
+            for parent_id, runs in self._runs_by_parent_id.items()
+        }
 
-        def _add_layer_runs(parent_id: Optional[RunID]):
-            layer_run_ids: List[RunID] = [
-                run.id for run in self._runs_by_parent_id[parent_id]
-            ]
-            ordered_layer_run_ids = run_sorter(layer_run_ids)
-            run_ids.extend(ordered_layer_run_ids)
-
-            for run_id in ordered_layer_run_ids:
-                _add_layer_runs(run_id)
-
-        _add_layer_runs(None)
-
-        return run_ids
+        return breadth_first(layers, run_sorter)
 
     @memoized_indexed
     def _get_run_ancestor_ids(self, run_id: RunID) -> List[RunID]:

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -11,6 +11,7 @@ sematic_py_lib(
         "//sematic:abstract_future",
         "//sematic:api_client",
         "//sematic:config",
+        "//sematic:graph",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -215,7 +215,7 @@ class CloudResolver(LocalResolver):
 
         # SUBMIT RESOLUTION JOB
         api_client.schedule_resolution(
-            future.id,
+            resolution_id=future.id,
             max_parallelism=self._max_parallelism,
             rerun_from=self._rerun_from_run_id,
         )

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -8,7 +8,6 @@ import cloudpickle
 
 # Sematic
 import sematic.api_client as api_client
-import sematic.storage as storage
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.container_images import (
     DEFAULT_BASE_IMAGE_TAG,
@@ -21,6 +20,7 @@ from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.resolvers.local_resolver import LocalResolver, make_edge_key
+from sematic.storage import S3Storage
 from sematic.utils.exceptions import format_exception_for_run
 from sematic.utils.memoized_property import memoized_property
 
@@ -99,8 +99,7 @@ class CloudResolver(LocalResolver):
         # this is the tag we use to find the resolution image
         self._base_image_tag = _base_image_tag or DEFAULT_BASE_IMAGE_TAG
 
-        # TODO: Replace this with a cloud storage engine
-        self._store_artifacts = True
+        self._storage = S3Storage()
 
         self._output_artifacts_by_run_id: Dict[str, Artifact] = {}
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -245,7 +245,7 @@ class CloudResolver(LocalResolver):
             return
 
         if run.nested_future_id is not None:
-            pickled_nested_future = storage.get(
+            pickled_nested_future = self._storage.get(
                 make_nested_future_storage_key(run.nested_future_id)
             )
             value = cloudpickle.loads(pickled_nested_future)

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -254,7 +254,7 @@ class CloudResolver(LocalResolver):
             output_edge = self._get_output_edges(run.id)[0]
             output_artifact = self._artifacts[output_edge.artifact_id]
             self._output_artifacts_by_run_id[run.id] = output_artifact
-            value = get_artifact_value(output_artifact)
+            value = get_artifact_value(output_artifact, storage=self._storage)
 
         self._update_future_with_value(future, value)
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -74,8 +74,9 @@ class CloudResolver(LocalResolver):
         max_parallelism: Optional[int] = None,
         _is_running_remotely: bool = False,
         _base_image_tag: str = "default",
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(**kwargs)
 
         # detach:
         #   True: default, the user wants to submit a detached resolution
@@ -214,7 +215,9 @@ class CloudResolver(LocalResolver):
 
         # SUBMIT RESOLUTION JOB
         api_client.schedule_resolution(
-            resolution_id=future.id, max_parallelism=self._max_parallelism
+            future.id,
+            max_parallelism=self._max_parallelism,
+            rerun_from=self._rerun_from_run_id,
         )
 
         return run.id

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -77,7 +77,12 @@ class LocalResolver(SilentResolver):
 
         runs, artifacts, edges = api_client.get_graph(run.root_id, root=True)
 
-        graph = Graph(runs=runs, artifacts=artifacts, edges=edges)
+        graph = Graph(
+            runs=runs,
+            artifacts=artifacts,
+            edges=edges,
+            storage=self._storage,
+        )
 
         if not graph.input_artifacts_ready(run.id):
             raise ValueError(
@@ -86,23 +91,14 @@ class LocalResolver(SilentResolver):
 
         logger.info(f"Attempting to rerun from {from_run_id}")
 
-        cloned_futures, input_artifacts, output_artifacts = graph.clone_futures(
-            storage=self._storage,
+        cloned_graph = graph.clone_futures(
             reset_from=from_run_id,
         )
 
         # Making sure we honor id of future passed from the outside
-        cloned_root_future = cloned_futures[run.root_id]
+        cloned_graph.set_root_future_id(future.id)
 
-        if cloned_root_future.id in input_artifacts:
-            input_artifacts[future.id] = input_artifacts[cloned_root_future.id]
-
-        if cloned_root_future.id in output_artifacts:
-            output_artifacts[future.id] = output_artifacts[cloned_root_future.id]
-
-        cloned_root_future.id = future.id
-
-        self._futures = list(cloned_futures.values())
+        self._futures = list(cloned_graph.futures_by_original_id.values())
 
         for future in self._futures:
             future.resolved_kwargs = self._get_resolved_kwargs(future)
@@ -110,10 +106,10 @@ class LocalResolver(SilentResolver):
             run_output_artifact = None
 
             if future.state == FutureState.RESOLVED:
-                run_output_artifact = output_artifacts[future.id]
+                run_output_artifact = cloned_graph.output_artifacts[future.id]
 
             if future.state in {FutureState.RESOLVED, FutureState.RAN}:
-                run_input_artifacts = input_artifacts[future.id]
+                run_input_artifacts = cloned_graph.input_artifacts[future.id]
 
             self._populate_graph(
                 future,
@@ -278,6 +274,8 @@ class LocalResolver(SilentResolver):
 
         if future.nested_future is None:
             raise Exception("Missing nested future")
+
+        run.nested_future_id = future.nested_future.id
 
         self._populate_graph(future.nested_future)
         self._add_run(run)

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -95,30 +95,9 @@ class LocalResolver(SilentResolver):
             storage=self._storage,
             reset_from=self._rerun_from_run_id,
         )
-        """
-        # Now setting the appropriate future states
-        ancestor_run_ids = graph.get_run_ancestor_ids(self._rerun_from_run_id)
-        all_downstream_run_ids = []
-        for ancestor_run_id in [self._rerun_from_run_id] + ancestor_run_ids:
-            all_downstream_run_ids += graph.get_run_downstream_ids(ancestor_run_id)
-
-        run_ids_to_reset = (
-            ancestor_run_ids + all_downstream_run_ids + [self._rerun_from_run_id]
-        )
-        """
 
         self._futures = list(futures_by_original_id.values())
 
-        """
-        for original_run_id, future in futures_by_original_id.items():
-            if future.nested_future is not None:
-                future.state = FutureState.RAN
-
-            original_run = graph.runs_by_id[original_run_id]
-            if FutureState[original_run.future_state] == FutureState.RESOLVED:
-                if original_run_id not in run_ids_to_reset:
-                    future.state = FutureState.RESOLVED
-        """
         for future in futures_by_original_id.values():
             future.resolved_kwargs = self._get_resolved_kwargs(future)
             run_input_artifacts: Dict[str, Artifact] = {}

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -60,6 +60,10 @@ class LocalResolver(SilentResolver):
             self._seed_from_clone(future, self._rerun_from_run_id)
 
     def _seed_from_clone(self, future: AbstractFuture, from_run_id: str):
+        """
+        Instead of simply queuing the root future, this method seeds the future graph
+        from a clone of another execution of same pipeline.
+        """
         try:
             run = api_client.get_run(from_run_id)
         except api_client.ResourceNotFoundError:

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -82,27 +82,32 @@ class LocalResolver(SilentResolver):
 
         logger.info(f"Attempting to rerun from {from_run_id}")
 
-        (
-            futures_by_original_id,
-            input_artifacts,
-            output_artifacts,
-        ) = graph.clone_futures_by_original_run_id(
+        cloned_futures, input_artifacts, output_artifacts = graph.clone_futures(
             storage=self._storage,
             reset_from=from_run_id,
         )
 
-        self._futures = list(futures_by_original_id.values())
-
         # Making sure we honor id of future passed from the outside
-        # This is also the resolution ID
-        self._root_future.id = future.id
+        cloned_root_future = cloned_futures[run.root_id]
 
-        for future in futures_by_original_id.values():
+        if cloned_root_future.id in input_artifacts:
+            input_artifacts[future.id] = input_artifacts[cloned_root_future.id]
+
+        if cloned_root_future.id in output_artifacts:
+            output_artifacts[future.id] = output_artifacts[cloned_root_future.id]
+
+        cloned_root_future.id = future.id
+
+        self._futures = list(cloned_futures.values())
+
+        for future in self._futures:
             future.resolved_kwargs = self._get_resolved_kwargs(future)
             run_input_artifacts: Dict[str, Artifact] = {}
             run_output_artifact = None
+
             if future.state == FutureState.RESOLVED:
                 run_output_artifact = output_artifacts[future.id]
+
             if future.state in {FutureState.RESOLVED, FutureState.RAN}:
                 run_input_artifacts = input_artifacts[future.id]
 

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -57,10 +57,6 @@ class LocalResolver(SilentResolver):
         self._sio_client = socketio.Client()
 
         self._rerun_from_run_id = rerun_from
-        # self._original_graph: Graph
-        # self._original_run_id_to_future: Dict[str, AbstractFuture] = {}
-        # self._future_id_to_original_run_id: Dict[str, str] = {}
-        # self._original_run_ancestor_ids: List[str] = []
 
     def resolve(self, future: AbstractFuture) -> Any:
         if self._rerun_from_run_id is None:

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -19,7 +19,7 @@ from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionS
 from sematic.db.models.run import Run
 from sematic.graph import Graph
 from sematic.resolvers.silent_resolver import SilentResolver
-from sematic.storage import LocalStorage
+from sematic.storage import LocalStorage, Storage
 from sematic.user_settings import get_all_user_settings
 from sematic.utils.exceptions import ExceptionMetadata, format_exception_for_run
 from sematic.utils.git import get_git_info
@@ -47,7 +47,7 @@ class LocalResolver(SilentResolver):
         self._buffer_runs: Dict[str, Run] = {}
         self._buffer_artifacts: Dict[str, Artifact] = {}
 
-        self._storage = LocalStorage()
+        self._storage: Storage = LocalStorage()
 
         self._sio_client = socketio.Client()
 

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -2,7 +2,7 @@
 import datetime
 import logging
 import uuid
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 # Third-party
 import socketio  # type: ignore
@@ -14,12 +14,7 @@ from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.config import get_config
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
-from sematic.db.models.factories import (
-    get_artifact_value,
-    make_artifact,
-    make_func_path,
-    make_run_from_future,
-)
+from sematic.db.models.factories import make_artifact, make_run_from_future
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.graph import Graph

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -94,6 +94,7 @@ class LocalResolver(SilentResolver):
             reset_from=self._rerun_from_run_id,
         )
 
+        """
         # Now setting the appropriate future states
         ancestor_run_ids = graph.get_run_ancestor_ids(self._rerun_from_run_id)
         all_downstream_run_ids = []
@@ -103,9 +104,11 @@ class LocalResolver(SilentResolver):
         run_ids_to_reset = (
             ancestor_run_ids + all_downstream_run_ids + [self._rerun_from_run_id]
         )
+        """
 
         self._futures = list(futures_by_original_id.values())
 
+        """
         for original_run_id, future in futures_by_original_id.items():
             if future.nested_future is not None:
                 future.state = FutureState.RAN
@@ -114,7 +117,7 @@ class LocalResolver(SilentResolver):
             if FutureState[original_run.future_state] == FutureState.RESOLVED:
                 if original_run_id not in run_ids_to_reset:
                     future.state = FutureState.RESOLVED
-
+        """
         for future in futures_by_original_id.values():
             future.resolved_kwargs = self._get_resolved_kwargs(future)
             run_input_artifacts: Dict[str, Artifact] = {}

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -85,6 +85,8 @@ class LocalResolver(SilentResolver):
                 "upstream runs did not succeed."
             )
 
+        logger.info(f"Attempting to rerun from {self._rerun_from_run_id}")
+
         (
             futures_by_original_id,
             input_artifacts,
@@ -134,33 +136,8 @@ class LocalResolver(SilentResolver):
 
         self._save_graph()
 
-        future = self._root_future
-
-        self._register_signal_handlers()
-
-        logger.info(f"Starting resolution {future.id}")
-
-        self._resolution_will_start()
-
-        while not future.state.is_terminal():
-            for future_ in self._futures:
-                if future_.state == FutureState.CREATED:
-                    self._schedule_future_if_args_resolved(future_)
-                if future_.state == FutureState.RETRYING:
-                    self._execute_future(future_)
-                if future_.state == FutureState.RAN:
-                    self._resolve_nested_future(future_)
-
-            self._wait_for_scheduled_run()
-
-        if future.state == FutureState.RESOLVED:
-            self._resolution_did_succeed()
-        elif future.state == FutureState.CANCELED:
-            return
-        else:
-            raise RuntimeError("Unresolved Future after resolver call.")
-
-        return future.value
+        self._resolution_loop()
+        return self._root_future.value
 
     def _update_edge(
         self,

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -66,14 +66,10 @@ class LocalResolver(SilentResolver):
         """
         try:
             run = api_client.get_run(from_run_id)
-        except api_client.ResourceNotFoundError:
-            raise ValueError(f"Cannot restart from {from_run_id}: run cannot be found.")
-
-        if from_run_id == run.root_id:
+        except api_client.ResourceNotFoundError as e:
             raise ValueError(
-                f"Cannot restart from {from_run_id}: "
-                "this is the root run, simply start over"
-            )
+                f"Cannot restart from {from_run_id}: run cannot be found."
+            ) from e
 
         runs, artifacts, edges = api_client.get_graph(run.root_id, root=True)
 
@@ -86,7 +82,7 @@ class LocalResolver(SilentResolver):
 
         if not graph.input_artifacts_ready(run.id):
             raise ValueError(
-                f"Cannot start from {from_run_id}: " "upstream runs did not succeed."
+                f"Cannot start from {from_run_id}: upstream runs did not succeed."
             )
 
         logger.info(f"Attempting to rerun from {from_run_id}")

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -93,7 +93,6 @@ class LocalResolver(SilentResolver):
             storage=self._storage,
             reset_from=self._rerun_from_run_id,
         )
-
         """
         # Now setting the appropriate future states
         ancestor_run_ids = graph.get_run_ancestor_ids(self._rerun_from_run_id)
@@ -133,7 +132,7 @@ class LocalResolver(SilentResolver):
                 output_artifact=run_output_artifact,
             )
 
-        # self._save_graph()
+        self._save_graph()
 
         future = self._root_future
 

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -85,7 +85,11 @@ class LocalResolver(SilentResolver):
                 "upstream runs did not succeed."
             )
 
-        futures_by_original_id = graph.get_duplicate_futures_by_original_run_id(
+        (
+            futures_by_original_id,
+            input_artifacts,
+            output_artifacts,
+        ) = graph.get_duplicate_futures_by_original_run_id(
             storage=self._storage,
             reset_from=self._rerun_from_run_id,
         )
@@ -110,32 +114,25 @@ class LocalResolver(SilentResolver):
             if FutureState[original_run.future_state] == FutureState.RESOLVED:
                 if original_run_id not in run_ids_to_reset:
                     future.state = FutureState.RESOLVED
-                    output_edges = graph.edges_by_source_id[original_run_id]
-                    output_artifact = graph.artifacts_by_id[output_edges[0].artifact_id]
-                    future.value = get_artifact_value(
-                        output_artifact, storage=self._storage
-                    )
 
+        for future in futures_by_original_id.values():
+            future.resolved_kwargs = self._get_resolved_kwargs(future)
+            run_input_artifacts: Dict[str, Artifact] = {}
+            run_output_artifact = None
+            if future.state == FutureState.RESOLVED:
+                run_output_artifact = output_artifacts[future.id]
             if future.state in {FutureState.RESOLVED, FutureState.RAN}:
-                future.resolved_kwargs = self._get_resolved_kwargs(future)
-                self._populate_graph(future)
+                run_input_artifacts = input_artifacts[future.id]
 
-        self._save_graph()
-
-        for original_run_id, future in futures_by_original_id.items():
-            print(original_run_id, future)
-            print("\tkwargs:")
-            for name, value in future.kwargs.items():
-                print(f"\t{name}: {value}")
-        # return
-        future = self._root_future
-        resolved_kwargs = self._get_resolved_kwargs(future)
-        if not len(resolved_kwargs) == len(future.kwargs):
-            raise ValueError(
-                "All input arguments of your root function should be concrete."
+            self._populate_graph(
+                future,
+                input_artifacts=run_input_artifacts,
+                output_artifact=run_output_artifact,
             )
 
-        future.resolved_kwargs = resolved_kwargs
+        # self._save_graph()
+
+        future = self._root_future
 
         self._register_signal_handlers()
 
@@ -191,7 +188,6 @@ class LocalResolver(SilentResolver):
         if edge.artifact_id is None and artifact_id is not None:
             edge.artifact_id = artifact_id
 
-        print(edge)
         self._add_edge(edge)
 
     def _get_input_edge(self, destination_run_id, destination_name) -> Optional[Edge]:
@@ -480,7 +476,6 @@ class LocalResolver(SilentResolver):
         """
         Update the graph based on future.
         """
-        print(f"POPULATE GRAPH FOR {future.id}")
         if future.id not in self._runs:
             run = self._make_run(future)
             self._add_run(run)
@@ -541,8 +536,7 @@ class LocalResolver(SilentResolver):
         # - the output value is input to multiple futures
         # - the future is nested and the parent future has multiple output edges
         output_edges = self._get_output_edges(future.id)
-        print("OUTPUT EDGES")
-        print(output_edges)
+
         # It means we are creating it for the first time
         if len(output_edges) == 0:
             # Let's figure out if the parent future has output edges yet

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -2,7 +2,7 @@
 import datetime
 import logging
 import uuid
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 # Third-party
 import socketio  # type: ignore
@@ -14,10 +14,17 @@ from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.config import get_config
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
-from sematic.db.models.factories import make_artifact, make_run_from_future
+from sematic.db.models.factories import (
+    get_artifact_value,
+    make_artifact,
+    make_func_path,
+    make_run_from_future,
+)
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
+from sematic.graph import Graph
 from sematic.resolvers.silent_resolver import SilentResolver
+from sematic.storage import LocalStorage
 from sematic.user_settings import get_all_user_settings
 from sematic.utils.exceptions import ExceptionMetadata, format_exception_for_run
 from sematic.utils.git import get_git_info
@@ -33,7 +40,7 @@ class LocalResolver(SilentResolver):
     input argument and output value is tracked as an artifact.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, rerun_from: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
 
         self._edges: Dict[str, Edge] = {}
@@ -45,10 +52,195 @@ class LocalResolver(SilentResolver):
         self._buffer_runs: Dict[str, Run] = {}
         self._buffer_artifacts: Dict[str, Artifact] = {}
 
-        # TODO: Replace this with a local storage engine
-        self._store_artifacts = False
+        self._storage = LocalStorage()
 
         self._sio_client = socketio.Client()
+
+        self._rerun_from_run_id = rerun_from
+        # self._original_graph: Graph
+        # self._original_run_id_to_future: Dict[str, AbstractFuture] = {}
+        # self._future_id_to_original_run_id: Dict[str, str] = {}
+        # self._original_run_ancestor_ids: List[str] = []
+
+    def resolve(self, future: AbstractFuture) -> Any:
+        if self._rerun_from_run_id is None:
+            return super().resolve(future)
+
+        try:
+            run = api_client.get_run(self._rerun_from_run_id)
+        except api_client.ResourceNotFoundError:
+            raise ValueError(
+                f"Cannot restart from {self._rerun_from_run_id}: run cannot be found."
+            )
+
+        if self._rerun_from_run_id == run.root_id:
+            raise ValueError(
+                f"Cannot restart from {self._rerun_from_run_id}: "
+                "this is the root run, simply start over"
+            )
+
+        runs, artifacts, edges = api_client.get_graph(run.root_id, root=True)
+
+        graph = Graph(runs=runs, artifacts=artifacts, edges=edges)
+
+        if not graph.input_artifacts_ready(run.id):
+            raise ValueError(
+                f"Cannot restart from {self._rerun_from_run_id}: "
+                "upstream runs did not succeed."
+            )
+
+        # self._original_run_ancestor_ids = self._original_graph.get_run_ancestor_ids(
+        #    self._rerun_from_run_id
+        # )
+
+        # """
+        futures_by_original_id = graph.get_duplicate_futures_by_original_run_id(
+            storage=self._storage,
+            reset_from=self._rerun_from_run_id,
+        )
+
+        # Now setting the appropriate future states
+        ancestor_run_ids = graph.get_run_ancestor_ids(self._rerun_from_run_id)
+        all_downstream_run_ids = []
+        for ancestor_run_id in [self._rerun_from_run_id] + ancestor_run_ids:
+            all_downstream_run_ids += graph.get_run_downstream_ids(ancestor_run_id)
+
+        for original_run_id, future in futures_by_original_id.items():
+            if future.nested_future is not None:
+                future.state = FutureState.RAN
+
+            original_run = graph.runs_by_id[original_run_id]
+            if FutureState[original_run.future_state] == FutureState.RESOLVED:
+                if original_run_id in ancestor_run_ids:
+                    continue
+                if original_run_id in all_downstream_run_ids:
+                    continue
+                if original_run_id == self._rerun_from_run_id:
+                    continue
+                future.state = FutureState.RESOLVED
+                output_edges = graph.edges_by_source_id[original_run_id]
+                output_artifact = graph.artifacts_by_id[output_edges[0].artifact_id]
+                future.value = get_artifact_value(
+                    output_artifact, storage=self._storage
+                )
+
+        for original_run_id, future in futures_by_original_id.items():
+            print(original_run_id, future)
+            print("\tkwargs:")
+            for name, value in future.kwargs.items():
+                print(f"\t{name}: {value}")
+
+        self._futures = list(futures_by_original_id.values())
+        # """
+        future = self._root_future
+        resolved_kwargs = self._get_resolved_kwargs(future)
+        if not len(resolved_kwargs) == len(future.kwargs):
+            raise ValueError(
+                "All input arguments of your root function should be concrete."
+            )
+
+        future.resolved_kwargs = resolved_kwargs
+
+        self._register_signal_handlers()
+
+        logger.info(f"Starting resolution {future.id}")
+
+        self._resolution_will_start()
+
+        while not future.state.is_terminal():
+            for future_ in self._futures:
+                if future_.state == FutureState.CREATED:
+                    self._schedule_future_if_args_resolved(future_)
+                if future_.state == FutureState.RETRYING:
+                    self._execute_future(future_)
+                if future_.state == FutureState.RAN:
+                    self._resolve_nested_future(future_)
+
+            self._wait_for_scheduled_run()
+
+        if future.state == FutureState.RESOLVED:
+            self._resolution_did_succeed()
+        elif future.state == FutureState.CANCELED:
+            return
+        else:
+            raise RuntimeError("Unresolved Future after resolver call.")
+
+        return future.value
+
+    def _has_cache(self, future: AbstractFuture) -> bool:
+        if self._rerun_from_run_id is None:
+            return False
+
+        future_parent_id = (
+            future.parent_future.id if future.parent_future is not None else None
+        )
+        original_parent_run_id = (
+            self._future_id_to_original_run_id.get(future_parent_id)
+            if future_parent_id
+            else None
+        )
+        layer_runs = self._original_graph.runs_by_parent_id[original_parent_run_id]
+
+        def _run_matches_future(run: Run, future_: AbstractFuture):
+            if run.calculator_path != make_func_path(future_):
+                return False
+
+            input_edges = self._original_graph.run_input_edges(run.id)
+
+            if set(input_edges) != set(future_.kwargs):
+                return False
+
+            for name, value in future.kwargs.items():
+                input_edge = input_edges[name]
+                if isinstance(value, AbstractFuture):
+                    if input_edge.source_run_id is None:
+                        return False
+                    source_run = self._original_graph.runs_by_id[
+                        input_edge.source_run_id
+                    ]
+                    if not _run_matches_future(source_run, value):
+                        return False
+                else:
+                    if input_edge.source_run_id is not None:
+                        return False
+
+            return True
+
+        matching_runs = [
+            layer_run
+            for layer_run in layer_runs
+            if _run_matches_future(layer_run, future)
+        ]
+
+        if len(matching_runs) == 0:
+            return False
+
+        if len(matching_runs) > 1:
+            raise RuntimeError("Multiple matching runs")
+
+        original_run = matching_runs[0]
+
+        self._original_run_id_to_future[original_run.id] = future
+
+        if FutureState[original_run.future_state] == FutureState.FAILED:
+            return False
+
+        if original_run.id in self._original_run_ancestor_ids:
+            pass
+
+    def __execute_future(self, future: AbstractFuture) -> None:
+        self._future_will_schedule(future)
+
+        if self._has_cache(future):
+            self._set_cached_output(future)
+            return
+
+        if future.props.inline:
+            logger.info("Running inline {}".format(future.calculator))
+            self._run_inline(future)
+        else:
+            logger.info("Scheduling {}".format(future.calculator))
+            self._schedule_future(future)
 
     def _update_edge(
         self,
@@ -109,7 +301,7 @@ class LocalResolver(SilentResolver):
         input_artifacts = {}
         for name, value in future.resolved_kwargs.items():
             artifact = make_artifact(
-                value, future.calculator.input_types[name], store=self._store_artifacts
+                value, future.calculator.input_types[name], storage=self._storage
             )
             self._add_artifact(artifact)
             input_artifacts[name] = artifact
@@ -222,7 +414,9 @@ class LocalResolver(SilentResolver):
 
         output_artifact = self._get_output_artifact(future.id)
         if output_artifact is None:
-            output_artifact = make_artifact(future.value, future.calculator.output_type)
+            output_artifact = make_artifact(
+                future.value, future.calculator.output_type, storage=self._storage
+            )
             self._add_artifact(output_artifact)
 
         self._populate_graph(future, output_artifact=output_artifact)

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -57,11 +57,9 @@ class LocalResolver(SilentResolver):
         if self._rerun_from_run_id is None:
             super()._seed_graph(future)
         else:
-            self._seed_from_clone(self._rerun_from_run_id)
-            # Making sure we honor id of future passed from the outside.
-            self._root_future.id = future.id
+            self._seed_from_clone(future, self._rerun_from_run_id)
 
-    def _seed_from_clone(self, from_run_id: str):
+    def _seed_from_clone(self, future: AbstractFuture, from_run_id: str):
         try:
             run = api_client.get_run(from_run_id)
         except api_client.ResourceNotFoundError:
@@ -94,6 +92,10 @@ class LocalResolver(SilentResolver):
         )
 
         self._futures = list(futures_by_original_id.values())
+
+        # Making sure we honor id of future passed from the outside
+        # This is also the resolution ID
+        self._root_future.id = future.id
 
         for future in futures_by_original_id.values():
             future.resolved_kwargs = self._get_resolved_kwargs(future)

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -58,20 +58,23 @@ class LocalResolver(SilentResolver):
 
         self._rerun_from_run_id = rerun_from
 
-    def resolve(self, future: AbstractFuture) -> Any:
+    def _seed_graph(self, future: AbstractFuture):
         if self._rerun_from_run_id is None:
-            return super().resolve(future)
+            super()._seed_graph(future)
+        else:
+            self._seed_from_clone(self._rerun_from_run_id)
+            # Making sure we honor id of future passed from the outside.
+            self._root_future.id = future.id
 
+    def _seed_from_clone(self, from_run_id: str):
         try:
-            run = api_client.get_run(self._rerun_from_run_id)
+            run = api_client.get_run(from_run_id)
         except api_client.ResourceNotFoundError:
-            raise ValueError(
-                f"Cannot restart from {self._rerun_from_run_id}: run cannot be found."
-            )
+            raise ValueError(f"Cannot restart from {from_run_id}: run cannot be found.")
 
-        if self._rerun_from_run_id == run.root_id:
+        if from_run_id == run.root_id:
             raise ValueError(
-                f"Cannot restart from {self._rerun_from_run_id}: "
+                f"Cannot restart from {from_run_id}: "
                 "this is the root run, simply start over"
             )
 
@@ -81,19 +84,18 @@ class LocalResolver(SilentResolver):
 
         if not graph.input_artifacts_ready(run.id):
             raise ValueError(
-                f"Cannot restart from {self._rerun_from_run_id}: "
-                "upstream runs did not succeed."
+                f"Cannot start from {from_run_id}: " "upstream runs did not succeed."
             )
 
-        logger.info(f"Attempting to rerun from {self._rerun_from_run_id}")
+        logger.info(f"Attempting to rerun from {from_run_id}")
 
         (
             futures_by_original_id,
             input_artifacts,
             output_artifacts,
-        ) = graph.get_duplicate_futures_by_original_run_id(
+        ) = graph.clone_futures_by_original_run_id(
             storage=self._storage,
-            reset_from=self._rerun_from_run_id,
+            reset_from=from_run_id,
         )
 
         self._futures = list(futures_by_original_id.values())
@@ -114,9 +116,6 @@ class LocalResolver(SilentResolver):
             )
 
         self._save_graph()
-
-        self._resolution_loop()
-        return self._root_future.value
 
     def _update_edge(
         self,

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -85,11 +85,6 @@ class LocalResolver(SilentResolver):
                 "upstream runs did not succeed."
             )
 
-        # self._original_run_ancestor_ids = self._original_graph.get_run_ancestor_ids(
-        #    self._rerun_from_run_id
-        # )
-
-        # """
         futures_by_original_id = graph.get_duplicate_futures_by_original_run_id(
             storage=self._storage,
             reset_from=self._rerun_from_run_id,
@@ -101,33 +96,38 @@ class LocalResolver(SilentResolver):
         for ancestor_run_id in [self._rerun_from_run_id] + ancestor_run_ids:
             all_downstream_run_ids += graph.get_run_downstream_ids(ancestor_run_id)
 
+        run_ids_to_reset = (
+            ancestor_run_ids + all_downstream_run_ids + [self._rerun_from_run_id]
+        )
+
+        self._futures = list(futures_by_original_id.values())
+
         for original_run_id, future in futures_by_original_id.items():
             if future.nested_future is not None:
                 future.state = FutureState.RAN
 
             original_run = graph.runs_by_id[original_run_id]
             if FutureState[original_run.future_state] == FutureState.RESOLVED:
-                if original_run_id in ancestor_run_ids:
-                    continue
-                if original_run_id in all_downstream_run_ids:
-                    continue
-                if original_run_id == self._rerun_from_run_id:
-                    continue
-                future.state = FutureState.RESOLVED
-                output_edges = graph.edges_by_source_id[original_run_id]
-                output_artifact = graph.artifacts_by_id[output_edges[0].artifact_id]
-                future.value = get_artifact_value(
-                    output_artifact, storage=self._storage
-                )
+                if original_run_id not in run_ids_to_reset:
+                    future.state = FutureState.RESOLVED
+                    output_edges = graph.edges_by_source_id[original_run_id]
+                    output_artifact = graph.artifacts_by_id[output_edges[0].artifact_id]
+                    future.value = get_artifact_value(
+                        output_artifact, storage=self._storage
+                    )
+
+            if future.state in {FutureState.RESOLVED, FutureState.RAN}:
+                future.resolved_kwargs = self._get_resolved_kwargs(future)
+                self._populate_graph(future)
+
+        self._save_graph()
 
         for original_run_id, future in futures_by_original_id.items():
             print(original_run_id, future)
             print("\tkwargs:")
             for name, value in future.kwargs.items():
                 print(f"\t{name}: {value}")
-
-        self._futures = list(futures_by_original_id.values())
-        # """
+        # return
         future = self._root_future
         resolved_kwargs = self._get_resolved_kwargs(future)
         if not len(resolved_kwargs) == len(future.kwargs):
@@ -163,81 +163,6 @@ class LocalResolver(SilentResolver):
 
         return future.value
 
-    def _has_cache(self, future: AbstractFuture) -> bool:
-        if self._rerun_from_run_id is None:
-            return False
-
-        future_parent_id = (
-            future.parent_future.id if future.parent_future is not None else None
-        )
-        original_parent_run_id = (
-            self._future_id_to_original_run_id.get(future_parent_id)
-            if future_parent_id
-            else None
-        )
-        layer_runs = self._original_graph.runs_by_parent_id[original_parent_run_id]
-
-        def _run_matches_future(run: Run, future_: AbstractFuture):
-            if run.calculator_path != make_func_path(future_):
-                return False
-
-            input_edges = self._original_graph.run_input_edges(run.id)
-
-            if set(input_edges) != set(future_.kwargs):
-                return False
-
-            for name, value in future.kwargs.items():
-                input_edge = input_edges[name]
-                if isinstance(value, AbstractFuture):
-                    if input_edge.source_run_id is None:
-                        return False
-                    source_run = self._original_graph.runs_by_id[
-                        input_edge.source_run_id
-                    ]
-                    if not _run_matches_future(source_run, value):
-                        return False
-                else:
-                    if input_edge.source_run_id is not None:
-                        return False
-
-            return True
-
-        matching_runs = [
-            layer_run
-            for layer_run in layer_runs
-            if _run_matches_future(layer_run, future)
-        ]
-
-        if len(matching_runs) == 0:
-            return False
-
-        if len(matching_runs) > 1:
-            raise RuntimeError("Multiple matching runs")
-
-        original_run = matching_runs[0]
-
-        self._original_run_id_to_future[original_run.id] = future
-
-        if FutureState[original_run.future_state] == FutureState.FAILED:
-            return False
-
-        if original_run.id in self._original_run_ancestor_ids:
-            pass
-
-    def __execute_future(self, future: AbstractFuture) -> None:
-        self._future_will_schedule(future)
-
-        if self._has_cache(future):
-            self._set_cached_output(future)
-            return
-
-        if future.props.inline:
-            logger.info("Running inline {}".format(future.calculator))
-            self._run_inline(future)
-        else:
-            logger.info("Scheduling {}".format(future.calculator))
-            self._schedule_future(future)
-
     def _update_edge(
         self,
         source_run_id: Optional[str],
@@ -266,6 +191,7 @@ class LocalResolver(SilentResolver):
         if edge.artifact_id is None and artifact_id is not None:
             edge.artifact_id = artifact_id
 
+        print(edge)
         self._add_edge(edge)
 
     def _get_input_edge(self, destination_run_id, destination_name) -> Optional[Edge]:
@@ -554,6 +480,7 @@ class LocalResolver(SilentResolver):
         """
         Update the graph based on future.
         """
+        print(f"POPULATE GRAPH FOR {future.id}")
         if future.id not in self._runs:
             run = self._make_run(future)
             self._add_run(run)
@@ -614,7 +541,8 @@ class LocalResolver(SilentResolver):
         # - the output value is input to multiple futures
         # - the future is nested and the parent future has multiple output edges
         output_edges = self._get_output_edges(future.id)
-
+        print("OUTPUT EDGES")
+        print(output_edges)
         # It means we are creating it for the first time
         if len(output_edges) == 0:
             # Let's figure out if the parent future has output edges yet

--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 
 # Sematic
 from sematic.config import KUBERNETES_POD_NAME_ENV_VAR
-from sematic.storage import set_from_file
+from sematic.storage import S3Storage
 from sematic.utils.retry import retry
 from sematic.utils.stdout import redirect_to_file
 
@@ -72,7 +72,7 @@ def _do_upload(file_path: str, remote_prefix: str):
     if remote_prefix.endswith("/"):
         remote_prefix = remote_prefix[:-1]
     remote = f"{remote_prefix}/{int(time.time() * 1000)}.log"
-    set_from_file(remote, file_path)
+    S3Storage().set_from_file(remote, file_path)
 
 
 def _start_log_streamer_out_of_process(

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -36,9 +36,17 @@ class StateMachineResolver(Resolver, abc.ABC):
         return self._root_future.value
 
     def _seed_graph(self, future):
+        """
+        Seeds the future graph with future, which is considered the root future.
+        Prior to calling this, `self._root_future` will raise.
+        """
         self._enqueue_root_future(future)
 
     def _resolution_loop(self):
+        """
+        Assuming that the future graph was seeded, this method will proceed
+        through the graph until the root future is resolved.
+        """
         self._register_signal_handlers()
 
         logger.info(f"Starting resolution {self._root_future.id}")

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -37,8 +37,13 @@ class StateMachineResolver(Resolver, abc.ABC):
 
     def _seed_graph(self, future):
         """
-        Seeds the future graph with future, which is considered the root future.
-        Prior to calling this, `self._root_future` will raise.
+        Set the initial futures for the resolution.
+
+        This is a stub that can be
+        overridden by child classes. The resolver will evolve the DAG using this initial
+        set of futures. The root future should always be element 0 of `self._futures`,
+        there are no requirements on order of other futures. The default implementation
+        just seeds with the root future itself and no others.
         """
         self._enqueue_root_future(future)
 

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -29,49 +29,52 @@ class StateMachineResolver(Resolver, abc.ABC):
         return self._futures[0]
 
     def resolve(self, future: AbstractFuture) -> typing.Any:
-        self._enqueue_root_future(future)
-        self._resolution_loop()
+        with self._catch_resolution_errors():
+            self._seed_graph(future)
+            self._resolution_loop()
+
         return self._root_future.value
 
+    def _seed_graph(self, future):
+        self._enqueue_root_future(future)
+
     def _resolution_loop(self):
-        with self._catch_resolution_errors():
+        self._register_signal_handlers()
 
-            self._register_signal_handlers()
+        logger.info(f"Starting resolution {self._root_future.id}")
 
-            logger.info(f"Starting resolution {self._root_future.id}")
+        self._resolution_will_start()
 
-            self._resolution_will_start()
+        while not self._root_future.state.is_terminal():
+            for future_ in self._futures:
+                if future_.state == FutureState.CREATED:
+                    self._schedule_future_if_args_resolved(future_)
+                    continue
+                if future_.state == FutureState.RETRYING:
+                    self._execute_future(future_)
+                    continue
+                if future_.state == FutureState.RAN:
+                    self._resolve_nested_future(future_)
+                    continue
 
-            while not self._root_future.state.is_terminal():
-                for future_ in self._futures:
-                    if future_.state == FutureState.CREATED:
-                        self._schedule_future_if_args_resolved(future_)
-                        continue
-                    if future_.state == FutureState.RETRYING:
-                        self._execute_future(future_)
-                        continue
-                    if future_.state == FutureState.RAN:
-                        self._resolve_nested_future(future_)
-                        continue
+                # should be unreachable code, here for a sanity check
+                if (
+                    future_.state != FutureState.SCHEDULED
+                    and not future_.state.is_terminal()
+                ):
+                    raise RuntimeError(
+                        f"Illegal state: future {future_.id} in state {future_.state}"
+                        " when it should have been already processed"
+                    )
 
-                    # should be unreachable code, here for a sanity check
-                    if (
-                        future_.state != FutureState.SCHEDULED
-                        and not future_.state.is_terminal()
-                    ):
-                        raise RuntimeError(
-                            f"Illegal state: future {future_.id} in state {future_.state}"
-                            " when it should have been already processed"
-                        )
+            self._wait_for_scheduled_runs()
 
-                self._wait_for_scheduled_runs()
-
-            if self._root_future.state == FutureState.RESOLVED:
-                self._resolution_did_succeed()
-            elif self._root_future.state == FutureState.CANCELED:
-                return
-            else:
-                raise RuntimeError("Unresolved Future after resolver call.")
+        if self._root_future.state == FutureState.RESOLVED:
+            self._resolution_did_succeed()
+        elif self._root_future.state == FutureState.CANCELED:
+            return
+        else:
+            raise RuntimeError("Unresolved Future after resolver call.")
 
     @contextmanager
     def _catch_resolution_errors(self):

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -23,19 +23,26 @@ class StateMachineResolver(Resolver, abc.ABC):
 
     @property
     def _root_future(self) -> AbstractFuture:
+        if len(self._futures) == 0:
+            raise RuntimeError("No root future: no futures were enqueued.")
+
         return self._futures[0]
 
     def resolve(self, future: AbstractFuture) -> typing.Any:
+        self._enqueue_root_future(future)
+        self._resolution_loop()
+        return self._root_future.value
+
+    def _resolution_loop(self):
         with self._catch_resolution_errors():
-            self._enqueue_root_future(future)
 
             self._register_signal_handlers()
 
-            logger.info(f"Starting resolution {future.id}")
+            logger.info(f"Starting resolution {self._root_future.id}")
 
             self._resolution_will_start()
 
-            while not future.state.is_terminal():
+            while not self._root_future.state.is_terminal():
                 for future_ in self._futures:
                     if future_.state == FutureState.CREATED:
                         self._schedule_future_if_args_resolved(future_)
@@ -59,14 +66,12 @@ class StateMachineResolver(Resolver, abc.ABC):
 
                 self._wait_for_scheduled_runs()
 
-            if future.state == FutureState.RESOLVED:
+            if self._root_future.state == FutureState.RESOLVED:
                 self._resolution_did_succeed()
-            elif future.state == FutureState.CANCELED:
+            elif self._root_future.state == FutureState.CANCELED:
                 return
             else:
                 raise RuntimeError("Unresolved Future after resolver call.")
-
-            return future.value
 
     @contextmanager
     def _catch_resolution_errors(self):
@@ -88,6 +93,9 @@ class StateMachineResolver(Resolver, abc.ABC):
             )
 
         future.resolved_kwargs = resolved_kwargs
+
+        # Cleaning up
+        self._futures.clear()
 
         self._enqueue_future(future)
 

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -4,6 +4,7 @@ pytest_test(
     deps = [
         "//sematic:abstract_future",
         "//sematic:calculator",
+        "//sematic:retry_settings",
         "//sematic/api/tests:fixtures",
         "//sematic/db/models:edge",
         "//sematic/db/models:resolution",
@@ -12,7 +13,6 @@ pytest_test(
         "//sematic/tests:fixtures",
         "//sematic/types:init",
         "//sematic/utils:exceptions",
-        "//sematic:retry_settings",
     ],
 )
 
@@ -24,7 +24,6 @@ pytest_test(
         "//sematic/utils:retry",
     ],
 )
-
 
 pytest_test(
     name = "test_resource_requirements",
@@ -73,6 +72,17 @@ pytest_test(
         "//sematic/db/tests:fixtures",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:worker",
+        "//sematic/tests:fixtures",
+    ],
+)
+
+sematic_py_lib(
+    name = "fixtures",
+    srcs = ["fixtures.py"],
+    pip_deps = [
+        "pytest",
+    ],
+    deps = [
         "//sematic/tests:fixtures",
     ],
 )

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -2,6 +2,7 @@ pytest_test(
     name = "test_local_resolver",
     srcs = ["test_local_resolver.py"],
     deps = [
+        ":fixtures",
         "//sematic:abstract_future",
         "//sematic:calculator",
         "//sematic:retry_settings",
@@ -48,6 +49,7 @@ pytest_test(
     name = "test_cloud_resolver",
     srcs = ["test_cloud_resolver.py"],
     deps = [
+        ":fixtures",
         "//sematic:api_client",
         "//sematic:calculator",
         "//sematic/api/tests:fixtures",

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -21,6 +21,6 @@ def mock_local_resolver_storage():
 def mock_cloud_resolver_storage():
     mock_storage = MockStorage()
     with mock.patch(
-        "sematic.resolvers.cloud_resolver.CloudStorage", return_value=mock_storage
+        "sematic.resolvers.cloud_resolver.S3Storage", return_value=mock_storage
     ):
         yield mock_storage

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -1,0 +1,26 @@
+# Standard Library
+from unittest import mock
+
+# Third party
+import pytest
+
+# Sematic
+from sematic.tests.fixtures import MockStorage
+
+
+@pytest.fixture
+def mock_local_resolver_storage():
+    mock_storage = MockStorage()
+    with mock.patch(
+        "sematic.resolvers.local_resolver.LocalStorage", return_value=mock_storage
+    ):
+        yield mock_storage
+
+
+@pytest.fixture
+def mock_cloud_resolver_storage():
+    mock_storage = MockStorage()
+    with mock.patch(
+        "sematic.resolvers.cloud_resolver.CloudStorage", return_value=mock_storage
+    ):
+        yield mock_storage

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -18,7 +18,11 @@ from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.resolvers.cloud_resolver import CloudResolver
-from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
+from sematic.tests.fixtures import (  # noqa: F401
+    MockStorage,
+    test_storage,
+    valid_client_version,
+)
 
 
 @func(base_image_tag="cuda", inline=False)
@@ -38,8 +42,10 @@ def pipeline() -> float:
 @mock.patch("sematic.api_client.schedule_run")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
+@mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=MockStorage())
 @mock_no_auth
 def test_simulate_cloud_exec(
+    mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_resolution: mock.MagicMock,
     mock_schedule_run: mock.MagicMock,
@@ -48,7 +54,6 @@ def test_simulate_cloud_exec(
     mock_socketio,
     mock_requests,  # noqa: F811
     test_db,  # noqa: F811
-    test_storage,  # noqa: F811
     valid_client_version,  # noqa: F811
 ):
     # On the user's machine

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -99,7 +99,7 @@ def test_simulate_cloud_exec(
     mock_update_run_future_states.side_effect = fake_update_run_future_states
 
     mock_schedule_resolution.assert_called_once_with(
-        resolution_id=future.id, max_parallelism=None
+        resolution_id=future.id, max_parallelism=None, rerun_from=None
     )
     assert api_client.get_resolution(future.id).status == ResolutionStatus.CREATED.value
 

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -20,11 +20,7 @@ from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.resolvers.cloud_resolver import CloudResolver
 from sematic.resolvers.tests.fixtures import mock_cloud_resolver_storage  # noqa: F401
-from sematic.tests.fixtures import (  # noqa: F401
-    MockStorage,
-    test_storage,
-    valid_client_version,
-)
+from sematic.tests.fixtures import valid_client_version  # noqa: F401
 
 
 @func(base_image_tag="cuda", inline=False)
@@ -38,18 +34,22 @@ def pipeline() -> float:
     return add(1, 2)
 
 
+@mock.patch("sematic.api_client.update_run_future_states")
 @mock.patch("sematic.resolvers.cloud_resolver.get_image_uris")
+@mock.patch("sematic.api_client.schedule_run")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
 def test_simulate_cloud_exec(
     mock_load_kube_config: mock.MagicMock,
-    mock_schedule_job: mock.MagicMock,
-    mock_get_image: mock.MagicMock,
-    mock_cloud_resolver_storage,  # noqa: F811
-    mock_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+    mock_schedule_run: mock.MagicMock,
+    mock_get_images: mock.MagicMock,
+    mock_update_run_future_states: mock.MagicMock,
     mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     mock_requests,  # noqa: F811
     test_db,  # noqa: F811
+    mock_cloud_resolver_storage,  # noqa: F811
     valid_client_version,  # noqa: F811
 ):
     # On the user's machine
@@ -88,7 +88,7 @@ def test_simulate_cloud_exec(
             run.future_state = FutureState.RESOLVED
             updates[run.id] = FutureState.RESOLVED
             edge = driver_resolver._get_output_edges(run.id)[0]
-            artifact = make_artifact(3, int, store=True)
+            artifact = make_artifact(3, int, storage=mock_cloud_resolver_storage)
             edge.artifact_id = artifact.id
             api_client.save_graph(
                 run.id, runs=[run], artifacts=[artifact], edges=[edge]

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -9,8 +9,9 @@ import pytest
 import sematic.api_client as api_client
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
+    mock_auth,
     mock_requests,
+    mock_socketio,
     test_client,
 )
 from sematic.calculator import func
@@ -18,6 +19,7 @@ from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.resolvers.cloud_resolver import CloudResolver
+from sematic.resolvers.tests.fixtures import mock_cloud_resolver_storage  # noqa: F401
 from sematic.tests.fixtures import (  # noqa: F401
     MockStorage,
     test_storage,
@@ -36,22 +38,16 @@ def pipeline() -> float:
     return add(1, 2)
 
 
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.api_client.update_run_future_states")
 @mock.patch("sematic.resolvers.cloud_resolver.get_image_uris")
-@mock.patch("sematic.api_client.schedule_run")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
-@mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=MockStorage())
-@mock_no_auth
 def test_simulate_cloud_exec(
-    mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
-    mock_schedule_resolution: mock.MagicMock,
-    mock_schedule_run: mock.MagicMock,
-    mock_get_images: mock.MagicMock,
-    mock_update_run_future_states: mock.MagicMock,
-    mock_socketio,
+    mock_schedule_job: mock.MagicMock,
+    mock_get_image: mock.MagicMock,
+    mock_cloud_resolver_storage,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
     mock_requests,  # noqa: F811
     test_db,  # noqa: F811
     valid_client_version,  # noqa: F811

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -20,7 +20,7 @@ from sematic.db.queries import get_resolution, get_root_graph, get_run
 from sematic.db.tests.fixtures import pg_mock, test_db  # noqa: F401
 from sematic.resolvers.local_resolver import LocalResolver
 from sematic.retry_settings import RetrySettings
-from sematic.tests.fixtures import valid_client_version  # noqa: F401
+from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
 from sematic.utils.exceptions import ExceptionMetadata
 
 
@@ -43,8 +43,13 @@ def pipeline(a: float, b: float) -> float:
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_single_function(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     future = add(1, 2)
 
@@ -96,8 +101,13 @@ def add_add_add(a: float, b: float) -> float:
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_add_add(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     future = add_add_add(1, 2)
 
@@ -114,8 +124,13 @@ def test_add_add(
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_pipeline(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     future = pipeline(3, 5)
 
@@ -135,8 +150,13 @@ def test_pipeline(
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_failure(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     class CustomException(Exception):
         pass
@@ -172,8 +192,13 @@ def test_failure(
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_resolver_error(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     @func
     def add(x: int, y: int) -> int:
@@ -294,16 +319,26 @@ class DBStateMachineTestResolver(LocalResolver):
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_db_state_machine(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     pipeline(1, 2).resolve(DBStateMachineTestResolver())
 
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_list_conversion(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     @func
     def alist(a: float, b: float) -> List[float]:
@@ -314,7 +349,10 @@ def test_list_conversion(
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
-def test_exceptions(mock_socketio, mock_requests, valid_client_version):  # noqa: F811
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
+def test_exceptions(
+    mock_storage, mock_socketio, mock_requests, valid_client_version  # noqa: F811
+):
     @func
     def fail():
         raise Exception("FAIL!")
@@ -360,8 +398,13 @@ def try_three_times():
 
 @mock_no_auth
 @mock.patch("socketio.Client.connect")
+@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_retry(
-    mock_socketio, test_db, mock_requests, valid_client_version  # noqa: F811
+    mock_storage,
+    mock_socketio,
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     future = try_three_times()
     try:

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -1,6 +1,5 @@
 # Standard Library
 from typing import List
-from unittest import mock
 
 # Third-party
 import pytest
@@ -8,8 +7,9 @@ import pytest
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
+    mock_auth,
     mock_requests,
+    mock_socketio,
     test_client,
 )
 from sematic.calculator import func
@@ -19,8 +19,9 @@ from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.queries import get_resolution, get_root_graph, get_run
 from sematic.db.tests.fixtures import pg_mock, test_db  # noqa: F401
 from sematic.resolvers.local_resolver import LocalResolver
+from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
 from sematic.retry_settings import RetrySettings
-from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
+from sematic.tests.fixtures import valid_client_version  # noqa: F401
 from sematic.utils.exceptions import ExceptionMetadata
 
 
@@ -41,12 +42,10 @@ def pipeline(a: float, b: float) -> float:
     return add(c, d)
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_single_function(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -99,12 +98,10 @@ def add_add_add(a: float, b: float) -> float:
     return add(bb, aa)
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_add_add(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -122,12 +119,10 @@ def test_add_add(
     assert len(edges) == 10
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_pipeline(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -148,12 +143,10 @@ def test_pipeline(
     assert len(edges) == 16
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_failure(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -190,12 +183,10 @@ def test_failure(
         assert future.state == expected_states[future.calculator.__name__]
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_resolver_error(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -317,12 +308,10 @@ class DBStateMachineTestResolver(LocalResolver):
         assert all(edge.artifact_id is None for edge in output_edges)
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_db_state_machine(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -330,12 +319,10 @@ def test_db_state_machine(
     pipeline(1, 2).resolve(DBStateMachineTestResolver())
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_list_conversion(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
@@ -347,11 +334,12 @@ def test_list_conversion(
     assert alist(1, 2).resolve() == [3, 3]
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_exceptions(
-    mock_storage, mock_socketio, mock_requests, valid_client_version  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
 ):
     @func
     def fail():
@@ -396,12 +384,10 @@ def try_three_times():
     raise SomeException()
 
 
-@mock_no_auth
-@mock.patch("socketio.Client.connect")
-@mock.patch("sematic.resolvers.local_resolver.LocalStorage", return_value=MockStorage())
 def test_retry(
-    mock_storage,
-    mock_socketio,
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -1,4 +1,5 @@
 # Standard Library
+from collections import defaultdict
 from typing import List
 
 # Third-party
@@ -419,3 +420,45 @@ def test_make_resolution():
     assert resolution.kind == ResolutionKind.LOCAL.value
     assert resolution.container_image_uris is None
     assert resolution.container_image_uri is None
+
+
+class RerunTestResolver(LocalResolver):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.scheduled_run_counts = defaultdict(lambda: 0)
+
+    def _future_will_schedule(self, future):
+        super()._future_will_schedule(future)
+        self.scheduled_run_counts[future.calculator.__name__] += 1
+
+
+def test_rerun_from_here(
+    mock_local_resolver_storage,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
+):
+    future = pipeline(1, 2)
+
+    output = future.resolve()
+
+    runs, _, __ = get_root_graph(future.id)
+
+    for run_id, expected_scheduled_run_counts in {
+        future.nested_future.id: dict(add=1),
+        future.nested_future.kwargs["a"].id: dict(add=4, add3=1),
+        future.nested_future.kwargs["b"].id: dict(add=3, add3=1),
+        future.nested_future.kwargs["b"].nested_future.id: dict(add=2),
+        future.nested_future.kwargs["b"].nested_future.kwargs["a"].id: dict(add=3),
+    }.items():
+        new_future = pipeline(1, 2)
+
+        resolver = RerunTestResolver(rerun_from=run_id)
+
+        new_output = new_future.resolve(resolver)
+
+        assert output == new_output
+
+        assert resolver.scheduled_run_counts == expected_scheduled_run_counts

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -6,8 +6,9 @@ import pytest
 # Sematic
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
-    mock_no_auth,
+    mock_auth,
     mock_requests,
+    mock_socketio,
     test_client,
 )
 from sematic.calculator import func
@@ -36,7 +37,6 @@ def pipeline(a: float, b: float) -> float:
 _MOCK_STORAGE = MockStorage()
 
 
-@mock.patch("socketio.Client.connect")
 @mock.patch(
     "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
 )
@@ -44,14 +44,14 @@ _MOCK_STORAGE = MockStorage()
 @mock.patch("kubernetes.config.load_kube_config")
 @mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=_MOCK_STORAGE)
 @mock.patch("sematic.resolvers.worker.S3Storage", return_value=_MOCK_STORAGE)
-@mock_no_auth
 def test_main(
     mock_worker_storage: mock.MagicMock,
     mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_job: mock.MagicMock,
     mock_get_image: mock.MagicMock,
-    mock_socketio,
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     mock_requests,  # noqa: F811
     test_db,  # noqa: F811
     test_storage,  # noqa: F811
@@ -85,7 +85,6 @@ def fail():
 __MOCK_STORAGE = MockStorage()
 
 
-@mock.patch("socketio.Client.connect")
 @mock.patch(
     "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
 )
@@ -93,14 +92,14 @@ __MOCK_STORAGE = MockStorage()
 @mock.patch("kubernetes.config.load_kube_config")
 @mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=__MOCK_STORAGE)
 @mock.patch("sematic.resolvers.worker.S3Storage", return_value=__MOCK_STORAGE)
-@mock_no_auth
 def test_fail(
     worker_mock_storage: mock.MagicMock,
     mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_job: mock.MagicMock,
     mock_get_image: mock.MagicMock,
-    mock_socketio,
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
     mock_requests,  # noqa: F811
     test_storage,  # noqa: F811
     valid_client_version,  # noqa: F811

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -16,7 +16,11 @@ from sematic.db.queries import get_resolution, get_root_graph, save_resolution
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.resolvers.cloud_resolver import CloudResolver
 from sematic.resolvers.worker import main
-from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
+from sematic.tests.fixtures import (  # noqa: F401
+    MockStorage,
+    test_storage,
+    valid_client_version,
+)
 
 
 @func
@@ -29,14 +33,21 @@ def pipeline(a: float, b: float) -> float:
     return add(a, b)
 
 
+_MOCK_STORAGE = MockStorage()
+
+
 @mock.patch("socketio.Client.connect")
 @mock.patch(
     "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
 )
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
+@mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=_MOCK_STORAGE)
+@mock.patch("sematic.resolvers.worker.S3Storage", return_value=_MOCK_STORAGE)
 @mock_no_auth
 def test_main(
+    mock_worker_storage: mock.MagicMock,
+    mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_job: mock.MagicMock,
     mock_get_image: mock.MagicMock,
@@ -71,14 +82,21 @@ def fail():
     raise Exception("FAIL!")
 
 
+__MOCK_STORAGE = MockStorage()
+
+
 @mock.patch("socketio.Client.connect")
 @mock.patch(
     "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
 )
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
+@mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=__MOCK_STORAGE)
+@mock.patch("sematic.resolvers.worker.S3Storage", return_value=__MOCK_STORAGE)
 @mock_no_auth
 def test_fail(
+    worker_mock_storage: mock.MagicMock,
+    mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_job: mock.MagicMock,
     mock_get_image: mock.MagicMock,

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -136,6 +136,9 @@ def main(
     `resolve` set to `True` will execute the driver logic.
     `resolve` set to `False` will execute the worker logic.
     """
+    if not resolve and rerun_from is not None:
+        raise ValueError("Can only have non-None rerun_from in resolve mode")
+
     runs, artifacts, edges = api_client.get_graph(run_id)
 
     if len(runs) == 0:
@@ -213,6 +216,7 @@ def wrap_main_with_logging():
         logger.info("Worker CLI args: run_id=%s", args.run_id)
         logger.info("Worker CLI args: resolve=%s", args.resolve)
         logger.info("Worker CLI args: max-parallelism=%s", args.max_parallelism)
+        logger.info("Worker CLI args: rerun_from=%s", args.rerun_from)
 
         main(
             run_id=args.run_id,

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -39,6 +39,7 @@ def parse_args():
     parser.add_argument("--run_id", type=str, required=True)
     parser.add_argument("--resolve", default=False, action="store_true", required=False)
     parser.add_argument("--max-parallelism", type=int, default=None, required=False)
+    parser.add_argument("--rerun-from", type=str, default=None, required=False)
 
     args = parser.parse_args()
 
@@ -123,7 +124,12 @@ def _set_run_output(run: Run, output: Any, type_: Any, edges: List[Edge]):
     api_client.save_graph(run.root_id, [run], artifacts, edges)
 
 
-def main(run_id: str, resolve: bool, max_parallelism: Optional[int] = None):
+def main(
+    run_id: str,
+    resolve: bool,
+    max_parallelism: Optional[int] = None,
+    rerun_from: Optional[str] = None,
+):
     """
     Main job logic.
 
@@ -147,7 +153,10 @@ def main(run_id: str, resolve: bool, max_parallelism: Optional[int] = None):
             future.id = run.id
 
             resolver = CloudResolver(
-                detach=False, max_parallelism=max_parallelism, _is_running_remotely=True
+                detach=False,
+                max_parallelism=max_parallelism,
+                rerun_from=rerun_from,
+                _is_running_remotely=True,
             )
             resolver.set_graph(runs=runs, artifacts=artifacts, edges=edges)
 
@@ -209,6 +218,7 @@ def wrap_main_with_logging():
             run_id=args.run_id,
             resolve=args.resolve,
             max_parallelism=args.max_parallelism,
+            rerun_from=args.rerun_from,
         )
 
 

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -100,18 +100,17 @@ def _set_run_output(run: Run, output: Any, type_: Any, edges: List[Edge]):
     Persist run output, whether it is a nested future or a concrete output.
     """
     artifacts = []
+    storage = S3Storage()
 
     if isinstance(output, Future):
         pickled_nested_future = cloudpickle.dumps(output)
-        S3Storage().set(
-            make_nested_future_storage_key(output.id), pickled_nested_future
-        )
+        storage.set(make_nested_future_storage_key(output.id), pickled_nested_future)
         run.nested_future_id = output.id
         run.future_state = FutureState.RAN
         run.ended_at = datetime.datetime.utcnow()
 
     else:
-        artifacts.append(make_artifact(output, type_, store=True))
+        artifacts.append(make_artifact(output, type_, storage=storage))
 
         # Set output artifact on output edges
         for edge in edges:

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -13,7 +13,6 @@ import cloudpickle
 
 # Sematic
 import sematic.api_client as api_client
-import sematic.storage as storage
 from sematic.abstract_future import FutureState
 from sematic.calculator import Calculator
 from sematic.db.models.artifact import Artifact
@@ -28,6 +27,7 @@ from sematic.resolvers.cloud_resolver import (
 )
 from sematic.resolvers.log_streamer import ingested_logs
 from sematic.scheduling.external_job import JobType
+from sematic.storage import S3Storage
 from sematic.utils.exceptions import format_exception_for_run
 
 
@@ -57,7 +57,9 @@ def _get_input_kwargs(
     artifacts_by_id = {artifact.id: artifact for artifact in artifacts}
 
     kwargs = {
-        edge.destination_name: get_artifact_value(artifacts_by_id[edge.artifact_id])
+        edge.destination_name: get_artifact_value(
+            artifacts_by_id[edge.artifact_id], storage=S3Storage()
+        )
         for edge in edges
         if edge.destination_run_id == run_id
         and edge.artifact_id is not None
@@ -101,7 +103,9 @@ def _set_run_output(run: Run, output: Any, type_: Any, edges: List[Edge]):
 
     if isinstance(output, Future):
         pickled_nested_future = cloudpickle.dumps(output)
-        storage.set(make_nested_future_storage_key(output.id), pickled_nested_future)
+        S3Storage().set(
+            make_nested_future_storage_key(output.id), pickled_nested_future
+        )
         run.nested_future_id = output.id
         run.future_state = FutureState.RAN
         run.ended_at = datetime.datetime.utcnow()

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -46,11 +46,13 @@ def schedule_resolution(
 
     Parameters
     ----------
-    resolution:
+    resolution: Resolution
         The resolution associated with the run
     max_parallelism:
         The maximum number of non-inlined runs that the resolver will allow to be in the
         SCHEDULED state at any one time.
+    rerun_from: Optional[str]
+        Start resolution from a particular point
     """
     resolution.external_jobs = _refresh_external_jobs(resolution.external_jobs)
     _assert_resolution_is_scheduleable(resolution)

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -38,7 +38,9 @@ def schedule_run(run: Run, resolution: Resolution) -> Run:
 
 
 def schedule_resolution(
-    resolution: Resolution, max_parallelism: Optional[int] = None
+    resolution: Resolution,
+    max_parallelism: Optional[int] = None,
+    rerun_from: Optional[str] = None,
 ) -> Resolution:
     """Start a resolution for the run on external compute.
 
@@ -53,7 +55,11 @@ def schedule_resolution(
     resolution.external_jobs = _refresh_external_jobs(resolution.external_jobs)
     _assert_resolution_is_scheduleable(resolution)
     external_jobs_list = list(resolution.external_jobs) + [
-        _schedule_resolution_job(resolution=resolution, max_parallelism=max_parallelism)
+        _schedule_resolution_job(
+            resolution=resolution,
+            max_parallelism=max_parallelism,
+            rerun_from=rerun_from,
+        )
     ]
     resolution.external_jobs = tuple(external_jobs_list)
     resolution.status = ResolutionStatus.SCHEDULED
@@ -202,7 +208,9 @@ def _schedule_job(run: Run, resolution: Resolution) -> ExternalJob:
 
 
 def _schedule_resolution_job(
-    resolution: Resolution, max_parallelism: Optional[int] = None
+    resolution: Resolution,
+    max_parallelism: Optional[int] = None,
+    rerun_from: Optional[str] = None,
 ) -> ExternalJob:
     """Reach out to external compute to start the execution of the resolution"""
     # should be impossible to fail this assert, but it makes mypy happy
@@ -212,4 +220,5 @@ def _schedule_resolution_job(
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
         max_parallelism=max_parallelism,
+        rerun_from=rerun_from,
     )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -350,9 +350,11 @@ def schedule_resolution_job(
     image: str,
     user_settings: Dict[str, str],
     max_parallelism: Optional[int] = None,
+    rerun_from: Optional[str] = None,
 ) -> ExternalJob:
 
     namespace = get_user_settings(SettingsVar.KUBERNETES_NAMESPACE)
+
     external_job = KubernetesExternalJob.new(
         try_number=0,
         run_id=resolution_id,
@@ -361,10 +363,14 @@ def schedule_resolution_job(
     )
 
     logger.info("Scheduling job %s", external_job.kubernetes_job_name)
+
     args = ["--run_id", resolution_id, "--resolve"]
 
     if max_parallelism is not None:
         args += ["--max-parallelism", str(max_parallelism)]
+
+    if rerun_from is not None:
+        args += ["--rerun-from", rerun_from]
 
     _schedule_kubernetes_job(
         name=external_job.kubernetes_job_name,

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -88,7 +88,7 @@ def test_schedule_run(mock_k8s, run: Run, resolution: Resolution):
 
 
 def test_schedule_resolution(mock_k8s, resolution: Resolution):
-    scheduled = schedule_resolution(resolution, max_parallelism=3)
+    scheduled = schedule_resolution(resolution, max_parallelism=3, rerun_from="foobar")
     assert len(scheduled.external_jobs) == 1
     external_job = scheduled.external_jobs[0]
     assert isinstance(external_job, KubernetesExternalJob)
@@ -98,6 +98,7 @@ def test_schedule_resolution(mock_k8s, resolution: Resolution):
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
         max_parallelism=3,
+        rerun_from="foobar",
     )
 
 

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -16,16 +16,30 @@ from sematic.utils.retry import retry
 
 
 class Storage(abc.ABC):
+    """
+    Abstract base class to represent a key/value storage engine.
+    """
+
     @abc.abstractmethod
     def set(self, key: str, value: bytes):
+        """
+        Sets value for key.
+        """
         pass
 
     @abc.abstractmethod
     def get(self, key: str) -> bytes:
+        """
+        Gets value for key.
+        """
         pass
 
 
 class MemoryStorage(Storage):
+    """
+    An in-memory key/value store implementing the `Storage` interface.
+    """
+
     def __init__(self):
         self._store: Dict[str, Any] = {}
 
@@ -37,6 +51,12 @@ class MemoryStorage(Storage):
 
 
 class LocalStorage(Storage):
+    """
+    A local storage implementation of the `Storage` interface. Values are stores
+    in the data directory of the Sematic directory, typically at
+    `~/.sematic/data`.
+    """
+
     def set(self, key: str, value: bytes):
         dir_path = os.path.split(key)[0]
         os.makedirs(os.path.join(get_config().data_dir, dir_path), exist_ok=True)
@@ -53,6 +73,11 @@ class LocalStorage(Storage):
 
 
 class S3Storage(Storage):
+    """
+    Implementation of the `Storage` interface for AWS S3 storage. The bucket
+    where to store values is determined by the `AWS_S3_BUCKET` user settings.
+    """
+
     @memoized_property
     def _bucket(self) -> str:
         return get_user_settings(SettingsVar.AWS_S3_BUCKET)

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -35,6 +35,11 @@ class Storage(abc.ABC):
         pass
 
 
+class NoSuchStorageKey(KeyError):
+    def __init__(self, storage: Storage, key: str):
+        super().__init__(f"No such storage key for {storage.__class__.__name__}: {key}")
+
+
 class MemoryStorage(Storage):
     """
     An in-memory key/value store implementing the `Storage` interface.
@@ -47,7 +52,10 @@ class MemoryStorage(Storage):
         self._store[key] = value
 
     def get(self, key: str) -> bytes:
-        return self._store[key]
+        try:
+            return self._store[key]
+        except KeyError:
+            raise NoSuchStorageKey(self, key)
 
 
 class LocalStorage(Storage):
@@ -69,7 +77,7 @@ class LocalStorage(Storage):
             with open(os.path.join(get_config().data_dir, key), "rb") as file:
                 return file.read()
         except FileNotFoundError:
-            raise KeyError(f"No suck key: {key}")
+            raise NoSuchStorageKey(self, key)
 
 
 class S3Storage(Storage):
@@ -87,11 +95,7 @@ class S3Storage(Storage):
         return boto3.client("s3")
 
     def set(self, key: str, value: bytes):
-        """Store value in S3
-
-        TODO: modularize the F out of this to enable local/remote storage switch
-        based on resolver. Also enable multiple storage clients (AWS, GCP, Azure)
-        """
+        """Store value in S3"""
         with io.BytesIO(value) as file_obj:
             self._s3_client.upload_fileobj(file_obj, self._bucket, key)
 
@@ -107,7 +111,7 @@ class S3Storage(Storage):
         except botocore.exceptions.ClientError as e:
             # Standardizing "Not found" errors across storage backends
             if "404" in str(e):
-                raise KeyError("{}: {}".format(key, str(e)))
+                raise NoSuchStorageKey(self, key)
 
             raise e
         return file_obj.getvalue()

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -128,8 +128,6 @@ class S3Storage(Storage):
     def get_line_stream(self, key: str, encoding="utf8") -> Iterable[str]:
         """Get value from S3 into a stream of text lines.
 
-        The encoding of the
-
         See TODO in `set`.
         """
         try:

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -1,5 +1,7 @@
 # Standard Library
+import abc
 import io
+import os
 from typing import Dict, Iterable, List
 
 # Third-party
@@ -7,118 +9,142 @@ import boto3
 import botocore.exceptions
 
 # Sematic
+from sematic.config import get_config
 from sematic.user_settings import SettingsVar, get_user_settings
+from sematic.utils.memoized_property import memoized_property
 from sematic.utils.retry import retry
 
 
-def _get_bucket() -> str:
-    return get_user_settings(SettingsVar.AWS_S3_BUCKET)
+class Storage(abc.ABC):
+    @abc.abstractmethod
+    def set(self, key: str, value: bytes):
+        pass
+
+    @abc.abstractmethod
+    def get(self, key: str) -> bytes:
+        pass
 
 
-def set(key: str, value: bytes):
-    """Store value in S3
+class LocalStorage(Storage):
+    def set(self, key: str, value: bytes):
+        dir_path = os.path.split(key)[0]
+        os.makedirs(os.path.join(get_config().data_dir, dir_path), exist_ok=True)
 
-    TODO: modularize the F out of this to enable local/remote storage switch
-    based on resolver. Also enable multiple storage clients (AWS, GCP, Azure)
-    """
-    s3_client = boto3.client("s3")
+        with open(os.path.join(get_config().data_dir, key), "wb") as file:
+            file.write(value)
 
-    with io.BytesIO(value) as file_obj:
-        s3_client.upload_fileobj(file_obj, _get_bucket(), key)
-
-
-def set_from_file(key: str, value_file_path: str):
-    """Store value in S3 using the contents of a file
-
-    see TODO in 'set'
-    """
-    s3_client = boto3.client("s3")
-
-    with open(value_file_path, "rb") as file_obj:
-        s3_client.upload_fileobj(file_obj, _get_bucket(), key)
+    def get(self, key: str) -> bytes:
+        with open(os.path.join(get_config().data_dir, key), "rb") as file:
+            return file.read()
 
 
-@retry(tries=3, delay=5)
-def get(key: str) -> bytes:
-    """Get value from S3.
+class S3Storage(Storage):
+    @memoized_property
+    def _bucket(self) -> str:
+        return get_user_settings(SettingsVar.AWS_S3_BUCKET)
 
-    See TODO in `set`.
-    """
-    file_obj = io.BytesIO()
-    s3_client = boto3.client("s3")
-    try:
-        s3_client.download_fileobj(_get_bucket(), key, file_obj)
-    except botocore.exceptions.ClientError as e:
-        # Standardizing "Not found" errors across storage backends
-        if "404" in str(e):
-            raise KeyError("{}: {}".format(key, str(e)))
+    @memoized_property
+    def _s3_client(self):
+        return boto3.client("s3")
 
-        raise e
-    return file_obj.getvalue()
+    def set(self, key: str, value: bytes):
+        """Store value in S3
 
+        TODO: modularize the F out of this to enable local/remote storage switch
+        based on resolver. Also enable multiple storage clients (AWS, GCP, Azure)
+        """
+        with io.BytesIO(value) as file_obj:
+            self._s3_client.upload_fileobj(file_obj, self._bucket, key)
 
-@retry(tries=3, delay=5)
-def get_line_stream(key: str, encoding="utf8") -> Iterable[str]:
-    """Get value from S3 into a stream of text lines.
+    @retry(tries=3, delay=5)
+    def get(self, key: str) -> bytes:
+        """Get value from S3.
 
-    The encoding of the
+        See TODO in `set`.
+        """
+        file_obj = io.BytesIO()
+        try:
+            self._s3_client.download_fileobj(self._bucket, key, file_obj)
+        except botocore.exceptions.ClientError as e:
+            # Standardizing "Not found" errors across storage backends
+            if "404" in str(e):
+                raise KeyError("{}: {}".format(key, str(e)))
 
-    See TODO in `set`.
-    """
-    s3_client = boto3.client("s3")
+            raise e
+        return file_obj.getvalue()
 
-    try:
-        obj = s3_client.get_object(Bucket=_get_bucket(), Key=key)
-        return _bytes_buffer_to_text(obj["Body"].iter_lines(), encoding)
-    except botocore.exceptions.ClientError as e:
-        # Standardizing "Not found" errors across storage backends
-        if "404" in str(e):
-            raise KeyError("{}: {}".format(key, str(e)))
+    def set_from_file(self, key: str, value_file_path: str):
+        """Store value in S3 using the contents of a file
 
-        raise e
+        see TODO in 'set'
+        """
+        with open(value_file_path, "rb") as file_obj:
+            self._s3_client.upload_fileobj(file_obj, self._bucket, key)
+
+    @retry(tries=3, delay=5)
+    def get_line_stream(self, key: str, encoding="utf8") -> Iterable[str]:
+        """Get value from S3 into a stream of text lines.
+
+        The encoding of the
+
+        See TODO in `set`.
+        """
+        try:
+            obj = self._s3_client.get_object(Bucket=self._bucket, Key=key)
+            return _bytes_buffer_to_text(obj["Body"].iter_lines(), encoding)
+        except botocore.exceptions.ClientError as e:
+            # Standardizing "Not found" errors across storage backends
+            if "404" in str(e):
+                raise KeyError("{}: {}".format(key, str(e)))
+
+            raise e
+
+    @retry(tries=3, delay=5)
+    def get_child_paths(self, key_prefix: str) -> List[str]:
+        """Get all descendants of the 'directory' specified by the prefix
+
+        Parameters
+        ----------
+        key_prefix:
+            The prefix to a key that would be used with 'get' or 'set'. The keys are
+            treated as being like directories, with '/' in a key specifying an
+            organizational unit for the objects.
+
+        Returns
+        -------
+        A list of all keys that start with the prefix. You can think of this as getting
+        the absolute file paths for all contents of a directory (including 'files' in
+        'subdirectories').
+        """
+        if not key_prefix.endswith("/"):
+            key_prefix = f"{key_prefix}/"
+
+        keys = []
+        has_more = True
+        continuation_token = None
+
+        while has_more:
+            continuation: Dict[str, str] = (
+                {}
+                if continuation_token is None
+                else {"ContinuationToken": continuation_token}  # type: ignore
+            )
+
+            list_objects_return = self._s3_client.list_objects_v2(
+                Bucket=self._bucket,
+                Prefix=key_prefix,
+                **continuation,
+            )
+
+            has_more = list_objects_return["IsTruncated"]
+            continuation_token = list_objects_return.get("NextContinuationToken")
+
+            for obj in list_objects_return.get("Contents", []):
+                keys.append(obj["Key"])
+
+        return keys
 
 
 def _bytes_buffer_to_text(bytes_buffer: Iterable[bytes], encoding) -> Iterable[str]:
     for line in bytes_buffer:
         yield str(line, encoding=encoding)
-
-
-@retry(tries=3, delay=5)
-def get_child_paths(key_prefix: str) -> List[str]:
-    """Get all descendants of the 'directory' specified by the prefix
-
-    Parameters
-    ----------
-    key_prefix:
-        The prefix to a key that would be used with 'get' or 'set'. The keys are
-        treated as being like directories, with '/' in a key specifying an
-        organizational unit for the objects.
-
-    Returns
-    -------
-    A list of all keys that start with the prefix. You can think of this as getting
-    the absolute file paths for all contents of a directory (including 'files' in
-    'subdirectories').
-    """
-    if not key_prefix.endswith("/"):
-        key_prefix = f"{key_prefix}/"
-    s3_client = boto3.client("s3")
-    keys = []
-    has_more = True
-    continuation_token = None
-    while has_more:
-        continuation: Dict[str, str] = (
-            {}
-            if continuation_token is None
-            else {"ContinuationToken": continuation_token}  # type: ignore
-        )
-        list_objects_return = s3_client.list_objects_v2(
-            Bucket=_get_bucket(),
-            Prefix=key_prefix,
-            **continuation,
-        )
-        has_more = list_objects_return["IsTruncated"]
-        continuation_token = list_objects_return.get("NextContinuationToken")
-        for obj in list_objects_return.get("Contents", []):
-            keys.append(obj["Key"])
-    return keys

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -2,7 +2,7 @@
 import abc
 import io
 import os
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
 
 # Third-party
 import boto3
@@ -25,6 +25,17 @@ class Storage(abc.ABC):
         pass
 
 
+class MemoryStorage(Storage):
+    def __init__(self):
+        self._store: Dict[str, Any] = {}
+
+    def set(self, key: str, value: bytes):
+        self._store[key] = value
+
+    def get(self, key: str) -> bytes:
+        return self._store[key]
+
+
 class LocalStorage(Storage):
     def set(self, key: str, value: bytes):
         dir_path = os.path.split(key)[0]
@@ -34,8 +45,11 @@ class LocalStorage(Storage):
             file.write(value)
 
     def get(self, key: str) -> bytes:
-        with open(os.path.join(get_config().data_dir, key), "rb") as file:
-            return file.read()
+        try:
+            with open(os.path.join(get_config().data_dir, key), "rb") as file:
+                return file.read()
+        except FileNotFoundError:
+            raise KeyError(f"No suck key: {key}")
 
 
 class S3Storage(Storage):

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -130,3 +130,19 @@ sematic_py_lib(
         "//sematic:storage",
     ],
 )
+
+pytest_test(
+    name = "test_graph",
+    srcs = ["test_graph.py"],
+    deps = [
+        "//sematic:abstract_future",
+        "//sematic:api_client",
+        "//sematic:calculator",
+        "//sematic:graph",
+        "//sematic/api/tests:fixtures",
+        "//sematic/db/models:factories",
+        "//sematic/db/tests:fixtures",
+        "//sematic/resolvers:local_resolver",
+        "//sematic/resolvers/tests:fixtures",
+    ],
+)

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -16,7 +16,7 @@ from sematic.api_client import (
 )
 from sematic.config import get_config
 from sematic.db.models.factories import make_artifact
-from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
+from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
 from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
 
 
@@ -136,16 +136,15 @@ def test_validate_server_compatibility_new_server_still_supports(mock_requests):
 
 
 @mock.patch("sematic.api_client.requests")
-def test_get_artifact_value_by_id(
-    mock_requests, test_storage, valid_client_version  # noqa: F811
-):
-    artifact = make_artifact(42, int, True)
+def test_get_artifact_value_by_id(mock_requests, valid_client_version):  # noqa: F811
+    mock_storage = MockStorage()
+    artifact = make_artifact(42, int, mock_storage)
     mock_requests.get.return_value = MockResponse(
         status_code=200,
         json_contents=dict(content=artifact.to_json_encodable()),
     )
 
-    value = get_artifact_value_by_id(artifact.id)
+    value = get_artifact_value_by_id(artifact.id, mock_storage)
 
     assert isinstance(value, int)
     assert value == 42

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -76,8 +76,8 @@ def test_clone_futures(
             assert futures_by_original_id[parent_run.id] is future_.parent_future
 
         # Making sure all future kwargs are correct
-        for input_edge in graph.edges_by_destination_id[original_run.id]:
-            artifact = graph.artifacts_by_id[input_edge.artifact_id]
+        for input_edge in graph._edges_by_destination_id[original_run.id]:
+            artifact = graph._artifacts_by_id[input_edge.artifact_id]
             assert input_artifacts[future_.id][input_edge.destination_name] is artifact
 
             if input_edge.source_run_id is None:
@@ -88,8 +88,8 @@ def test_clone_futures(
                 assert future_.kwargs[input_edge.destination_name] is upstream_future
 
         # Making sure output values are correct
-        for output_edge in graph.edges_by_source_id[original_run_id]:
-            artifact = graph.artifacts_by_id[output_edge.artifact_id]
+        for output_edge in graph._edges_by_source_id[original_run_id]:
+            artifact = graph._artifacts_by_id[output_edge.artifact_id]
             assert output_artifacts[future_.id] is artifact
 
             value = get_artifact_value(artifact, mock_local_resolver_storage)

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -51,21 +51,19 @@ def test_clone_futures(
 
     runs_by_id = {run.id: run for run in runs}
 
-    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
 
-    (
-        futures_by_original_id,
-        input_artifacts,
-        output_artifacts,
-    ) = graph.clone_futures(storage=mock_local_resolver_storage)
+    cloned_graph = graph.clone_futures()
 
-    assert len(futures_by_original_id) == len(runs)
+    assert len(cloned_graph.futures_by_original_id) == len(runs)
 
-    root_future = futures_by_original_id[future.id]
+    root_future = cloned_graph.futures_by_original_id[future.id]
     assert root_future.calculator._func is pipeline._func
     assert root_future.parent_future is None
 
-    for original_run_id, future_ in futures_by_original_id.items():
+    for original_run_id, future_ in cloned_graph.futures_by_original_id.items():
         original_run = runs_by_id[original_run_id]
         # No reset so state should be the same
         assert future.state.value == original_run.future_state
@@ -73,30 +71,40 @@ def test_clone_futures(
         # Parent future should exist and be the correct one
         if original_run.parent_id is not None:
             parent_run = runs_by_id[original_run.parent_id]
-            assert futures_by_original_id[parent_run.id] is future_.parent_future
+            assert (
+                cloned_graph.futures_by_original_id[parent_run.id]
+                is future_.parent_future
+            )
 
         # Making sure all future kwargs are correct
         for input_edge in graph._edges_by_destination_id[original_run.id]:
             artifact = graph._artifacts_by_id[input_edge.artifact_id]
-            assert input_artifacts[future_.id][input_edge.destination_name] is artifact
+            assert (
+                cloned_graph.input_artifacts[future_.id][input_edge.destination_name]
+                is artifact
+            )
 
             if input_edge.source_run_id is None:
                 value = get_artifact_value(artifact, mock_local_resolver_storage)
                 assert future_.kwargs[input_edge.destination_name] == value
             else:
-                upstream_future = futures_by_original_id[input_edge.source_run_id]
+                upstream_future = cloned_graph.futures_by_original_id[
+                    input_edge.source_run_id
+                ]
                 assert future_.kwargs[input_edge.destination_name] is upstream_future
 
         # Making sure output values are correct
         for output_edge in graph._edges_by_source_id[original_run_id]:
             artifact = graph._artifacts_by_id[output_edge.artifact_id]
-            assert output_artifacts[future_.id] is artifact
+            assert cloned_graph.output_artifacts[future_.id] is artifact
 
             value = get_artifact_value(artifact, mock_local_resolver_storage)
             assert future_.value == value
             if output_edge.destination_run_id is not None:
                 downstream_run = runs_by_id[output_edge.destination_run_id]
-                downstream_future = futures_by_original_id[downstream_run.id]
+                downstream_future = cloned_graph.futures_by_original_id[
+                    downstream_run.id
+                ]
                 assert downstream_future.kwargs[output_edge.destination_name] is future_
 
 
@@ -113,15 +121,15 @@ def test_clone_futures_reset(
 
     runs, artifacts, edges = api_client.get_graph(future.id, root=True)
 
-    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
 
     reset_from_run_id = future.nested_future.kwargs["a"].nested_future.kwargs["a"].id
 
-    futures_by_original_id, _, __ = graph.clone_futures(
-        reset_from=reset_from_run_id, storage=mock_local_resolver_storage
-    )
+    cloned_graph = graph.clone_futures(reset_from=reset_from_run_id)
 
-    root_future = futures_by_original_id[future.id]
+    root_future = cloned_graph.futures_by_original_id[future.id]
 
     assert root_future.state == FutureState.RAN
 
@@ -131,7 +139,7 @@ def test_clone_futures_reset(
     # Check that the second add3 future has no children
     assert not any(
         future_.parent_future is second_add3_future
-        for future_ in futures_by_original_id.values()
+        for future_ in cloned_graph.futures_by_original_id.values()
     )
 
     first_add3_future = second_add3_future.kwargs["a"]
@@ -139,7 +147,7 @@ def test_clone_futures_reset(
 
     first_add3_child_futures = [
         future_
-        for future_ in futures_by_original_id.values()
+        for future_ in cloned_graph.futures_by_original_id.values()
         if future_.parent_future is first_add3_future
     ]
 
@@ -150,7 +158,7 @@ def test_clone_futures_reset(
 
     top_level_add_futures = [
         future_
-        for future_ in futures_by_original_id.values()
+        for future_ in cloned_graph.futures_by_original_id.values()
         if future_.parent_future is root_future
         and future_ not in {first_add3_future, second_add3_future}
     ]
@@ -187,15 +195,15 @@ def test_reset_failed(
 
     runs, artifacts, edges = api_client.get_graph(future.id, root=True)
 
-    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
 
     reset_from_run_id = future.nested_future.kwargs["a"].id
 
-    futures_by_original_id, _, __ = graph.clone_futures(
-        reset_from=reset_from_run_id, storage=mock_local_resolver_storage
-    )
+    cloned_graph = graph.clone_futures(reset_from=reset_from_run_id)
 
-    root_future = futures_by_original_id[future.id]
+    root_future = cloned_graph.futures_by_original_id[future.id]
 
     assert root_future.state is FutureState.RAN
     assert root_future.nested_future.state is FutureState.CREATED
@@ -220,7 +228,9 @@ def test_run_execution_ordering(
 
     runs, artifacts, edges = api_client.get_graph(future.id, root=True)
 
-    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
 
     run_ids_by_execution_order = graph._sorted_run_ids_by_layer(
         run_sorter=graph._execution_order
@@ -255,7 +265,9 @@ def test_run_reverse_ordering(
 
     runs, artifacts, edges = api_client.get_graph(future.id, root=True)
 
-    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
 
     run_ids_by_reverse_order = graph._sorted_run_ids_by_layer(
         run_sorter=graph._reverse_execution_order

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -210,3 +210,73 @@ def test_reset_failed(
     assert root_future.nested_future.state is FutureState.CREATED
     assert root_future.nested_future.kwargs["a"].state is FutureState.CREATED
     assert root_future.nested_future.kwargs["b"].state is FutureState.CREATED
+
+
+@func
+def order_test() -> float:
+    return add3(add3(1, 2, 3), 2, 3)
+
+
+def test_run_execution_ordering(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    future = order_test()
+    future.resolve(LocalResolver())
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+
+    run_ids_by_execution_order = graph.run_ids_sorted_by_layer(
+        run_sorter=graph._execution_order
+    )
+
+    expected_order = [
+        future.id,
+        future.nested_future.kwargs["a"].id,
+        future.nested_future.id,
+        future.nested_future.kwargs["a"].nested_future.kwargs["a"].id,
+        future.nested_future.kwargs["a"].nested_future.id,
+        future.nested_future.nested_future.kwargs["a"].id,
+        future.nested_future.nested_future.id,
+    ]
+
+    assert run_ids_by_execution_order == expected_order
+
+
+def test_run_reverse_ordering(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    future = order_test()
+    future.resolve(LocalResolver())
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+
+    run_ids_by_reverse_order = graph.run_ids_sorted_by_layer(
+        run_sorter=graph._reverse_execution_order
+    )
+
+    expected_order = [
+        future.id,
+        future.nested_future.id,
+        future.nested_future.kwargs["a"].id,
+        future.nested_future.nested_future.id,
+        future.nested_future.nested_future.kwargs["a"].id,
+        future.nested_future.kwargs["a"].nested_future.id,
+        future.nested_future.kwargs["a"].nested_future.kwargs["a"].id,
+    ]
+
+    print(expected_order)
+    print(run_ids_by_reverse_order)
+
+    assert run_ids_by_reverse_order == expected_order

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -236,11 +236,15 @@ def test_run_execution_ordering(
     )
 
     expected_order = [
+        # Layer 0
         future.id,
+        # Layer 1
         future.nested_future.kwargs["a"].id,
         future.nested_future.id,
+        # Layer 1.1
         future.nested_future.kwargs["a"].nested_future.kwargs["a"].id,
         future.nested_future.kwargs["a"].nested_future.id,
+        # Layer 1.2
         future.nested_future.nested_future.kwargs["a"].id,
         future.nested_future.nested_future.id,
     ]
@@ -267,16 +271,17 @@ def test_run_reverse_ordering(
     )
 
     expected_order = [
+        # Layer 0
         future.id,
+        # Layer 1
         future.nested_future.id,
         future.nested_future.kwargs["a"].id,
+        # Layer 1.2
         future.nested_future.nested_future.id,
         future.nested_future.nested_future.kwargs["a"].id,
+        # Layer 1.1
         future.nested_future.kwargs["a"].nested_future.id,
         future.nested_future.kwargs["a"].nested_future.kwargs["a"].id,
     ]
-
-    print(expected_order)
-    print(run_ids_by_reverse_order)
 
     assert run_ids_by_reverse_order == expected_order

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -57,7 +57,7 @@ def test_clone_futures(
         futures_by_original_id,
         input_artifacts,
         output_artifacts,
-    ) = graph.clone_futures_by_original_run_id(storage=mock_local_resolver_storage)
+    ) = graph.clone_futures(storage=mock_local_resolver_storage)
 
     assert len(futures_by_original_id) == len(runs)
 
@@ -117,11 +117,7 @@ def test_clone_futures_reset(
 
     reset_from_run_id = future.nested_future.kwargs["a"].nested_future.kwargs["a"].id
 
-    (
-        futures_by_original_id,
-        input_artifacts,
-        output_artifacts,
-    ) = graph.clone_futures_by_original_run_id(
+    futures_by_original_id, _, __ = graph.clone_futures(
         reset_from=reset_from_run_id, storage=mock_local_resolver_storage
     )
 
@@ -195,11 +191,7 @@ def test_reset_failed(
 
     reset_from_run_id = future.nested_future.kwargs["a"].id
 
-    (
-        futures_by_original_id,
-        input_artifacts,
-        output_artifacts,
-    ) = graph.clone_futures_by_original_run_id(
+    futures_by_original_id, _, __ = graph.clone_futures(
         reset_from=reset_from_run_id, storage=mock_local_resolver_storage
     )
 
@@ -230,7 +222,7 @@ def test_run_execution_ordering(
 
     graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
 
-    run_ids_by_execution_order = graph.run_ids_sorted_by_layer(
+    run_ids_by_execution_order = graph._run_ids_sorted_by_layer(
         run_sorter=graph._execution_order
     )
 
@@ -265,7 +257,7 @@ def test_run_reverse_ordering(
 
     graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
 
-    run_ids_by_reverse_order = graph.run_ids_sorted_by_layer(
+    run_ids_by_reverse_order = graph._run_ids_sorted_by_layer(
         run_sorter=graph._reverse_execution_order
     )
 

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -6,7 +6,6 @@ import sematic.api_client as api_client
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
     mock_auth,
-    mock_no_auth,
     mock_requests,
     mock_socketio,
     test_client,

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -1,0 +1,212 @@
+# Third-party
+import pytest
+
+# Sematic
+import sematic.api_client as api_client
+from sematic.abstract_future import FutureState
+from sematic.api.tests.fixtures import (  # noqa: F401
+    mock_auth,
+    mock_no_auth,
+    mock_requests,
+    mock_socketio,
+    test_client,
+)
+from sematic.calculator import func
+from sematic.db.models.factories import get_artifact_value
+from sematic.db.tests.fixtures import test_db  # noqa: F401
+from sematic.graph import Graph
+from sematic.resolvers.local_resolver import LocalResolver
+from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
+
+
+@func
+def add(a: float, b: float) -> float:
+    return a + b
+
+
+@func
+def add3(a: float, b: float, c: float) -> float:
+    return add(add(a, b), c)
+
+
+@func
+def pipeline(a: float, b: float, c: float) -> float:
+    d = add3(add(a, b), add(b, c), add(a, c))
+    return add3(d, b, c)
+
+
+def test_clone_futures(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    future = pipeline(1, 2, 3)
+    resolver = LocalResolver()
+    output = future.resolve(resolver)
+
+    assert output == 17
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    runs_by_id = {run.id: run for run in runs}
+
+    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+
+    (
+        futures_by_original_id,
+        input_artifacts,
+        output_artifacts,
+    ) = graph.clone_futures_by_original_run_id(storage=mock_local_resolver_storage)
+
+    assert len(futures_by_original_id) == len(runs)
+
+    root_future = futures_by_original_id[future.id]
+    assert root_future.calculator._func is pipeline._func
+    assert root_future.parent_future is None
+
+    for original_run_id, future_ in futures_by_original_id.items():
+        original_run = runs_by_id[original_run_id]
+        # No reset so state should be the same
+        assert future.state.value == original_run.future_state
+
+        # Parent future should exist and be the correct one
+        if original_run.parent_id is not None:
+            parent_run = runs_by_id[original_run.parent_id]
+            assert futures_by_original_id[parent_run.id] is future_.parent_future
+
+        # Making sure all future kwargs are correct
+        for input_edge in graph.edges_by_destination_id[original_run.id]:
+            artifact = graph.artifacts_by_id[input_edge.artifact_id]
+            assert input_artifacts[future_.id][input_edge.destination_name] is artifact
+
+            if input_edge.source_run_id is None:
+                value = get_artifact_value(artifact, mock_local_resolver_storage)
+                assert future_.kwargs[input_edge.destination_name] == value
+            else:
+                upstream_future = futures_by_original_id[input_edge.source_run_id]
+                assert future_.kwargs[input_edge.destination_name] is upstream_future
+
+        # Making sure output values are correct
+        for output_edge in graph.edges_by_source_id[original_run_id]:
+            artifact = graph.artifacts_by_id[output_edge.artifact_id]
+            assert output_artifacts[future_.id] is artifact
+
+            value = get_artifact_value(artifact, mock_local_resolver_storage)
+            assert future_.value == value
+            if output_edge.destination_run_id is not None:
+                downstream_run = runs_by_id[output_edge.destination_run_id]
+                downstream_future = futures_by_original_id[downstream_run.id]
+                assert downstream_future.kwargs[output_edge.destination_name] is future_
+
+
+def test_clone_futures_reset(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    future = pipeline(1, 2, 3)
+    resolver = LocalResolver()
+    future.resolve(resolver)
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+
+    reset_from_run_id = future.nested_future.kwargs["a"].nested_future.kwargs["a"].id
+
+    (
+        futures_by_original_id,
+        input_artifacts,
+        output_artifacts,
+    ) = graph.clone_futures_by_original_run_id(
+        reset_from=reset_from_run_id, storage=mock_local_resolver_storage
+    )
+
+    root_future = futures_by_original_id[future.id]
+
+    assert root_future.state == FutureState.RAN
+
+    second_add3_future = root_future.nested_future
+    assert second_add3_future.state == FutureState.CREATED
+
+    # Check that the second add3 future has no children
+    assert not any(
+        future_.parent_future is second_add3_future
+        for future_ in futures_by_original_id.values()
+    )
+
+    first_add3_future = second_add3_future.kwargs["a"]
+    assert first_add3_future.state is FutureState.RAN
+
+    first_add3_child_futures = [
+        future_
+        for future_ in futures_by_original_id.values()
+        if future_.parent_future is first_add3_future
+    ]
+
+    assert len(first_add3_child_futures) == 2
+    assert all(
+        future_.state is FutureState.CREATED for future_ in first_add3_child_futures
+    )
+
+    top_level_add_futures = [
+        future_
+        for future_ in futures_by_original_id.values()
+        if future_.parent_future is root_future
+        and future_ not in {first_add3_future, second_add3_future}
+    ]
+
+    assert len(top_level_add_futures) == 3
+    assert all(
+        future_.state is FutureState.RESOLVED for future_ in top_level_add_futures
+    )
+
+
+@func
+def add_fail(a: float, b: float) -> float:
+    raise Exception("fail")
+
+
+@func
+def add4(a: float, b: float, c: float, d: float) -> float:
+    return add(add(a, b), add_fail(c, d))
+
+
+def test_reset_failed(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    resolver = LocalResolver()
+
+    future = add4(1, 2, 3, 4)
+
+    with pytest.raises(Exception):
+        future.resolve(resolver)
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
+
+    reset_from_run_id = future.nested_future.kwargs["a"].id
+
+    (
+        futures_by_original_id,
+        input_artifacts,
+        output_artifacts,
+    ) = graph.clone_futures_by_original_run_id(
+        reset_from=reset_from_run_id, storage=mock_local_resolver_storage
+    )
+
+    root_future = futures_by_original_id[future.id]
+
+    assert root_future.state is FutureState.RAN
+    assert root_future.nested_future.state is FutureState.CREATED
+    assert root_future.nested_future.kwargs["a"].state is FutureState.CREATED
+    assert root_future.nested_future.kwargs["b"].state is FutureState.CREATED

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -222,7 +222,7 @@ def test_run_execution_ordering(
 
     graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
 
-    run_ids_by_execution_order = graph._run_ids_sorted_by_layer(
+    run_ids_by_execution_order = graph._sorted_run_ids_by_layer(
         run_sorter=graph._execution_order
     )
 
@@ -257,7 +257,7 @@ def test_run_reverse_ordering(
 
     graph = Graph(runs=runs, edges=edges, artifacts=artifacts)
 
-    run_ids_by_reverse_order = graph._run_ids_sorted_by_layer(
+    run_ids_by_reverse_order = graph._sorted_run_ids_by_layer(
         run_sorter=graph._reverse_execution_order
     )
 

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -236,6 +236,7 @@ def test_load_non_inline_logs(test_db, mock_storage: MockStorage):  # noqa: F811
         max_lines=max_lines,
         filter_strings=[],
     )
+    assert result.continuation_cursor is not None
     cursor = Cursor.from_token(result.continuation_cursor)
     result.continuation_cursor = None
     assert result == LogLineResult(
@@ -254,6 +255,7 @@ def test_load_non_inline_logs(test_db, mock_storage: MockStorage):  # noqa: F811
         max_lines=max_lines,
         filter_strings=[],
     )
+    assert result.continuation_cursor is not None
     cursor = Cursor.from_token(result.continuation_cursor)
     result.continuation_cursor = None
     assert result == LogLineResult(
@@ -326,7 +328,7 @@ def test_load_inline_logs(mock_storage: MockStorage, test_db):  # noqa: F811
         max_lines=max_lines,
         filter_strings=[],
     )
-
+    assert result.continuation_cursor is not None
     cursor = Cursor.from_token(result.continuation_cursor)
     result.continuation_cursor = None
     assert result == LogLineResult(
@@ -346,6 +348,8 @@ def test_load_inline_logs(mock_storage: MockStorage, test_db):  # noqa: F811
         max_lines=max_lines,
         filter_strings=[],
     )
+    assert result.continuation_cursor is not None
+
     cursor = Cursor.from_token(result.continuation_cursor)
     result.continuation_cursor = None
 
@@ -416,7 +420,9 @@ def test_load_log_lines(mock_storage: MockStorage, test_db):  # noqa: F811
     )
 
     run.future_state = FutureState.SCHEDULED
-    run.external_jobs = [ExternalJob(kind="fake", try_number=0, external_job_id="fake")]
+    run.external_jobs = (
+        ExternalJob(kind="fake", try_number=0, external_job_id="fake"),
+    )
     save_run(run)
     text_lines = [line.line for line in finite_logs(100)]
     log_file_contents = bytes("\n".join(text_lines), encoding="utf8")

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -1,8 +1,11 @@
 # Standard Library
 from typing import Iterable, List
+from unittest import mock
+
+# Third party
+import pytest
 
 # Sematic
-from sematic import storage
 from sematic.abstract_future import FutureState
 from sematic.db.models.resolution import ResolutionStatus
 from sematic.db.queries import save_resolution, save_run
@@ -22,11 +25,18 @@ from sematic.resolvers.cloud_resolver import (
     START_INLINE_RUN_INDICATOR,
 )
 from sematic.scheduling.external_job import ExternalJob, JobType
-from sematic.tests.fixtures import test_storage  # noqa: F401
+from sematic.tests.fixtures import MockStorage  # noqa: F401
 
 _streamed_lines: List[str] = []
 _DUMMY_LOGS_FILE = "logs.log"
 _DUMMY_RUN_ID = "abc123"
+
+
+@pytest.fixture
+def mock_storage():
+    storage = MockStorage()
+    with mock.patch("sematic.log_reader.S3Storage", return_value=storage):
+        yield storage
 
 
 # Using this should help ensure we're actually properly streaming.
@@ -194,7 +204,7 @@ def test_get_log_lines_from_line_stream_filter():
     )
 
 
-def test_load_non_inline_logs(test_storage, test_db):  # noqa: F811
+def test_load_non_inline_logs(test_db, mock_storage: MockStorage):  # noqa: F811
     run = make_run(future_state=FutureState.RESOLVED)
     save_run(run)
 
@@ -216,7 +226,7 @@ def test_load_non_inline_logs(test_storage, test_db):  # noqa: F811
     assert result.lines == []
     assert result.continuation_cursor is None
     assert result.log_unavailable_reason == "No log files found"
-    storage.set(key, log_file_contents)
+    mock_storage.set(key, log_file_contents)
 
     result = _load_non_inline_logs(
         run_id=run.id,
@@ -271,7 +281,7 @@ def test_load_non_inline_logs(test_storage, test_db):  # noqa: F811
     )
 
 
-def test_load_inline_logs(test_storage, test_db):  # noqa: F811
+def test_load_inline_logs(mock_storage: MockStorage, test_db):  # noqa: F811
     run = make_run(future_state=FutureState.RESOLVED)
     save_run(run)
     resolution = make_resolution(status=ResolutionStatus.COMPLETE)
@@ -305,7 +315,7 @@ def test_load_inline_logs(test_storage, test_db):  # noqa: F811
     assert result.lines == []
     assert result.continuation_cursor is None
     assert result.log_unavailable_reason == "Resolver logs are missing"
-    storage.set(key, log_file_contents)
+    mock_storage.set(key, log_file_contents)
 
     result = _load_inline_logs(
         run_id=run.id,
@@ -366,7 +376,7 @@ def test_load_inline_logs(test_storage, test_db):  # noqa: F811
     )
 
 
-def test_load_log_lines(test_storage, test_db):  # noqa: F811
+def test_load_log_lines(mock_storage: MockStorage, test_db):  # noqa: F811
     run = make_run(future_state=FutureState.CREATED)
     save_run(run)
     resolution = make_resolution(status=ResolutionStatus.SCHEDULED)
@@ -412,7 +422,7 @@ def test_load_log_lines(test_storage, test_db):  # noqa: F811
     log_file_contents = bytes("\n".join(text_lines), encoding="utf8")
     prefix = log_prefix(run.id, JobType.worker)
     key = f"{prefix}12345.log"
-    storage.set(key, log_file_contents)
+    mock_storage.set(key, log_file_contents)
 
     result = load_log_lines(
         run_id=run.id,

--- a/sematic/ui/src/components/ReactFlowDag.tsx
+++ b/sematic/ui/src/components/ReactFlowDag.tsx
@@ -131,8 +131,13 @@ function ReactFlowDag(props: ReactFlowDagProps) {
         });
       } else {
         let parentEdge = edgesById.get(edge.parent_id);
-        if (parentEdge) {
+        while (parentEdge !== undefined) {
           artifactNodeId = makeArtifactNodeId(parentEdge);
+          if (parentEdge.parent_id !== null) {
+            parentEdge = edgesById.get(parentEdge.parent_id);
+          } else {
+            parentEdge = undefined;
+          }
         }
       }
 

--- a/sematic/ui/src/components/RunPanel.tsx
+++ b/sematic/ui/src/components/RunPanel.tsx
@@ -1,4 +1,4 @@
-import { FileCopy, History, Insights } from "@mui/icons-material";
+import { ContentCopy, FileCopy, History, Insights } from "@mui/icons-material";
 import {
   Box,
   FormControl,
@@ -107,10 +107,8 @@ export default function RunPanel(props: {
             <Box sx={{ paddingBottom: 3, gridColumn: 1 }}>
               <Box marginBottom={3}>
                 <Typography variant="h6">{selectedRun.name}</Typography>
-                <CalculatorPath
-                  calculatorPath={"ID:" + selectedRun.id.substring(0, 6)}
-                />{" "}
-                &middot;{" "}
+                <CalculatorPath calculatorPath={selectedRun.id} />
+                <br />
                 <CalculatorPath calculatorPath={selectedRun.calculator_path} />
               </Box>
               <Tags tags={selectedRun.tags || []} />

--- a/sematic/ui/src/components/RunPanel.tsx
+++ b/sematic/ui/src/components/RunPanel.tsx
@@ -1,4 +1,4 @@
-import { ContentCopy, FileCopy, History, Insights } from "@mui/icons-material";
+import { FileCopy, History, Insights } from "@mui/icons-material";
 import {
   Box,
   FormControl,
@@ -107,7 +107,7 @@ export default function RunPanel(props: {
             <Box sx={{ paddingBottom: 3, gridColumn: 1 }}>
               <Box marginBottom={3}>
                 <Typography variant="h6">{selectedRun.name}</Typography>
-                <CalculatorPath calculatorPath={selectedRun.id} />
+                <CalculatorPath calculatorPath={"ID: " + selectedRun.id} />
                 <br />
                 <CalculatorPath calculatorPath={selectedRun.calculator_path} />
               </Box>

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -3,34 +3,40 @@ sematic_py_lib(
     srcs = ["exceptions.py"],
     deps = [
         "//sematic:abstract_calculator",
-    ]
+    ],
 )
 
 sematic_py_lib(
     name = "memoized_property",
     srcs = ["memoized_property.py"],
-    deps = []
+    deps = [],
 )
 
 sematic_py_lib(
     name = "retry",
     srcs = ["retry.py"],
-    deps = []
+    deps = [],
 )
 
 sematic_py_lib(
     name = "stdout",
     srcs = ["stdout.py"],
-    deps = []
+    deps = [],
 )
 
 sematic_py_lib(
     name = "git",
     srcs = ["git.py"],
-    deps = [
-        "//sematic/db/models:git_info",
-    ],
     pip_deps = [
         "git-python",
     ],
+    deps = [
+        "//sematic/db/models:git_info",
+    ],
+)
+
+sematic_py_lib(
+    name = "sorting",
+    srcs = ["sorting.py"],
+    deps = [],
 )

--- a/sematic/utils/memoized_property.py
+++ b/sematic/utils/memoized_property.py
@@ -50,6 +50,29 @@ def _make_cache_name(name: str):
 
 
 def memoized_indexed(fget: typing.Callable) -> typing.Callable:
+    """
+    Memoizes the output of methods with a single string argument (index).
+
+    Example
+    -------
+    >>> class C(object):
+    ...     load_name_count = defaultdict(lambda: 0)
+    ...     @memoized_indexed
+    ...     def name_by_user_id(self, user_id: str) -> str:
+    ...         self.load_name_count[user_id] += 1
+    ...         return self._name_mapping[user_id]
+    >>> c = C()
+    >>> c.load_name_count
+    {}
+    >>> c.name_by_user_id("abc123")
+    "abc123's name"
+    >>> c.load_name_count
+    {"abc123": 1}
+    >>> c.name_by_user_id("abc123")
+    "abc123's name"
+    >>> c.load_name_count
+    {"abc123": 1}
+    """
     cache_name = _make_cache_name(fget.__name__)
 
     @wraps(fget)

--- a/sematic/utils/memoized_property.py
+++ b/sematic/utils/memoized_property.py
@@ -47,3 +47,21 @@ def memoized_property(fget: typing.Callable) -> property:
 
 def make_cache_name(name: str):
     return f"_{name}"
+
+
+def memoized_indexed(fget: typing.Callable) -> typing.Callable:
+    cache_name = make_cache_name(fget.__name__)
+
+    @wraps(fget)
+    def fget_memoized(self, index: str):
+        cache = getattr(self, cache_name, {})
+        setattr(self, cache_name, cache)
+
+        if index not in cache:
+            cache[index] = fget(self, index)
+
+        return cache[index]
+
+    fget_memoized.__annotations__ = fget.__annotations__
+
+    return fget_memoized

--- a/sematic/utils/memoized_property.py
+++ b/sematic/utils/memoized_property.py
@@ -32,12 +32,18 @@ def memoized_property(fget: typing.Callable) -> property:
     >>> c.load_name_count
     1
     """
-    attr_name = "_{0}".format(fget.__name__)
+    cache_name = make_cache_name(fget.__name__)
 
     @wraps(fget)
     def fget_memoized(self):
-        if not hasattr(self, attr_name):
-            setattr(self, attr_name, fget(self))
-        return getattr(self, attr_name)
+        if not hasattr(self, cache_name):
+            setattr(self, cache_name, fget(self))
+        return getattr(self, cache_name)
+
+    fget_memoized.__annotations__ = fget.__annotations__
 
     return property(fget_memoized)
+
+
+def make_cache_name(name: str):
+    return f"_{name}"

--- a/sematic/utils/memoized_property.py
+++ b/sematic/utils/memoized_property.py
@@ -32,7 +32,7 @@ def memoized_property(fget: typing.Callable) -> property:
     >>> c.load_name_count
     1
     """
-    cache_name = make_cache_name(fget.__name__)
+    cache_name = _make_cache_name(fget.__name__)
 
     @wraps(fget)
     def fget_memoized(self):
@@ -45,12 +45,12 @@ def memoized_property(fget: typing.Callable) -> property:
     return property(fget_memoized)
 
 
-def make_cache_name(name: str):
+def _make_cache_name(name: str):
     return f"_{name}"
 
 
 def memoized_indexed(fget: typing.Callable) -> typing.Callable:
-    cache_name = make_cache_name(fget.__name__)
+    cache_name = _make_cache_name(fget.__name__)
 
     @wraps(fget)
     def fget_memoized(self, index: str):

--- a/sematic/utils/sorting.py
+++ b/sematic/utils/sorting.py
@@ -11,7 +11,7 @@ def topological_sort(
     Parameters
     ----------
     dependencies: Dict[str, List[Optional[str]]]
-        A mapping of node to its dependencies. Roots has [None].
+        A mapping of node to its dependencies. The root nodes have [None] as dependencies.
 
     Returns
     -------

--- a/sematic/utils/sorting.py
+++ b/sematic/utils/sorting.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 
 def topological_sort(
@@ -12,6 +12,11 @@ def topological_sort(
     ----------
     dependencies: Dict[str, List[Optional[str]]]
         A mapping of node to its dependencies. Roots has [None].
+
+    Returns
+    -------
+    List[str]
+        IDs sorted topologically.
     """
 
     def _find_next_ids(previous_ids: List[Optional[str]]):
@@ -31,3 +36,39 @@ def topological_sort(
         return next_ids + _find_next_ids(previous_ids + next_ids)  # type: ignore
 
     return _find_next_ids([None])
+
+
+def breadth_first(
+    layers: Dict[Optional[str], List[str]],
+    layer_sorter: Callable[[List[str]], List[str]] = sorted,
+) -> List[str]:
+    """
+    Breadth-first sorting.
+
+    Parameters
+    ----------
+    layers: Dict[Optional[str], List[str]]
+        A mapping of parent node to list of child nodes.
+    layer_sorter: Callable[[List[str]], List[str]]
+        A sorter to sort ids within a given layer.
+
+    Returns
+    -------
+    List[str]
+        IDs ordered breadth first and according to layer_sorter with a given
+        layer.
+    """
+    ids: List[str] = []
+
+    def _add_layer_ids(parent_id: Optional[str]):
+        layer_ids: List[str] = layers.get(parent_id, [])
+
+        ordered_layer_ids = layer_sorter(layer_ids)
+        ids.extend(ordered_layer_ids)
+
+        for id_ in ordered_layer_ids:
+            _add_layer_ids(id_)
+
+    _add_layer_ids(None)
+
+    return ids

--- a/sematic/utils/sorting.py
+++ b/sematic/utils/sorting.py
@@ -1,0 +1,33 @@
+# Standard Library
+from typing import Dict, List, Optional
+
+
+def topological_sort(
+    dependencies: Dict[str, List[Optional[str]]],
+) -> List[str]:
+    """
+    Sorts a list of strings topologically.
+
+    Parameters
+    ----------
+    dependencies: Dict[str, List[Optional[str]]]
+        A mapping of node to its dependencies. Roots has [None].
+    """
+
+    def _find_next_ids(previous_ids: List[Optional[str]]):
+        # Sorting for determinism.
+        next_ids = sorted(
+            [
+                id_
+                for id_, deps in dependencies.items()
+                if id_ not in previous_ids
+                and all(dependency in previous_ids for dependency in deps)
+            ]
+        )
+
+        if len(next_ids) == 0:
+            return []
+
+        return next_ids + _find_next_ids(previous_ids + next_ids)  # type: ignore
+
+    return _find_next_ids([None])

--- a/sematic/utils/tests/BUILD
+++ b/sematic/utils/tests/BUILD
@@ -21,3 +21,11 @@ pytest_test(
         "//sematic/utils:stdout",
     ],
 )
+
+pytest_test(
+    name = "test_sorting",
+    srcs = ["test_sorting.py"],
+    deps = [
+        "//sematic/utils:sorting",
+    ],
+)

--- a/sematic/utils/tests/test_sorting.py
+++ b/sematic/utils/tests/test_sorting.py
@@ -1,0 +1,20 @@
+# Sematic
+from sematic.utils.sorting import breadth_first, topological_sort
+
+
+def test_topological_sort():
+    dependencies = {
+        "A": [None],
+        "B": ["A"],
+        "C": ["A"],
+        "D": ["C", "E"],
+        "E": ["B", "A"],
+    }
+
+    assert topological_sort(dependencies) == ["A", "B", "C", "E", "D"]
+
+
+def test_breadth_first():
+    layers = {None: ["A", "B"], "A": ["C", "D"], "B": ["E", "F"], "D": ["G", "H"]}
+
+    assert breadth_first(layers) == ["A", "B", "C", "D", "G", "H", "E", "F"]


### PR DESCRIPTION
This PR introduces the base mechanism for re-running an existing resolution from a given point.

The mechanism is as follows:
- pass a `rerun_from` argument to the resolver
- fetch entire graph for `rerun_from`'s root run
- recreate future graph
- set state of futures corresponding to `FAILED`, `NESTED_FAILED`, and `CANCELED` runs to `CREATED`
- set state of futures corresponding to `rerun_from`, all its downstream step within same layer, and all downstream of all ancestors to `CREATED`
- set state of futures corresponding to `rerun_from`'s ancestors to `RAN`
- skip all descendants of downstream runs of `rerun_from` and descendants of downstream of its ancestors
- set the new futures as `self._futures`
- persist the graph
- proceed with regular resolution loop

rerun-from-here is supported for `LocalResolver` and `CloudResolver`.
To support `LocalResolver`, the storage engine was refactored to allow local storage. Supporting `LocalResolver` was useful for fast development. Now the storage engine has a `Storage` abstract base class, and `LocalStorage` and `S3Storage` concrete implementations.

This PR does not include UI work. This will come in a subsequent PR.

Testing
-------
- Unit tests for `Graph`
- Unit tests for `LocalResolver`
- Unit tests for the resolution scheduling endpoint and `job_scheduler.py`
- Manual tests for local and cloud execution