### PR TITLE
Fix max_parallelism for deached mode

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -124,7 +124,13 @@ def schedule_resolution_endpoint(
 ) -> flask.Response:
     resolution = get_resolution(resolution_id)
 
-    resolution = schedule_resolution(resolution)
+    max_parallelism = None
+    if flask.request.json and "max_parallelism" in flask.request.json:
+        max_parallelism = flask.request.json["max_parallelism"]
+
+    resolution = schedule_resolution(
+        resolution=resolution, max_parallelism=max_parallelism
+    )
 
     save_resolution(resolution)
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -145,9 +145,16 @@ def schedule_run(run_id: str) -> Run:
     return Run.from_json_encodable(response["content"])
 
 
-def schedule_resolution(resolution_id: str) -> Resolution:
+def schedule_resolution(
+    resolution_id: str, max_parallelism: Optional[int] = None
+) -> Resolution:
     """Ask the server to start a detached resolution execution."""
-    response = _post(f"/resolutions/{resolution_id}/schedule", json_payload={})
+    payload = {}
+
+    if max_parallelism is not None:
+        payload["max_parallelism"] = max_parallelism
+
+    response = _post(f"/resolutions/{resolution_id}/schedule", json_payload=payload)
     return Resolution.from_json_encodable(response["content"])
 
 

--- a/sematic/examples/bazel/BUILD
+++ b/sematic/examples/bazel/BUILD
@@ -15,7 +15,7 @@ sematic_pipeline(
     name = "bazel",
     dev = True,
     registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
-    repository = " sematic-dev",
+    repository = "sematic-dev",
     deps = [
         ":bazel_lib",
     ],

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -52,9 +52,6 @@ class CloudResolver(LocalResolver):
 
         When `False`, the driver job runs on the local machine. The shell prompt
         will return when the entire pipeline has completed.
-    is_running_remotely: bool
-        For Sematic internal usage. End users should always leave this at the default
-        value of False.
     max_parallelism: Optional[int]
         The maximum number of non-inlined runs that this resolver will allow to be in the
         SCHEDULED state at any one time. Must be a positive integer, or None for
@@ -66,6 +63,9 @@ class CloudResolver(LocalResolver):
         considered in this parallelism limit. Note also that runs that are in the RAN
         state do not contribute to the limit, since they do not consume computing
         resources.
+    _is_running_remotely: bool
+        For Sematic internal usage. End users should always leave this at the default
+        value of False.
     """
 
     def __init__(
@@ -214,7 +214,9 @@ class CloudResolver(LocalResolver):
         api_client.notify_pipeline_update(run.calculator_path)
 
         # SUBMIT RESOLUTION JOB
-        api_client.schedule_resolution(future.id)
+        api_client.schedule_resolution(
+            resolution_id=future.id, max_parallelism=self._max_parallelism
+        )
 
         return run.id
 

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -108,6 +108,7 @@ class StateMachineResolver(Resolver, abc.ABC):
 
     def _can_schedule_future(self, _: AbstractFuture) -> bool:
         """Returns whether the specified future can be scheduled."""
+        logger.error("SHOULD NOT BE HERE!")
         return True
 
     @abc.abstractmethod

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -108,7 +108,6 @@ class StateMachineResolver(Resolver, abc.ABC):
 
     def _can_schedule_future(self, _: AbstractFuture) -> bool:
         """Returns whether the specified future can be scheduled."""
-        logger.error("SHOULD NOT BE HERE!")
         return True
 
     @abc.abstractmethod

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -97,8 +97,11 @@ def test_simulate_cloud_exec(
 
     mock_update_run_future_states.side_effect = fake_update_run_future_states
 
-    mock_schedule_resolution.assert_called_once_with(future.id)
+    mock_schedule_resolution.assert_called_once_with(
+        resolution_id=future.id, max_parallelism=None
+    )
     assert api_client.get_resolution(future.id).status == ResolutionStatus.CREATED.value
+
     resolution = api_client.get_resolution(future.id)
     root_run = api_client.get_run(future.id)
     assert root_run.container_image_uri == images["default"]

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -38,7 +38,7 @@ def parse_args():
     parser = argparse.ArgumentParser("Sematic cloud worker")
     parser.add_argument("--run_id", type=str, required=True)
     parser.add_argument("--resolve", default=False, action="store_true", required=False)
-    parser.add_argument("--max_parallelism", type=int, default=None, required=False)
+    parser.add_argument("--max-parallelism", type=int, default=None, required=False)
 
     args = parser.parse_args()
 
@@ -200,7 +200,7 @@ def wrap_main_with_logging():
         )
         logger.info("Worker CLI args: run_id=%s", args.run_id)
         logger.info("Worker CLI args: resolve=%s", args.resolve)
-        logger.info("Worker CLI args: max_parallelism=%s", args.max_parallelism)
+        logger.info("Worker CLI args: max-parallelism=%s", args.max_parallelism)
 
         main(
             run_id=args.run_id,

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -37,18 +37,23 @@ def schedule_run(run: Run, resolution: Resolution) -> Run:
     return run
 
 
-def schedule_resolution(resolution: Resolution) -> Resolution:
+def schedule_resolution(
+    resolution: Resolution, max_parallelism: Optional[int] = None
+) -> Resolution:
     """Start a resolution for the run on external compute.
 
     Parameters
     ----------
     resolution:
         The resolution associated with the run
+    max_parallelism:
+        The maximum number of non-inlined runs that the resolver will allow to be in the
+        SCHEDULED state at any one time.
     """
     resolution.external_jobs = _refresh_external_jobs(resolution.external_jobs)
     _assert_resolution_is_scheduleable(resolution)
     external_jobs_list = list(resolution.external_jobs) + [
-        _schedule_resolution_job(resolution)
+        _schedule_resolution_job(resolution=resolution, max_parallelism=max_parallelism)
     ]
     resolution.external_jobs = tuple(external_jobs_list)
     resolution.status = ResolutionStatus.SCHEDULED
@@ -196,7 +201,9 @@ def _schedule_job(run: Run, resolution: Resolution) -> ExternalJob:
     )
 
 
-def _schedule_resolution_job(resolution: Resolution) -> ExternalJob:
+def _schedule_resolution_job(
+    resolution: Resolution, max_parallelism: Optional[int] = None
+) -> ExternalJob:
     """Reach out to external compute to start the execution of the resolution"""
     # should be impossible to fail this assert, but it makes mypy happy
     assert resolution.container_image_uri is not None
@@ -204,4 +211,5 @@ def _schedule_resolution_job(resolution: Resolution) -> ExternalJob:
         resolution_id=resolution.root_id,
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
+        max_parallelism=max_parallelism,
     )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -349,7 +349,9 @@ def schedule_resolution_job(
     resolution_id: str,
     image: str,
     user_settings: Dict[str, str],
+    max_parallelism: Optional[int] = None,
 ) -> ExternalJob:
+
     namespace = get_user_settings(SettingsVar.KUBERNETES_NAMESPACE)
     external_job = KubernetesExternalJob.new(
         try_number=0,
@@ -357,8 +359,13 @@ def schedule_resolution_job(
         namespace=namespace,
         job_type=JobType.driver,
     )
+
     logger.info("Scheduling job %s", external_job.kubernetes_job_name)
     args = ["--run_id", resolution_id, "--resolve"]
+
+    if max_parallelism is not None:
+        args += ["--max_parallelism", str(max_parallelism)]
+
     _schedule_kubernetes_job(
         name=external_job.kubernetes_job_name,
         image=image,

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -364,7 +364,7 @@ def schedule_resolution_job(
     args = ["--run_id", resolution_id, "--resolve"]
 
     if max_parallelism is not None:
-        args += ["--max_parallelism", str(max_parallelism)]
+        args += ["--max-parallelism", str(max_parallelism)]
 
     _schedule_kubernetes_job(
         name=external_job.kubernetes_job_name,

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -88,7 +88,7 @@ def test_schedule_run(mock_k8s, run: Run, resolution: Resolution):
 
 
 def test_schedule_resolution(mock_k8s, resolution: Resolution):
-    scheduled = schedule_resolution(resolution)
+    scheduled = schedule_resolution(resolution, max_parallelism=3)
     assert len(scheduled.external_jobs) == 1
     external_job = scheduled.external_jobs[0]
     assert isinstance(external_job, KubernetesExternalJob)
@@ -97,6 +97,7 @@ def test_schedule_resolution(mock_k8s, resolution: Resolution):
         resolution_id=resolution.root_id,
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
+        max_parallelism=3,
     )
 
 


### PR DESCRIPTION
The `max_parallelism` configuration wasn't passed to the detached `CloudResolver`, meaning detached execution ignored it.

This PR passes it through the worker command line interface.

## Testing

Discovered by @augray on [this branch](https://github.com/sematic-ai/sematic/tree/augray/parallel-reproduce).
Validated on top of it as well.

Resolution link: https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/2fae07faef3c4b758ebf36c01c697b93

Snapshot of the above resolution graph showing the parameter is not ignored:
![image](https://user-images.githubusercontent.com/1894533/197635399-ba6b6afa-2210-4815-a668-d4b63e11541e.png)

Resolver logs (with extra debugging lines which weren't added to the PR) showing the parameter is passed and taken into account:
```
tudor@[the-box]:~/sematic$ kubectl exec -i sematic-driver-2fae07faef3c4b758ebf36c01c697b93-fd3e8f-ljwn7 -- cat /tmp/sematic_logs/worker.log
2022-10-24 21:32:45,971 - INFO - __main__: Worker CLI args: run_id=2fae07faef3c4b758ebf36c01c697b93
2022-10-24 21:32:45,972 - INFO - __main__: Worker CLI args: resolve=True
2022-10-24 21:32:45,972 - INFO - __main__: Worker CLI args: max_parallelism=2
2022-10-24 21:32:46,148 - INFO - __main__: Importing function sematic.examples.bazel.pipeline.pipeline
2022-10-24 21:32:46,243 - INFO - botocore.credentials: Found credentials from IAM Role: c4_2xlarge-eks-node-group-20220715172153217400000001
2022-10-24 21:32:46,874 - INFO - __main__: Resolving pipeline
2022-10-24 21:32:46,875 - INFO - sematic.resolvers.state_machine_resolver: Starting resolution 2fae07faef3c4b758ebf36c01c697b93
2022-10-24 21:32:47,720 - INFO - sematic.resolvers.state_machine_resolver: Running inline sematic.examples.bazel.pipeline.pipeline
2022-10-24 21:32:47,758 - INFO - sematic.resolvers.cloud_resolver: --------- Sematic Start Inline Run 2fae07faef3c4b758ebf36c01c697b93 ---------
2022-10-24 21:32:48,199 - INFO - sematic.resolvers.cloud_resolver: --------- Sematic End Inline Run 2fae07faef3c4b758ebf36c01c697b93 ---------
2022-10-24 21:32:48,199 - WARNING - sematic.resolvers.cloud_resolver: #### 0 futures scheduled out of 13
2022-10-24 21:32:48,199 - WARNING - root: Have 0 remote runs scheduled out of a maximum of 2
2022-10-24 21:32:48,452 - INFO - sematic.resolvers.state_machine_resolver: Scheduling sematic.examples.bazel.pipeline.sleep_for
2022-10-24 21:32:48,546 - WARNING - sematic.resolvers.cloud_resolver: #### 1 futures scheduled out of 13
2022-10-24 21:32:48,546 - WARNING - root: Have 1 remote runs scheduled out of a maximum of 2
2022-10-24 21:32:48,809 - INFO - sematic.resolvers.state_machine_resolver: Scheduling sematic.examples.bazel.pipeline.sleep_for
2022-10-24 21:32:48,892 - WARNING - sematic.resolvers.cloud_resolver: #### 2 futures scheduled out of 13
2022-10-24 21:32:48,892 - WARNING - root: Have 2 remote runs scheduled out of a maximum of 2
2022-10-24 21:32:48,892 - INFO - sematic.resolvers.state_machine_resolver: Currently not scheduling sematic.examples.bazel.pipeline.sleep_for
2022-10-24 21:32:48,892 - WARNING - sematic.resolvers.cloud_resolver: #### 2 futures scheduled out of 13
2022-10-24 21:32:48,892 - WARNING - root: Have 2 remote runs scheduled out of a maximum of 2
2022-10-24 21:32:48,892 - INFO - sematic.resolvers.state_machine_resolver: Currently not scheduling sematic.examples.bazel.pipeline.sleep_for
2022-10-24 21:32:48,892 - WARNING - sematic.resolvers.cloud_resolver: #### 2 futures scheduled out of 13
2022-10-24 21:32:48,892 - WARNING - root: Have 2 remote runs scheduled out of a maximum of 2
[...]
```