### PR TITLE
Allow for using sematic.SilentResolver without going into deep imports

### DIFF
--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -24,6 +24,7 @@ from sematic.container_images import has_container_image  # noqa: F401,E402
 from sematic.resolver import Resolver  # noqa: F401,E402
 from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
 from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401,E402
+from sematic.resolvers.silent_resolver import SilentResolver  # noqa: F401,E402
 from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
     KubernetesResourceRequirements,
     KubernetesSecretMount,


### PR DESCRIPTION
`sematic.SilentResolver` not created in `sematic` package, this allows for direct usage
