### PR TITLE
fix latest condition off-by-one error

### DIFF
--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -208,7 +208,7 @@ def refresh_job(job: ExternalJob) -> KubernetesExternalJob:
     )
     if (
         k8s_job.status.conditions is not None  # type: ignore
-        and len(k8s_job.status.conditions) > 1  # type: ignore
+        and len(k8s_job.status.conditions) >= 1  # type: ignore
     ):
         conditions = sorted(
             k8s_job.status.conditions,  # type: ignore


### PR DESCRIPTION
There was a check for reading k8s status conditions that should have been looking for >=1, but was only >1.