### PR TITLE
Fix Python migration UPDATE SQL statement

### DIFF
--- a/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
+++ b/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
@@ -1,9 +1,6 @@
 # Standard Library
 import json
 
-# Third-party
-from sqlalchemy.sql import text
-
 # Sematic
 from sematic.db.db import db
 
@@ -24,15 +21,9 @@ def up():
             container_image_uris = json.dumps({"default": container_image_uri})
 
             conn.execute(
-                text(
-                    "UPDATE resolutions "
-                    "SET container_image_uris = :container_image_uris "
-                    "WHERE root_id = :root_id"
-                ),
-                dict(
-                    container_image_uris=container_image_uris,
-                    root_id=resolution_id,
-                ),
+                "UPDATE resolutions SET container_image_uris = ? WHERE root_id = ?",
+                container_image_uris,
+                resolution_id,
             )
 
 

--- a/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
+++ b/sematic/db/migrations/20221019225916_migrate_container_image_uris.py
@@ -1,6 +1,9 @@
 # Standard Library
 import json
 
+# Third-party
+from sqlalchemy.sql import text
+
 # Sematic
 from sematic.db.db import db
 
@@ -21,9 +24,15 @@ def up():
             container_image_uris = json.dumps({"default": container_image_uri})
 
             conn.execute(
-                "UPDATE resolutions SET container_image_uris = ? WHERE root_id = ?",
-                container_image_uris,
-                resolution_id,
+                text(
+                    "UPDATE resolutions "
+                    "SET container_image_uris = :container_image_uris "
+                    "WHERE root_id = :root_id"
+                ),
+                dict(
+                    container_image_uris=container_image_uris,
+                    root_id=resolution_id,
+                ),
             )
 
 


### PR DESCRIPTION
The `20221019225916_migrate_container_image_uris.py` had an invalid SQL statement.

This was not detected in our dev deployments because at the time when we ran it there we were still using SQLAlchemy models instead of raw SQL statements. This change was made after the migrations was initially rolled out.