### PR TITLE
Add the "Third-party" import section to isort configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ exclude = [
 profile = "black"
 import_heading_stdlib="Standard Library"
 import_heading_firstparty="Sematic"
+import_heading_thirdparty="Third-party"
 known_third_party = ["flask", "psycopg2", "matplotlib", "cloudpickle"]
 multi_line_output = 3

--- a/sematic/api/app.py
+++ b/sematic/api/app.py
@@ -1,4 +1,4 @@
-# Third party
+# Third-party
 from flask import Flask
 from flask_cors import CORS
 

--- a/sematic/api/endpoints/events.py
+++ b/sematic/api/endpoints/events.py
@@ -1,9 +1,8 @@
 # Standard Library
 from typing import Optional
 
+# Third-party
 import flask
-
-# Third party
 import flask_socketio  # type: ignore
 
 # Sematic

--- a/sematic/api/endpoints/tests/test_artifacts.py
+++ b/sematic/api/endpoints/tests/test_artifacts.py
@@ -1,6 +1,7 @@
 # Standard Library
 from typing import Any, Dict
 
+# Third-party
 import flask.testing
 
 # Sematic

--- a/sematic/api/tests/fixtures.py
+++ b/sematic/api/tests/fixtures.py
@@ -6,9 +6,8 @@ from typing import Any, Dict
 from unittest import mock
 from urllib.parse import urljoin
 
-import flask.testing
-
 # Third-party
+import flask.testing
 import pytest
 
 # responses 0.21.0 has type stubs but they break mypy

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
-# Third party
+# Third-party
 import requests
 from requests.exceptions import ConnectionError
 

--- a/sematic/cli/tests/test_main.py
+++ b/sematic/cli/tests/test_main.py
@@ -2,18 +2,12 @@
 import tempfile
 from dataclasses import asdict
 
+# Third-party
 import pytest
 
 # Sematic
-# import sematic.cli.main as main
-# from sematic.cli.process_utils import server_is_running
 from sematic.config import Config, get_config, set_config
 from sematic.db.tests.fixtures import test_db  # noqa: F401
-
-# import subprocess
-
-# Third-party
-# from click.testing import CliRunner
 
 
 @pytest.fixture

--- a/sematic/container_images.py
+++ b/sematic/container_images.py
@@ -3,8 +3,7 @@ import os
 import re
 from typing import Dict
 
-# Third-party
-import __main__
+import __main__  # isort:skip
 
 CONTAINER_IMAGE_ENV_VAR = "SEMATIC_CONTAINER_IMAGE"
 

--- a/sematic/container_images.py
+++ b/sematic/container_images.py
@@ -3,6 +3,7 @@ import os
 import re
 from typing import Dict
 
+# Third-party
 import __main__
 
 CONTAINER_IMAGE_ENV_VAR = "SEMATIC_CONTAINER_IMAGE"

--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -1,7 +1,7 @@
 # Standard Library
 import datetime
 
-# Third party
+# Third-party
 from sqlalchemy import Column, types
 
 # Sematic

--- a/sematic/db/models/base.py
+++ b/sematic/db/models/base.py
@@ -1,4 +1,4 @@
-# Third party
+# Third-party
 from sqlalchemy.ext.declarative import declarative_base
 
 

--- a/sematic/db/models/note.py
+++ b/sematic/db/models/note.py
@@ -2,7 +2,7 @@
 import datetime
 import uuid
 
-# Third party
+# Third-party
 from sqlalchemy import Column, types
 
 # Sematic

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -21,7 +21,7 @@ import logging
 from enum import Enum, unique
 from typing import Any, Dict, List, Optional, Union
 
-# Third party
+# Third-party
 from sqlalchemy import Column, types
 from sqlalchemy.orm import validates
 

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-# Third party
+# Third-party
 from sqlalchemy import Column, types
 from sqlalchemy.orm import validates
 

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -2,6 +2,7 @@
 import hashlib
 import json
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/db/models/tests/test_resolution.py
+++ b/sematic/db/models/tests/test_resolution.py
@@ -1,6 +1,7 @@
 # Standard Library
 import re
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/examples/dynamic_graph/pipeline.py
+++ b/sematic/examples/dynamic_graph/pipeline.py
@@ -10,7 +10,6 @@ import time
 from typing import List
 
 # Sematic
-# Third-party
 import sematic
 
 

--- a/sematic/examples/liver_cirrhosis/train.py
+++ b/sematic/examples/liver_cirrhosis/train.py
@@ -1,13 +1,12 @@
 # Standard Library
 from dataclasses import dataclass
 
+# Third-party
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 import sklearn
-
-# Third-party
 from sklearn.metrics import (
     auc,
     classification_report,

--- a/sematic/examples/mnist/pytorch/train_eval.py
+++ b/sematic/examples/mnist/pytorch/train_eval.py
@@ -1,6 +1,7 @@
 # Standard Library
 from typing import List
 
+# Third-party
 import pandas
 import plotly.express as px
 import torch

--- a/sematic/examples/titanic_survival_prediction/plots.py
+++ b/sematic/examples/titanic_survival_prediction/plots.py
@@ -1,7 +1,6 @@
+# Third-party
 import matplotlib.figure
 import matplotlib.pyplot as plt
-
-# Third-party
 import pandas as pd
 import seaborn as sns
 

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -1,7 +1,7 @@
 # Standard Library
 from unittest import mock
 
-# Third party
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/resolvers/tests/test_resource_requirements.py
+++ b/sematic/resolvers/tests/test_resource_requirements.py
@@ -1,3 +1,4 @@
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -1,3 +1,4 @@
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -1,6 +1,7 @@
 # Standard Library
 from unittest import mock
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -1,6 +1,7 @@
 # Standard Library
 from unittest import mock
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -2,9 +2,8 @@
 from datetime import datetime
 from unittest import mock
 
-import pytest
-
 # Third-party
+import pytest
 from kubernetes.client.exceptions import ApiException
 
 # Sematic

--- a/sematic/testing/tests/test_mock_funcs.py
+++ b/sematic/testing/tests/test_mock_funcs.py
@@ -1,6 +1,7 @@
 # Standard Library
 from typing import List
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/tests/test_38_interpreter.py
+++ b/sematic/tests/test_38_interpreter.py
@@ -1,6 +1,7 @@
 # Standard Library
 import sys
 
+# Third-party
 # confirm that third party dependencies were installed
 import requests  # noqa: F401
 

--- a/sematic/tests/test_39_interpreter.py
+++ b/sematic/tests/test_39_interpreter.py
@@ -1,6 +1,7 @@
 # Standard Library
 import sys
 
+# Third-party
 # confirm that third party dependencies were installed
 import requests  # noqa: F401
 

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from unittest import mock
 
-# Third party
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/tests/test_config_dir.py
+++ b/sematic/tests/test_config_dir.py
@@ -1,6 +1,7 @@
 # Standard Library
 import pathlib
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -2,7 +2,7 @@
 from typing import Iterable, List
 from unittest import mock
 
-# Third party
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/tests/test_retry_settings.py
+++ b/sematic/tests/test_retry_settings.py
@@ -1,6 +1,7 @@
 # Standard Library
 from typing import Optional, Tuple
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/tests/test_versions.py
+++ b/sematic/tests/test_versions.py
@@ -2,6 +2,7 @@
 import os
 import re
 
+# Third-party
 import yaml
 
 # Sematic

--- a/sematic/types/tests/test_registry.py
+++ b/sematic/types/tests/test_registry.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import Enum, unique
 from typing import Any, List, Literal, Optional, Union
 
-# Third party
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/types/tests/test_type.py
+++ b/sematic/types/tests/test_type.py
@@ -1,3 +1,4 @@
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/types/types/matplotlib/__init__.py
+++ b/sematic/types/types/matplotlib/__init__.py
@@ -1,4 +1,5 @@
 try:
+    # Third-party
     import matplotlib  # noqa: F401
 except ImportError:
     pass

--- a/sematic/types/types/pandas/__init__.py
+++ b/sematic/types/types/pandas/__init__.py
@@ -1,4 +1,5 @@
 try:
+    # Third-party
     import pandas  # noqa: F401
 except ImportError:
     pass

--- a/sematic/types/types/pandas/dataframe.py
+++ b/sematic/types/types/pandas/dataframe.py
@@ -2,7 +2,7 @@
 import json
 from typing import Any, Dict, List
 
-# Third party
+# Third-party
 import pandas
 
 # Sematic

--- a/sematic/types/types/pandas/tests/test_dataframe.py
+++ b/sematic/types/types/pandas/tests/test_dataframe.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 
+# Third-party
 import pandas
 
 # Sematic

--- a/sematic/types/types/plotly/__init__.py
+++ b/sematic/types/types/plotly/__init__.py
@@ -1,4 +1,5 @@
 try:
+    # Third-party
     import plotly  # noqa: F401
 except ImportError:
     pass

--- a/sematic/types/types/pytorch/__init__.py
+++ b/sematic/types/types/pytorch/__init__.py
@@ -1,4 +1,5 @@
 try:
+    # Third-party
     import torch  # noqa: F401
 except ImportError:
     pass

--- a/sematic/types/types/snowflake/snowflake_table.py
+++ b/sematic/types/types/snowflake/snowflake_table.py
@@ -4,8 +4,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Generator, Type
 
-# Third-party
 try:
+    # Third-party
     import pandas
     import pyarrow  # type: ignore  # noqa: F401
     import snowflake.connector

--- a/sematic/types/types/tests/test_enum.py
+++ b/sematic/types/types/tests/test_enum.py
@@ -1,6 +1,7 @@
 # Standard Library
 from enum import Enum, unique
 
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/types/types/tests/test_integer.py
+++ b/sematic/types/types/tests/test_integer.py
@@ -1,3 +1,4 @@
+# Third-party
 import pytest
 
 # Sematic

--- a/sematic/user_settings.py
+++ b/sematic/user_settings.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Dict, Optional
 
-# Third-arty
+# Third-party
 import yaml
 
 # Sematic

--- a/sematic/utils/git.py
+++ b/sematic/utils/git.py
@@ -25,6 +25,7 @@ def get_git_info(object_: Any) -> Optional["Repo"]:  # type: ignore # noqa: F821
     """
     try:
         # if git is not installed on the user's system, this will fail to import
+        # Third-party
         import git  # type: ignore
     except ImportError as e:
         logger.warn("Could not get git information", exc_info=e)


### PR DESCRIPTION
Adds the "Third-party" import section alongside the existing "Standard Library" and "Sematic" sections to the isort config file, and fixes the code imports accordingly.