### PR TITLE
Expose Kubernetes infra failures in the Run panel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ with nothing else on the line.
 -->
 * HEAD
     * [feature] Support for easier testing of Sematic pipelines
+    * [feature] Expose Kubernetes infra failures in the Run panel
 * 0.18.1
     * [bugfix] Remove SQLAlchemy model dependencies from Python migrations
     * [bugfix] Enable usage of multiple base images in detached mode

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -40,7 +40,8 @@ click
 
 # Examples
 torch
-torchvision
+torchvision==0.13.1  # Because 0.14.0 fails with
+# AssertionError: In torchvision-0.14.0-cp39-cp39-manylinux1_x86_64.whl, torchvision-0.14.0.dist-info/RECORD is not mentioned in RECORD
 torchmetrics
 plotly
 pandas

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -15,6 +15,7 @@ sematic_py_lib(
         "//sematic/resolvers:worker",
         "//sematic/types:casting",
         "//sematic/types:init",
+        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -34,4 +34,5 @@ from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
 )
 from sematic.resolvers.silent_resolver import SilentResolver  # noqa: F401,E402
 from sematic.retry_settings import RetrySettings  # noqa: F401, E402
+from sematic.utils.exceptions import KubernetesError, ResolutionError  # noqa: F401,E402
 from sematic.versions import CURRENT_VERSION_STR as __version__  # noqa: F401,E402

--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -19,7 +19,6 @@ sematic_py_lib(
         "//sematic/db/models:run",
         "//sematic/db/models:user",
         "//sematic/scheduling:job_scheduler",
-        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -259,8 +259,7 @@ def _get_run_if_modified(
     new_future_state, new_external_jobs = update_run_status(future_state, jobs)
     run = None
 
-    # TODO: implement safer comparison logic
-    # these jobs variables can be either tuples or lists of polymorphic dataclasses
+    # we standardize to tuples, but sometimes we get lists
     if tuple(new_external_jobs) != tuple(jobs):
         run = get_run(run_id)
         run.external_jobs = new_external_jobs

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -193,7 +193,7 @@ def test_schedule_run(
             still_exists=True,
             start_time=None,
             most_recent_condition=None,
-            most_recent_pod_phase=None,
+            most_recent_pod_phase_message=None,
             most_recent_pod_condition_message=None,
             most_recent_container_condition_message=None,
             has_infra_failure=False,
@@ -245,7 +245,7 @@ def test_update_future_states(
             still_exists=True,
             start_time=1.01,
             most_recent_condition=None,
-            most_recent_pod_phase=None,
+            most_recent_pod_phase_message=None,
             most_recent_pod_condition_message=None,
             most_recent_container_condition_message=None,
             has_infra_failure=False,
@@ -283,7 +283,7 @@ def test_update_run_disappeared(
             still_exists=True,
             start_time=1.01,
             most_recent_condition=None,
-            most_recent_pod_phase=None,
+            most_recent_pod_phase_message=None,
             most_recent_pod_condition_message=None,
             most_recent_container_condition_message=None,
             has_infra_failure=False,
@@ -312,11 +312,8 @@ def test_update_run_disappeared(
         assert loaded.external_exception_metadata == ExceptionMetadata(
             repr="The Kubernetes job state is unknown",
             name="KubernetesError",
-            module="sematic.scheduling.kubernetes",
-            ancestors=[
-                f"{ValueError.__module__}.{ValueError.__name__}",
-                f"{Exception.__module__}.{Exception.__name__}",
-            ],
+            module="sematic.utils.exceptions",
+            ancestors=[f"{Exception.__module__}.{Exception.__name__}"],
         )
 
 
@@ -337,7 +334,7 @@ def test_update_run_k8_pod_error(
             still_exists=True,
             start_time=1.01,
             most_recent_condition=None,
-            most_recent_pod_phase=None,
+            most_recent_pod_phase_message=None,
             most_recent_pod_condition_message=None,
             most_recent_container_condition_message=None,
             has_infra_failure=False,
@@ -350,7 +347,7 @@ def test_update_run_k8_pod_error(
         job.still_exists = False
         assert not job.is_active()
         job.has_infra_failure = True
-        job.most_recent_pod_phase = "Failed"
+        job.most_recent_pod_phase_message = "Failed"
         job.most_recent_pod_condition_message = "test pod condition"
         job.most_recent_container_condition_message = "test container condition"
         mock_k8s.refresh_job.side_effect = lambda j: job
@@ -367,11 +364,8 @@ def test_update_run_k8_pod_error(
         assert loaded.external_exception_metadata == ExceptionMetadata(
             repr="Failed\ntest pod condition\ntest container condition",
             name="KubernetesError",
-            module="sematic.scheduling.kubernetes",
-            ancestors=[
-                f"{ValueError.__module__}.{ValueError.__name__}",
-                f"{Exception.__module__}.{Exception.__name__}",
-            ],
+            module="sematic.utils.exceptions",
+            ancestors=[f"{Exception.__module__}.{Exception.__name__}"],
         )
 
 

--- a/sematic/api/server.py
+++ b/sematic/api/server.py
@@ -92,7 +92,7 @@ def run_wsgi(daemon: bool):
 def make_log_config():
     stdout_handler_list = ["stdout"] if get_config().server_log_to_stdout else []
     full_handler_list = ["default", "error"] + stdout_handler_list
-    root_logger_config = {"level": "DEBUG", "handlers": full_handler_list}
+    root_logger_config = {"level": "INFO", "handlers": full_handler_list}
     log_rotation_settings = {
         "formatter": "standard",
         "class": "logging.handlers.RotatingFileHandler",

--- a/sematic/api/server.py
+++ b/sematic/api/server.py
@@ -92,7 +92,7 @@ def run_wsgi(daemon: bool):
 def make_log_config():
     stdout_handler_list = ["stdout"] if get_config().server_log_to_stdout else []
     full_handler_list = ["default", "error"] + stdout_handler_list
-    root_logger_config = {"level": "INFO", "handlers": full_handler_list}
+    root_logger_config = {"level": "DEBUG", "handlers": full_handler_list}
     log_rotation_settings = {
         "formatter": "standard",
         "class": "logging.handlers.RotatingFileHandler",

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -193,8 +193,7 @@ def update_run_future_states(run_ids: List[str]) -> Dict[str, FutureState]:
     """Ask the server to update the status of given run ids if needed and return them.
 
     The server will actively update run statuses based on the state of remote jobs
-    associated with the runs. It will NOT perform any updates to the run statuses
-    that result from result availability or calculator errors.
+    associated with the runs.
 
     Parameters
     ----------

--- a/sematic/db/migrations/20221025201847_add_external_exception_json_field.sql
+++ b/sematic/db/migrations/20221025201847_add_external_exception_json_field.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE runs ADD COLUMN external_exception_json JSONB;
+
+-- migrate:down
+
+ALTER TABLE runs DROP COLUMN external_exception_json;

--- a/sematic/db/migrations/20221027233641_rename_exception_fields_to_metadata.sql
+++ b/sematic/db/migrations/20221027233641_rename_exception_fields_to_metadata.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+
+ALTER TABLE runs RENAME COLUMN exception_json TO exception_metadata_json;
+ALTER TABLE runs RENAME COLUMN external_exception_json TO external_exception_metadata_json;
+
+-- migrate:down
+
+ALTER TABLE runs RENAME COLUMN exception_metadata_json TO exception_json;
+ALTER TABLE runs RENAME COLUMN external_exception_metadata_json TO external_exception_json;

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -10,7 +10,15 @@ CREATE TABLE runs (
     ended_at timestamp,
     resolved_at timestamp,
     failed_at timestamp,
-    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), external_jobs_json JSONB, resource_requirements_json JSONB, exception_json JSONB, container_image_uri TEXT,
+    parent_id character(32),
+    description TEXT, tags TEXT,
+    source_code TEXT, root_id character(32),
+    nested_future_id character(32),
+    external_jobs_json JSONB,
+    resource_requirements_json JSONB,
+    exception_json JSONB,
+    container_image_uri TEXT,
+    external_exception_json JSONB,
 
     PRIMARY KEY (id)
 );
@@ -19,7 +27,8 @@ CREATE TABLE artifacts (
     id character(40) NOT NULL,
     json_summary JSONB NOT NULL,
     created_at timestamp NOT NULL,
-    updated_at timestamp NOT NULL, type_serialization JSONB,
+    updated_at timestamp NOT NULL,
+    type_serialization JSONB,
 
     PRIMARY KEY (id)
 );
@@ -69,7 +78,10 @@ CREATE TABLE resolutions (
     status TEXT NOT NULL,
     kind TEXT NOT NULL,
     container_image_uri TEXT,
-    settings_env_vars JSONB NOT NULL, external_jobs_json JSONB, git_info_json JSONB, container_image_uris JSONB,
+    settings_env_vars JSONB NOT NULL,
+    external_jobs_json JSONB,
+    git_info_json JSONB,
+    container_image_uris JSONB,
 
     PRIMARY KEY (root_id),
     FOREIGN KEY (root_id) REFERENCES runs(id)
@@ -98,4 +110,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20221013060942'),
   ('20221013070256'),
   ('20221017233940'),
-  ('20221019225916');
+  ('20221019225916'),
+  ('20221025201847');

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -16,9 +16,9 @@ CREATE TABLE runs (
     nested_future_id character(32),
     external_jobs_json JSONB,
     resource_requirements_json JSONB,
-    exception_json JSONB,
+    exception_metadata_json JSONB,
     container_image_uri TEXT,
-    external_exception_json JSONB,
+    external_exception_metadata_json JSONB,
 
     PRIMARY KEY (id)
 );
@@ -111,4 +111,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20221013070256'),
   ('20221017233940'),
   ('20221019225916'),
-  ('20221025201847');
+  ('20221025201847'),
+  ('20221027233641');

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -243,7 +243,7 @@ class CloudResolver(LocalResolver):
         # if the external run is reported to not have completed successfully by the server
         if run.future_state not in {FutureState.RESOLVED.value, FutureState.RAN.value}:
             self._handle_future_failure(
-                future, Exception("Run failed, see exception in the UI."), run.exception
+                future, run.exception_metadata, run.external_exception_metadata
             )
             return
 
@@ -271,9 +271,9 @@ class CloudResolver(LocalResolver):
         if (
             failed_future.state == FutureState.FAILED
             and run is not None
-            and run.exception is None
+            and run.exception_metadata is None
         ):
-            run.exception = format_exception_for_run()
+            run.exception_metadata = format_exception_for_run()
         self._add_run(run)
         self._save_graph()
         if failed_future.state == FutureState.NESTED_FAILED:

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -22,7 +22,9 @@ class SilentResolver(StateMachineResolver):
             value = future.calculator.calculate(**future.resolved_kwargs)
             self._update_future_with_value(future, value)
         except ResolutionError:
-            # was already properly handled
+            # only we raise ResolutionError when determining a failure is unrecoverable
+            # if we got this exception type, then the failure has already been properly
+            # handled and all is left to do is to terminate the execution.
             raise
         except Exception as e:
             logger.error("Error executing future", exc_info=e)

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -4,7 +4,7 @@ import logging
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.resolvers.state_machine_resolver import StateMachineResolver
-from sematic.utils.exceptions import format_exception_for_run
+from sematic.utils.exceptions import ResolutionError, format_exception_for_run
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,9 @@ class SilentResolver(StateMachineResolver):
             self._start_inline_execution(future.id)
             value = future.calculator.calculate(**future.resolved_kwargs)
             self._update_future_with_value(future, value)
+        except ResolutionError:
+            # was already properly handled
+            raise
         except Exception as e:
             logger.error("Error executing future", exc_info=e)
             self._handle_future_failure(future, format_exception_for_run(e))

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -329,10 +329,10 @@ class StateMachineResolver(Resolver, abc.ABC):
             raise ResolutionError(exception_metadata, external_exception_metadata)
 
         if not retry_settings.should_retry(
-            exception_metadata
-        ) or not retry_settings.should_retry(external_exception_metadata):
+            exception_metadata, external_exception_metadata
+        ):
             logging.info(
-                "Retries exhausted or exception not retryable for "
+                "Retries exhausted or exception not retriable for "
                 f"{future.id}, failing now."
             )
             self._fail_future_and_parents(future)

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -12,7 +12,11 @@ from contextlib import contextmanager
 from sematic.abstract_calculator import CalculatorError
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.resolver import Resolver
-from sematic.utils.exceptions import ExceptionMetadata, format_exception_for_run
+from sematic.utils.exceptions import (
+    ExceptionMetadata,
+    ResolutionError,
+    format_exception_for_run,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +255,7 @@ class StateMachineResolver(Resolver, abc.ABC):
     @staticmethod
     def _get_resolved_kwargs(future: AbstractFuture) -> typing.Dict[str, typing.Any]:
         """
-        Extract only resolved/concrete kwargs
+        Extract only resolved/concrete kwargs.
         """
         resolved_kwargs = {}
         for name, value in future.kwargs.items():
@@ -301,35 +305,45 @@ class StateMachineResolver(Resolver, abc.ABC):
     def _handle_future_failure(
         self,
         future: AbstractFuture,
-        exception: Exception,
         exception_metadata: typing.Optional[ExceptionMetadata] = None,
-    ):
+        external_exception_metadata: typing.Optional[ExceptionMetadata] = None,
+    ) -> None:
         """
         When a future fails, its state machine as well as that of its parent
         futures need to be updated.
-        """
-        if (
-            future.props.retry_settings is not None
-            and future.props.retry_settings.should_retry(
-                exception_metadata or format_exception_for_run(exception)
-            )
-        ):
-            retries_left = (
-                future.props.retry_settings.retries
-                - future.props.retry_settings.retry_count
-            )
-            logger.info(f"Retrying {future.id}. " f"{retries_left} retries left.")
-            self._set_future_state(future, FutureState.RETRYING)
-            future.props.retry_settings.retry_count += 1
-        else:
-            logging.info(f"Retries exhausted for {future.id}, failing now.")
-            self._fail_future_and_parents(future)
-            raise exception
 
-    def _fail_future_and_parents(
-        self,
-        future: AbstractFuture,
-    ):
+        Parameters
+        ----------
+        exception_metadata:
+            Metadata describing an exception which occurred during code execution
+            (Pipeline, Resolver, Driver)
+        external_exception_metadata:
+            Metadata describing an exception which occurred in external compute
+            infrastructure
+        """
+        retry_settings = future.props.retry_settings
+
+        if retry_settings is None:
+            logging.info(f"No retries configured for {future.id}, failing now.")
+            self._fail_future_and_parents(future)
+            raise ResolutionError(exception_metadata, external_exception_metadata)
+
+        if not retry_settings.should_retry(
+            exception_metadata
+        ) or not retry_settings.should_retry(external_exception_metadata):
+            logging.info(
+                "Retries exhausted or exception not retryable for "
+                f"{future.id}, failing now."
+            )
+            self._fail_future_and_parents(future)
+            raise ResolutionError(exception_metadata, external_exception_metadata)
+
+        retries_left = retry_settings.retries - retry_settings.retry_count
+        logger.info(f"Retrying {future.id}. {retries_left} retries left.")
+        self._set_future_state(future, FutureState.RETRYING)
+        retry_settings.retry_count += 1
+
+    def _fail_future_and_parents(self, future: AbstractFuture) -> None:
         """
         Mark the future FAILED and its parent futures NESTED_FAILED.
         """
@@ -345,8 +359,9 @@ class StateMachineResolver(Resolver, abc.ABC):
     ) -> None:
         try:
             value = future.calculator.cast_output(value)
-        except TypeError as exception:
-            self._handle_future_failure(future, exception)
+        except TypeError as e:
+            logger.error("Unable to process future value", exc_info=e)
+            self._handle_future_failure(future, format_exception_for_run(e))
             return
 
         if isinstance(value, AbstractFuture):
@@ -360,7 +375,7 @@ class StateMachineResolver(Resolver, abc.ABC):
         self, future: AbstractFuture, nested_future: AbstractFuture
     ) -> None:
         """
-        Setting a nested future on a RAN future
+        Setting a nested future on a RAN future.
         """
         future.nested_future = nested_future
         nested_future.parent_future = future

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -3,6 +3,7 @@ pytest_test(
     srcs = ["test_local_resolver.py"],
     deps = [
         ":fixtures",
+        "//sematic:abstract_calculator",
         "//sematic:abstract_future",
         "//sematic:calculator",
         "//sematic:retry_settings",
@@ -39,9 +40,11 @@ pytest_test(
     name = "test_silent_resolver",
     srcs = ["test_silent_resolver.py"],
     deps = [
+        "//sematic:abstract_calculator",
         "//sematic:calculator",
         "//sematic:retry_settings",
         "//sematic/resolvers:silent_resolver",
+        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -121,5 +121,5 @@ def test_fail(
     runs, _, _ = get_root_graph(future.id)
 
     assert runs[0].future_state == FutureState.FAILED.value
-    assert runs[0].exception is not None
-    assert "FAIL!" in runs[0].exception.repr
+    assert runs[0].exception_metadata is not None
+    assert "FAIL!" in runs[0].exception_metadata.repr

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -77,14 +77,14 @@ def _fail_run(run: Run, e: BaseException) -> None:
     run.future_state = FutureState.FAILED
     run.failed_at = datetime.datetime.utcnow()
 
-    if run.exception_metadata is not None:
+    if run.exception_metadata is None:
+        # this means the exception probably happened in the Resolver code
+        run.exception_metadata = format_exception_for_run(e)
+    else:
         # if the run already has an exception marked on it, then it's the innermost cause
         # of the failure; any other exception generated afterwards is done so while trying
         # to handle the failure
         logger.warning("Got exception while handling run failure", exc_info=e)
-    else:
-        # this means the exception probably happened in the Resolver code
-        run.exception_metadata = format_exception_for_run(e)
 
     api_client.save_graph(run.id, [run], [], [])
 

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -77,14 +77,15 @@ def _fail_run(run: Run, e: BaseException) -> None:
     run.future_state = FutureState.FAILED
     run.failed_at = datetime.datetime.utcnow()
 
-    # if the run already has an exception marked on it, then it's the innermost cause
-    # of the failure; any other exception generated afterwards is done so while trying to
-    # handle the failure
     if run.exception_metadata is not None:
+        # if the run already has an exception marked on it, then it's the innermost cause
+        # of the failure; any other exception generated afterwards is done so while trying
+        # to handle the failure
         logger.warning("Got exception while handling run failure", exc_info=e)
-    # this means the exception probably happened in the Resolver code
     else:
+        # this means the exception probably happened in the Resolver code
         run.exception_metadata = format_exception_for_run(e)
+
     api_client.save_graph(run.id, [run], [], [])
 
 

--- a/sematic/retry_settings.py
+++ b/sematic/retry_settings.py
@@ -1,6 +1,6 @@
 # Standard Library
 from dataclasses import dataclass, field
-from typing import Tuple, Type
+from typing import Optional, Tuple, Type
 
 # Sematic
 from sematic.utils.exceptions import ExceptionMetadata
@@ -28,10 +28,13 @@ class RetrySettings:
         if not isinstance(self.exceptions, (tuple, list, set)):
             raise ValueError(f"exceptions should be a tuple, got {self.exceptions}")
 
-    def should_retry(self, exception_metadata: ExceptionMetadata) -> bool:
+    def should_retry(self, exception_metadata: Optional[ExceptionMetadata]) -> bool:
         """
         Should the given exception trigger a retry?
         """
+        if exception_metadata is None:
+            return True
+
         if not self._matches_exceptions(exception_metadata):
             return False
 

--- a/sematic/retry_settings.py
+++ b/sematic/retry_settings.py
@@ -1,9 +1,12 @@
 # Standard Library
+import logging
 from dataclasses import dataclass, field
 from typing import Optional, Tuple, Type
 
 # Sematic
 from sematic.utils.exceptions import ExceptionMetadata
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -28,14 +31,29 @@ class RetrySettings:
         if not isinstance(self.exceptions, (tuple, list, set)):
             raise ValueError(f"exceptions should be a tuple, got {self.exceptions}")
 
-    def should_retry(self, exception_metadata: Optional[ExceptionMetadata]) -> bool:
+    def should_retry(
+        self, *exception_metadata_tuple: Optional[ExceptionMetadata]
+    ) -> bool:
         """
-        Should the given exception trigger a retry?
-        """
-        if exception_metadata is None:
-            return True
+        Should the given exceptions trigger a retry?
 
-        if not self._matches_exceptions(exception_metadata):
+        If this is called with no effective parameters or only with None values, it means
+        we are in an abnormal situation in which a future failed with no known cause.
+
+        Parameters
+        ----------
+        exception_metadata_tuple: Tuple[Optional[ExceptionMetadata]]
+            Metadata describing a series of exceptions that have affected execution.
+        """
+        filtered_list = [e for e in exception_metadata_tuple if e is not None]
+        if len(filtered_list) == 0:
+            logger.warning(
+                "`should_retry` called with no effective exception metadata! "
+                "Unknown failure situation!"
+            )
+            return False
+
+        if not any(map(self._matches_exceptions, filtered_list)):
             return False
 
         return self.retry_count < self.retries

--- a/sematic/scheduling/BUILD
+++ b/sematic/scheduling/BUILD
@@ -2,6 +2,7 @@ sematic_py_lib(
     name = "external_job",
     srcs = ["external_job.py"],
     deps = [
+        "//sematic/utils:exceptions",
     ],
 )
 
@@ -21,11 +22,12 @@ sematic_py_lib(
     name = "kubernetes",
     srcs = ["kubernetes.py"],
     deps = [
-        "//sematic/utils:retry",
         "//sematic:config",
         "//sematic:container_images",
         "//sematic/scheduling:external_job",
-        "//sematic/resolvers:resource_requirements"
+        "//sematic/resolvers:resource_requirements",
+        "//sematic/utils:exceptions",
+        "//sematic/utils:retry",
     ],
     pip_deps = [
         "kubernetes",

--- a/sematic/scheduling/external_job.py
+++ b/sematic/scheduling/external_job.py
@@ -1,6 +1,10 @@
 # Standard Library
 import enum
 from dataclasses import dataclass
+from typing import Optional
+
+# Sematic
+from sematic.utils.exceptions import ExceptionMetadata
 
 KUBERNETES_JOB_KIND = "k8s"
 
@@ -43,3 +47,9 @@ class ExternalJob:
         True if the job is still active, False otherwise.
         """
         raise NotImplementedError("Subclasses of ExternalJob should define is_active")
+
+    def get_exception_metadata(self) -> Optional[ExceptionMetadata]:
+        """Returns an `ExceptionMetadata` object in case the job has experienced a
+        failure.
+        """
+        return None

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -380,7 +380,7 @@ def _get_most_recent_pod_details(
         # try to build a message based on the latest container status
         if _is_none_or_empty(most_recent_pod.status.container_statuses):
             most_recent_container_condition_message = "There is no container!"
-            has_infra_failure = True
+            has_infra_failure = most_recent_pod.status.phase != "Pending"
         else:
             # there can be only one
             most_recent_container_status = most_recent_pod.status.container_statuses[
@@ -391,7 +391,7 @@ def _get_most_recent_pod_details(
             )
 
             if _has_container_failure(most_recent_container_status):
-                has_infra_failure = True
+                has_infra_failure = most_recent_pod.status.phase != "Pending"
 
     except OpenApiException as e:
         has_infra_failure = True

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -1,7 +1,10 @@
 # Standard Library
+from datetime import datetime
 from unittest import mock
 
 import pytest
+
+# Third-party
 from kubernetes.client.exceptions import ApiException
 
 # Sematic
@@ -143,12 +146,18 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=0,
             succeeded_pod_count=0,
-            most_recent_condition=None,
             has_started=False,
             still_exists=True,
+            start_time=None,
+            most_recent_condition=None,
+            most_recent_pod_phase=None,
+            most_recent_pod_condition_message=None,
+            most_recent_container_condition_message=None,
+            has_infra_failure=False,
         ),
         True,  # job hasn't started yet
     ),
+    # TODO add pending
     (
         KubernetesExternalJob(
             kind="k8s",
@@ -158,9 +167,14 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=1,
             succeeded_pod_count=0,
-            most_recent_condition=None,
             has_started=True,
             still_exists=True,
+            start_time=datetime.now().timestamp(),
+            most_recent_condition=None,
+            most_recent_pod_phase="Running",
+            most_recent_pod_condition_message="Pod condition is 'Ready'",
+            most_recent_container_condition_message="Container is running",
+            has_infra_failure=False,
         ),
         True,  # job has started and has active pods
     ),
@@ -173,9 +187,14 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=0,
             succeeded_pod_count=1,
-            most_recent_condition=KubernetesJobCondition.Complete.value,
             has_started=True,
             still_exists=True,
+            start_time=datetime.now().timestamp(),
+            most_recent_condition=KubernetesJobCondition.Complete.value,
+            most_recent_pod_phase="Succeeded",
+            most_recent_pod_condition_message=None,
+            most_recent_container_condition_message=None,
+            has_infra_failure=False,
         ),
         False,  # job has completed successfully
     ),
@@ -188,9 +207,17 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=0,
             succeeded_pod_count=0,
-            most_recent_condition=KubernetesJobCondition.Failed.value,
             has_started=True,
             still_exists=True,
+            start_time=datetime.now().timestamp(),
+            most_recent_condition=KubernetesJobCondition.Failed.value,
+            most_recent_pod_phase="Failed",
+            most_recent_pod_condition_message=(
+                "Pod condition is NOT 'Ready': ContainersNotReady; "
+                "containers with unready status: [sematic-worker-XXX]"
+            ),
+            most_recent_container_condition_message="Container is terminated: Error",
+            has_infra_failure=True,
         ),
         False,  # job has failed
     ),
@@ -203,9 +230,14 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=0,
             succeeded_pod_count=1,
-            most_recent_condition=KubernetesJobCondition.Complete.value,
             has_started=True,
             still_exists=False,
+            start_time=1.01,
+            most_recent_condition=KubernetesJobCondition.Complete.value,
+            most_recent_pod_phase="Succeeded",
+            most_recent_pod_condition_message=None,
+            most_recent_container_condition_message=None,
+            has_infra_failure=False,
         ),
         False,  # job completed long ago and no longer exists
     ),
@@ -218,11 +250,16 @@ IS_ACTIVE_CASES = [
             ),
             pending_or_running_pod_count=0,
             succeeded_pod_count=0,
-            most_recent_condition=None,
             has_started=True,
             still_exists=False,
+            start_time=1.01,
+            most_recent_condition=None,
+            most_recent_pod_phase=None,
+            most_recent_pod_condition_message=None,
+            most_recent_container_condition_message=None,
+            has_infra_failure=False,
         ),
-        False,  # job was not updated between start and complete dissapearance
+        False,  # job was not updated between start and complete disappearance
     ),
 ]
 
@@ -250,9 +287,14 @@ def test_refresh_job(mock_batch_api, mock_load_kube_config):
         ),
         pending_or_running_pod_count=0,
         succeeded_pod_count=1,
-        most_recent_condition=None,
         has_started=True,
         still_exists=True,
+        start_time=1.01,
+        most_recent_condition=None,
+        most_recent_pod_phase=None,
+        most_recent_pod_condition_message=None,
+        most_recent_container_condition_message=None,
+        has_infra_failure=False,
     )
     mock_k8s_job.status.active = 1
 
@@ -265,7 +307,7 @@ def test_refresh_job(mock_batch_api, mock_load_kube_config):
     success_condition = mock.MagicMock()
     success_condition.status = "True"
     success_condition.type = KubernetesJobCondition.Complete.value
-    success_condition.lastTransitionTime = 1
+    success_condition.last_transition_time = 1
 
     fail_condition = mock.MagicMock()
     # aka, the Failed condition does NOT apply. K8s doesn't really set
@@ -273,7 +315,7 @@ def test_refresh_job(mock_batch_api, mock_load_kube_config):
     # the conditions is supposed to be.
     fail_condition.status = "False"
     fail_condition.type = KubernetesJobCondition.Failed.value
-    fail_condition.lastTransitionTime = 2
+    fail_condition.last_transition_time = 2
     mock_k8s_job.status.conditions = [
         success_condition,
         fail_condition,

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -261,11 +261,8 @@ IS_ACTIVE_CASES = [
             start_time=datetime.now().timestamp(),
             most_recent_condition=KubernetesJobCondition.Failed.value,
             most_recent_pod_phase_message="Pod phase is 'Failed'",
-            most_recent_pod_condition_message=(
-                "Pod condition is NOT 'Ready': ContainersNotReady; "
-                "containers with unready status: [sematic-worker-XXX]"
-            ),
-            most_recent_container_condition_message="Container is terminated: Error",
+            most_recent_pod_condition_message="Pod condition is 'Initialized'",
+            most_recent_container_condition_message="Container is terminated: OOMKilled",
             has_infra_failure=True,
         ),
         False,  # job has failed

--- a/sematic/testing/tests/BUILD
+++ b/sematic/testing/tests/BUILD
@@ -2,8 +2,10 @@ pytest_test(
     name = "test_mock_funcs",
     srcs = ["test_mock_funcs.py"],
     deps = [
+        "//sematic:abstract_calculator",
         "//sematic:calculator",
         "//sematic/resolvers:silent_resolver",
         "//sematic/testing:mock_funcs",
+        "//sematic/utils:exceptions",
     ],
 )

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -8,6 +8,7 @@ pytest_test(
         "//sematic:calculator",
         "//sematic:future",
         "//sematic/db/tests:fixtures",
+        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/tests/test_retry_settings.py
+++ b/sematic/tests/test_retry_settings.py
@@ -5,7 +5,7 @@ import pytest
 
 # Sematic
 from sematic.retry_settings import RetrySettings
-from sematic.utils.exceptions import ExceptionMetadata
+from sematic.utils.exceptions import ExceptionMetadata, KubernetesError
 
 
 class ParentError(Exception):
@@ -224,6 +224,90 @@ def test_matches_exceptions(matches: bool, exception_metadata: ExceptionMetadata
                 ),
             ),
             RetrySettings(exceptions=(ValueError,), retries=2),
+            2,
+        ),
+        (
+            False,
+            (
+                ExceptionMetadata(
+                    name=KubernetesError.__name__,
+                    module=KubernetesError.__module__,
+                    repr="KubernetesError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(
+                        KubernetesError
+                    ),
+                ),
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            True,
+            (
+                ExceptionMetadata(
+                    name=KubernetesError.__name__,
+                    module=KubernetesError.__module__,
+                    repr="KubernetesError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(
+                        KubernetesError
+                    ),
+                ),
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            True,
+            (
+                ExceptionMetadata(
+                    name=KubernetesError.__name__,
+                    module=KubernetesError.__module__,
+                    repr="KubernetesError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(
+                        KubernetesError
+                    ),
+                ),
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+            ),
+            RetrySettings(exceptions=(KubernetesError,), retries=2),
+            1,
+        ),
+        (
+            False,
+            (
+                ExceptionMetadata(
+                    name=KubernetesError.__name__,
+                    module=KubernetesError.__module__,
+                    repr="KubernetesError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(
+                        KubernetesError
+                    ),
+                ),
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+            ),
+            RetrySettings(exceptions=(KubernetesError,), retries=2),
             2,
         ),
     ),

--- a/sematic/tests/test_retry_settings.py
+++ b/sematic/tests/test_retry_settings.py
@@ -1,3 +1,6 @@
+# Standard Library
+from typing import Optional, Tuple
+
 import pytest
 
 # Sematic
@@ -52,76 +55,184 @@ def test_matches_exceptions(matches: bool, exception_metadata: ExceptionMetadata
 
 
 @pytest.mark.parametrize(
-    "should_retry, exception_metadata, retry_settings, retry_count",
+    "should_retry, exception_metadata_tuple, retry_settings, retry_count",
     (
         (
             True,
-            ExceptionMetadata(
-                name=ValueError.__name__,
-                module=ValueError.__module__,
-                repr="ValueError",
-                ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+            (
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
             ),
             RetrySettings(exceptions=(ValueError,), retries=2),
             1,
         ),
         (
             False,
-            ExceptionMetadata(
-                name=ValueError.__name__,
-                module=ValueError.__module__,
-                repr="ValueError",
-                ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+            (
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            False,
+            (
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
             ),
             RetrySettings(exceptions=(ValueError,), retries=2),
             2,
         ),
         (
             False,
-            ExceptionMetadata(
-                name=ValueError.__name__,
-                module=ValueError.__module__,
-                repr="ValueError",
-                ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+            (
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
             ),
             RetrySettings(exceptions=(ValueError,), retries=2),
             2,
         ),
         (
             True,
-            ExceptionMetadata(
-                name=Child1Error.__name__,
-                module=Child1Error.__module__,
-                repr="Child1Error",
-                ancestors=ExceptionMetadata.ancestors_from_exception(Child1Error),
+            (
+                ExceptionMetadata(
+                    name=Child1Error.__name__,
+                    module=Child1Error.__module__,
+                    repr="Child1Error",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Child1Error),
+                ),
             ),
             RetrySettings(exceptions=(ParentError,), retries=2),
             1,
         ),
         (
             True,
-            ExceptionMetadata(
-                name=GrandChildError.__name__,
-                module=GrandChildError.__module__,
-                repr="GrandChildError",
-                ancestors=ExceptionMetadata.ancestors_from_exception(GrandChildError),
+            (
+                ExceptionMetadata(
+                    name=GrandChildError.__name__,
+                    module=GrandChildError.__module__,
+                    repr="GrandChildError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(
+                        GrandChildError
+                    ),
+                ),
             ),
             RetrySettings(exceptions=(ParentError,), retries=2),
             1,
         ),
         (
-            True,
-            None,
-            RetrySettings(exceptions=(ParentError,), retries=2),
+            False,
+            (),
+            RetrySettings(exceptions=(ValueError,), retries=2),
             1,
+        ),
+        (
+            False,
+            (None,),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            False,
+            (None, None),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            True,
+            (
+                None,
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            True,
+            (
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            True,
+            (
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            1,
+        ),
+        (
+            False,
+            (
+                ExceptionMetadata(
+                    name=Exception.__name__,
+                    module=Exception.__module__,
+                    repr="Exception",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(Exception),
+                ),
+                ExceptionMetadata(
+                    name=ValueError.__name__,
+                    module=ValueError.__module__,
+                    repr="ValueError",
+                    ancestors=ExceptionMetadata.ancestors_from_exception(ValueError),
+                ),
+            ),
+            RetrySettings(exceptions=(ValueError,), retries=2),
+            2,
         ),
     ),
 )
 def test_should_retry(
     should_retry: bool,
-    exception_metadata: ExceptionMetadata,
+    exception_metadata_tuple: Tuple[Optional[ExceptionMetadata]],
     retry_settings: RetrySettings,
     retry_count: int,
 ):
     retry_settings.retry_count = retry_count
-    assert retry_settings.should_retry(exception_metadata) is should_retry
+    assert retry_settings.should_retry(*exception_metadata_tuple) is should_retry

--- a/sematic/tests/test_retry_settings.py
+++ b/sematic/tests/test_retry_settings.py
@@ -109,6 +109,12 @@ def test_matches_exceptions(matches: bool, exception_metadata: ExceptionMetadata
             RetrySettings(exceptions=(ParentError,), retries=2),
             1,
         ),
+        (
+            True,
+            None,
+            RetrySettings(exceptions=(ParentError,), retries=2),
+            1,
+        ),
     ),
 )
 def test_should_retry(

--- a/sematic/ui/src/Models.tsx
+++ b/sematic/ui/src/Models.tsx
@@ -30,8 +30,8 @@ export type Run = {
   calculator_path: string;
   description: string | null;
   source_code: string;
-  exception_json: ExceptionMetadata | null;
-  external_exception_json: ExceptionMetadata | null;
+  exception_metadata_json: ExceptionMetadata | null;
+  external_exception_metadata_json: ExceptionMetadata | null;
   tags: Array<string>;
   parent_id: string | null;
   root_id: string;

--- a/sematic/ui/src/Models.tsx
+++ b/sematic/ui/src/Models.tsx
@@ -31,6 +31,7 @@ export type Run = {
   description: string | null;
   source_code: string;
   exception_json: ExceptionMetadata | null;
+  external_exception_json: ExceptionMetadata | null;
   tags: Array<string>;
   parent_id: string | null;
   root_id: string;

--- a/sematic/ui/src/components/Exception.tsx
+++ b/sematic/ui/src/components/Exception.tsx
@@ -1,12 +1,12 @@
 import { Alert, AlertTitle } from "@mui/material";
 import { ExceptionMetadata } from "../Models";
 
-export default function Exception(props: { exception: ExceptionMetadata }) {
-  const { exception } = props;
+export function Exception(props: { exception_metadata: ExceptionMetadata }) {
+  const { exception_metadata } = props;
   return (
     <Alert severity="error" icon={false}>
       <AlertTitle>
-        {exception.repr.split("\n")[exception.repr.split("\n").length - 2]}
+        {exception_metadata.repr.split("\n")[exception_metadata.repr.split("\n").length - 2]}
       </AlertTitle>
       <pre
         style={{
@@ -14,8 +14,25 @@ export default function Exception(props: { exception: ExceptionMetadata }) {
           overflowWrap: "anywhere",
         }}
       >
-        {exception.repr}
+        {exception_metadata.repr}
       </pre>
+    </Alert>
+  );
+}
+
+export function ExternalException(props: { exception_metadata: ExceptionMetadata }) {
+  return (
+    <Alert severity="error" variant="outlined" sx={{ alignItems: 'center' }} >
+      <AlertTitle>
+        <pre
+          style={{
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {props.exception_metadata.repr}
+        </pre>
+      </AlertTitle>
     </Alert>
   );
 }

--- a/sematic/ui/src/components/Exception.tsx
+++ b/sematic/ui/src/components/Exception.tsx
@@ -1,5 +1,18 @@
-import { Alert, AlertTitle } from "@mui/material";
+import { Alert, AlertTitle, Link } from "@mui/material";
 import { ExceptionMetadata } from "../Models";
+
+const DISCORD_MESSAGE = (
+  "For assistance with this error message, you can reach out to us on "
+);
+
+function DiscordHelp() {
+  return (
+    <pre>
+      {DISCORD_MESSAGE}
+      <Link href="https://discord.gg/4KZJ6kYVax">Discord</Link>.
+    </pre>
+  );
+}
 
 export function Exception(props: { exception_metadata: ExceptionMetadata }) {
   const { exception_metadata } = props;
@@ -20,9 +33,12 @@ export function Exception(props: { exception_metadata: ExceptionMetadata }) {
   );
 }
 
-export function ExternalException(props: { exception_metadata: ExceptionMetadata }) {
+export function ExternalException(
+  props: { exception_metadata: ExceptionMetadata, discord_reference?: Boolean }
+) {
+  const { exception_metadata, discord_reference = true } = props;
   return (
-    <Alert severity="error" icon={false} >
+    <Alert severity="error" icon={false}>
       <AlertTitle>
         <pre
           style={{
@@ -30,7 +46,8 @@ export function ExternalException(props: { exception_metadata: ExceptionMetadata
             overflowWrap: "anywhere",
           }}
         >
-          {props.exception_metadata.repr}
+          {exception_metadata.repr}
+          {discord_reference && <DiscordHelp/>}
         </pre>
       </AlertTitle>
     </Alert>

--- a/sematic/ui/src/components/Exception.tsx
+++ b/sematic/ui/src/components/Exception.tsx
@@ -22,7 +22,7 @@ export function Exception(props: { exception_metadata: ExceptionMetadata }) {
 
 export function ExternalException(props: { exception_metadata: ExceptionMetadata }) {
   return (
-    <Alert severity="error" variant="outlined" sx={{ alignItems: 'center' }} >
+    <Alert severity="error" icon={false} >
       <AlertTitle>
         <pre
           style={{

--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -1,4 +1,4 @@
-import Exception from "./Exception";
+import { Exception, ExternalException } from "./Exception";
 import { Box } from "@mui/material";
 import { Run } from "../Models";
 import { fetchJSON } from "../utils";
@@ -57,9 +57,16 @@ export default function LogPanel(props: { run: Run }) {
   const logView = error === undefined ? standardLogView : logErrorView;
 
   return (
-    <Box>
-      {run.exception_json && <Exception exception={run.exception_json} />}
-      {logView}
+    <Box sx={{ display: "grid" }} >
+      <Box sx={{ gridRow: 1, paddingBottom: 4, }} >
+        {run.external_exception_json && <ExternalException exception_metadata={run.external_exception_json} />}
+      </Box>
+      <Box sx={{ gridRow: 2, paddingBottom: 4, }} >
+        {run.exception_json && <Exception exception_metadata={run.exception_json} />}
+      </Box>
+      <Box sx={{ gridRow: 3, paddingBottom: 4, }} >
+        {logView}
+      </Box>
     </Box>
   );
 }

--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -1,13 +1,11 @@
-import { Exception, ExternalException } from "./Exception";
-import { Box } from "@mui/material";
-import { Run } from "../Models";
-import { fetchJSON } from "../utils";
+import { Alert, Box } from "@mui/material";
 import { useCallback, useContext, useState } from "react";
 import { UserContext } from "..";
+import { Run } from "../Models";
 import { LogLineRequestResponse } from "../Payloads";
-import ScrollingLogView from "./ScrollingLogView";
-import { MoreLinesCallback } from "./ScrollingLogView";
-import { Alert } from "@mui/material";
+import { fetchJSON } from "../utils";
+import { Exception, ExternalException } from "./Exception";
+import ScrollingLogView, { MoreLinesCallback } from "./ScrollingLogView";
 
 export default function LogPanel(props: { run: Run }) {
   const { run } = props;
@@ -59,10 +57,12 @@ export default function LogPanel(props: { run: Run }) {
   return (
     <Box sx={{ display: "grid" }} >
       <Box sx={{ gridRow: 1, paddingBottom: 4, }} >
-        {run.external_exception_json && <ExternalException exception_metadata={run.external_exception_json} />}
+        {run.external_exception_metadata_json && <ExternalException
+            exception_metadata={run.external_exception_metadata_json} />}
       </Box>
       <Box sx={{ gridRow: 2, paddingBottom: 4, }} >
-        {run.exception_json && <Exception exception_metadata={run.exception_json} />}
+        {run.exception_metadata_json &&
+            <Exception exception_metadata={run.exception_metadata_json} />}
       </Box>
       <Box sx={{ gridRow: 3, paddingBottom: 4, }} >
         {logView}

--- a/sematic/utils/exceptions.py
+++ b/sematic/utils/exceptions.py
@@ -116,6 +116,12 @@ def format_exception_for_run(
     )
 
 
+class KubernetesError(Exception):
+    """An error originated in external Kubernetes compute infrastructure."""
+
+    pass
+
+
 class ResolutionError(Exception):
     """The pipeline resolution has failed.
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -10,6 +10,7 @@ CURRENT_VERSION = (0, 18, 1)
 # Represents the smallest client version that works with the server
 # at the CURRENT_VERSION. Should be updated any time a breaking change
 # is made to the web API.
+# TODO: Bump for https://github.com/sematic-ai/sematic/pull/269
 MIN_CLIENT_SERVER_SUPPORTS = (0, 18, 0)
 
 


### PR DESCRIPTION
This PR introduces a mechanism that collects Kubernetes Pod and Container failures for each Run, stores them and exposes them in the UI, above the exception log section for the Run.

A new `KubernetesError` is introduced to represent these errors, which is retriable.

This also comes with a refactoring that uses `ExceptionMetadata` as the format in which both code execution exceptions and external Kubernetes errors are stored and passed through the application. The reasons behind this are:
- `KubernetesError` does not have an origin inside the code base; its stack trace would be deceptive
- `KubernetesError` must fail the resolution, even if code execution errors do not occur
- code exceptions were inconsistently being handled depending on the Resolver type and on their point of origin
- parents can be failed due to exceptions from their children

Also, a new `ResolutionError` is used to halt execution, based on either code exceptions or Kubernetes errors as the initial cause. All these changes are a first step towards #264.

## Testing

Updated and added unit tests.

❗ TODO: propagate latest exception testing and add more test cases

### Pod Pending Example (no error)

This does not show up in the UI.
Server logs:
```
2022-10-26 23:28:26,128 [DEBUG] sematic.scheduling.kubernetes: K8 pods for job default/sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7:
{'api_version': 'v1',
 'items': [{'api_version': None,
            'kind': None,
[...]
            'status': {'conditions': [{'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 25, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'Initialized'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 25, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'Ready'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 25, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'ContainersReady'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 25, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'PodScheduled'}],
                       'container_statuses': [{'container_id': None,
                                               'image': 'XXX',
                                               'image_id': '',
                                               'last_state': {'running': None,
                                                              'terminated': None,
                                                              'waiting': None},
                                               'name': 'sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7',
                                               'ready': False,
                                               'restart_count': 0,
                                               'started': False,
                                               'state': {'running': None,
                                                         'terminated': None,
                                                         'waiting': {'message': None,
                                                                     'reason': 'ContainerCreating'}}}],
                       'ephemeral_container_statuses': None,
                       'host_ip': '10.99.4.217',
                       'init_container_statuses': None,
                       'message': None,
                       'nominated_node_name': None,
                       'phase': 'Pending',
                       'pod_i_ps': None,
                       'pod_ip': None,
                       'qos_class': 'BestEffort',
                       'reason': None,
                       'start_time': datetime.datetime(2022, 10, 26, 23, 28, 25, tzinfo=tzlocal())}}],
 'kind': 'PodList',
 'metadata': {'_continue': None,
              'remaining_item_count': None,
              'resource_version': '27329239',
              'self_link': None}}
2022-10-26 23:28:26,250 [DEBUG] sematic.scheduling.kubernetes: Job default/sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7 refreshed: KubernetesExternalJob(kind='k8s', try_number=0, external_job_id='default/sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7', pending_or_running_pod_count=1, succeeded_pod_count=0, has_started=True, still_exists=True, start_time=1666826905.0, most_recent_condition=None, most_recent_pod_phase='Pending', most_recent_pod_condition_message="Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-e44527aa04bb4a729d6bcf6e489714c4-a0f5b7]", most_recent_container_condition_message='Container is waiting: ContainerCreating', has_infra_failure=False)
```

### Code Execution Error

The UI shows the error logs, as before.
Server logs:
```
2022-10-26 23:28:26,409 [DEBUG] sematic.scheduling.kubernetes: K8 pods for job default/sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3:
{'api_version': 'v1',
 'items': [{'api_version': None,
            'kind': None,
[...]
            'status': {'conditions': [{'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 8, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'Initialized'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 23, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'Ready'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 23, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'ContainersReady'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 26, 23, 28, 8, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'PodScheduled'}],
                       'container_statuses': [{'container_id': 'XXX',
                                               'image': 'XXX',
                                               'image_id': 'XXX',
                                               'last_state': {'running': None,
                                                              'terminated': None,
                                                              'waiting': None},
                                               'name': 'sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3',
                                               'ready': False,
                                               'restart_count': 0,
                                               'started': False,
                                               'state': {'running': None,
                                                         'terminated': {'container_id': 'XXX',
                                                                        'exit_code': 1,
                                                                        'finished_at': datetime.datetime(2022, 10, 26, 23, 28, 23, tzinfo=tzlocal()),
                                                                        'message': None,
                                                                        'reason': 'Error',
                                                                        'signal': None,
                                                                        'started_at': datetime.datetime(2022, 10, 26, 23, 28, 14, tzinfo=tzlocal())},
                                                         'waiting': None}}],
                       'ephemeral_container_statuses': None,
                       'host_ip': '10.99.4.217',
                       'init_container_statuses': None,
                       'message': None,
                       'nominated_node_name': None,
                       'phase': 'Failed',
                       'pod_i_ps': [{'ip': '10.99.4.153'}],
                       'pod_ip': '10.99.4.153',
                       'qos_class': 'BestEffort',
                       'reason': None,
                       'start_time': datetime.datetime(2022, 10, 26, 23, 28, 8, tzinfo=tzlocal())}}],
 'kind': 'PodList',
 'metadata': {'_continue': None,
              'remaining_item_count': None,
              'resource_version': '27329242',
              'self_link': None}}
2022-10-26 23:28:26,538 [DEBUG] sematic.scheduling.kubernetes: Job default/sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3 refreshed: KubernetesExternalJob(kind='k8s', try_number=0, external_job_id='default/sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3', pending_or_running_pod_count=0, succeeded_pod_count=0, has_started=True, still_exists=True, start_time=1666826888.0, most_recent_condition='Failed', most_recent_pod_phase='Failed', most_recent_pod_condition_message="Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-e644bc3d5bf04b6d8acacac3577c3353-2784f3]", most_recent_container_condition_message='Container is terminated: Error', has_infra_failure=True)
```

### External Kubernetes Error

UI:
![image](https://user-images.githubusercontent.com/1894533/198178576-27de1e03-32c8-4e6f-890a-48553450afba.png)

Server logs:
```
2022-10-27 02:00:04,977 [DEBUG] sematic.scheduling.kubernetes: K8 pods for job default/sematic-worker-42ec7728d906458a99066354030ad186-40b631:
{'api_version': 'v1',
 'items': [{'api_version': None,
            'kind': None,
[...]
            'status': {'conditions': [{'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 27, 1, 59, 6, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'Initialized'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 27, 2, 0, 1, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-42ec7728d906458a99066354030ad186-40b631]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'Ready'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 27, 2, 0, 1, tzinfo=tzlocal()),
                                       'message': 'containers with unready '
                                                  'status: '
                                                  '[sematic-worker-42ec7728d906458a99066354030ad186-40b631]',
                                       'reason': 'ContainersNotReady',
                                       'status': 'False',
                                       'type': 'ContainersReady'},
                                      {'last_probe_time': None,
                                       'last_transition_time': datetime.datetime(2022, 10, 27, 1, 59, 6, tzinfo=tzlocal()),
                                       'message': None,
                                       'reason': None,
                                       'status': 'True',
                                       'type': 'PodScheduled'}],
                       'container_statuses': [{'container_id': 'XXX',
                                               'image': 'XXX',
                                               'image_id': 'XXX',
                                               'last_state': {'running': None,
                                                              'terminated': None,
                                                              'waiting': None},
                                               'name': 'sematic-worker-42ec7728d906458a99066354030ad186-40b631',
                                               'ready': False,
                                               'restart_count': 0,
                                               'started': False,
                                               'state': {'running': None,
                                                         'terminated': {'container_id': 'XXX',
                                                                        'exit_code': 137,
                                                                        'finished_at': datetime.datetime(2022, 10, 27, 2, 0, tzinfo=tzlocal()),
                                                                        'message': None,
                                                                        'reason': 'OOMKilled',
                                                                        'signal': None,
                                                                        'started_at': datetime.datetime(2022, 10, 27, 1, 59, 7, tzinfo=tzlocal())},
                                                         'waiting': None}}],
                       'ephemeral_container_statuses': None,
                       'host_ip': '10.99.4.217',
                       'init_container_statuses': None,
                       'message': None,
                       'nominated_node_name': None,
                       'phase': 'Failed',
                       'pod_i_ps': [{'ip': '10.99.4.64'}],
                       'pod_ip': '10.99.4.64',
                       'qos_class': 'BestEffort',
                       'reason': None,
                       'start_time': datetime.datetime(2022, 10, 27, 1, 59, 6, tzinfo=tzlocal())}}],
 'kind': 'PodList',
 'metadata': {'_continue': None,
              'remaining_item_count': None,
              'resource_version': '27357798',
              'self_link': None}}
2022-10-27 02:00:05,016 [DEBUG] sematic.scheduling.kubernetes: Job default/sematic-worker-42ec7728d906458a99066354030ad186-40b631 refreshed: KubernetesExternalJob(kind='k8s', try_number=0, external_job_id='default/sematic-worker-42ec7728d906458a99066354030ad186-40b631', pending_or_running_pod_count=0, succeeded_pod_count=0, has_started=True, still_exists=True, start_time=1666835946.0, most_recent_condition='Failed', most_recent_pod_phase='Pod phase is: Failed', most_recent_pod_condition_message="Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-42ec7728d906458a99066354030ad186-40b631]", most_recent_container_condition_message='Container is terminated: OOMKilled', has_infra_failure=True)
2022-10-27 02:00:05,017 [WARNING] sematic.scheduling.job_scheduler: Job failed due to K8s job failure:
Pod phase is: Failed
Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-42ec7728d906458a99066354030ad186-40b631]
Container is terminated: OOMKilled
Job states:
KubernetesExternalJob(kind='k8s', try_number=0, external_job_id='default/sematic-worker-42ec7728d906458a99066354030ad186-40b631', pending_or_running_pod_count=0, succeeded_pod_count=0, has_started=True, still_exists=True, start_time=1666835946.0, most_recent_condition='Failed', most_recent_pod_phase='Pod phase is: Failed', most_recent_pod_condition_message="Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-42ec7728d906458a99066354030ad186-40b631]", most_recent_container_condition_message='Container is terminated: OOMKilled', has_infra_failure=True)
```

Resolver logs:
```
INFO:root:Retries exhausted or exception not retryable for 8e06270fd9504e2c888aafe9565b84b4, failing now.
INFO:sematic.resolvers.local_resolver:Processing failure of run b6b1ddc293e843429e8d6f57fa32fe76, state: FutureState.NESTED_FAILED
INFO:sematic.resolvers.local_resolver:Processing failure of run d68d4cad67d64c179d65de9312312b30, state: FutureState.NESTED_FAILED
Traceback (most recent call last):
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/examples/add/add_cloud.py", line 15, in <module>
    result = future.resolve(CloudResolver(detach=False))
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/future.py", line 39, in resolve
    self.value = resolver.resolve(self)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 108, in resolve
    return super().resolve(future)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 38, in resolve
    self._resolution_loop()
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 87, in _resolution_loop
    self._wait_for_scheduled_runs()
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 233, in _wait_for_scheduled_runs
    self._process_run_output(run_id)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 244, in _process_run_output
    self._handle_future_failure(
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/add/add_cloud_binary.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 339, in _handle_future_failure
    raise ResolutionError(exception_metadata, external_exception_metadata)
sematic.utils.exceptions.ResolutionError: The pipeline resolution failed due to previous errors
External failure:
Pod phase is: Failed
Pod condition is NOT 'Ready': ContainersNotReady; containers with unready status: [sematic-worker-8e06270fd9504e2c888aafe9565b84b4-efd92d]
Container is terminated: Error
```

### Code Execution Error + External Kubernetes Error

Similar logs as above.

UI:
![image](https://user-images.githubusercontent.com/1894533/198178967-93d8564b-11be-47e8-8d00-46a6a22fa9dd.png)


