### PR TITLE
Support abstract base classes in type annotations

### DIFF
--- a/sematic/types/registry.py
+++ b/sematic/types/registry.py
@@ -1,4 +1,5 @@
 # Standard Library
+import abc
 import inspect
 import typing
 from enum import Enum
@@ -294,11 +295,7 @@ def validate_type_annotation(*types: TypeAnnotation) -> None:
     """
 
     def assert_supported(type_):
-        try:
-            subclasses_type = issubclass(type_, type)
-        except TypeError:
-            subclasses_type = False
-        if type(type_) is type or subclasses_type or is_enum(type_):
+        if _is_type(type_) or _is_abc(type_) or is_enum(type_):
             return
         if not is_parameterized_generic(type_, raise_for_unparameterized=True):
             raise TypeError(
@@ -375,17 +372,13 @@ def is_parameterized_generic(
 
 def _is_supported_registry_key(type_: RegistryKey) -> bool:
     try:
-        subclasses_type = issubclass(type_, type)
-    except TypeError:
-        subclasses_type = False
-    try:
         subclasses_enum = issubclass(type_, Enum)
     except TypeError:
         subclasses_enum = False
     is_unparameterized_generic = type_ in SUPPORTED_GENERIC_TYPING_ANNOTATIONS.keys()
     return (
-        type(type_) is type
-        or subclasses_type
+        _is_type(type_)
+        or _is_abc(type_)
         or is_unparameterized_generic
         or subclasses_enum
     )
@@ -410,6 +403,44 @@ def is_sematic_parametrized_generic_type(type_: Any) -> bool:
         )
     except Exception:
         return False
+
+
+def _is_type(type_: Any) -> bool:
+    """Determine if type_ subclasses 'type' or has a type of 'type'
+
+    Parameters
+    ----------
+    type_:
+        The type to check
+
+    Returns
+    -------
+    True if type_ subclasses 'type' or has a type of 'type'. False otherwise
+    """
+    try:
+        subclasses_type = issubclass(type_, type)
+    except TypeError:
+        subclasses_type = False
+    return subclasses_type or type(type_) is type
+
+
+def _is_abc(type_: Any) -> bool:
+    """Determine if type_ subclasses 'ABC' or has a type of 'ABCMeta'
+
+    Parameters
+    ----------
+    type_:
+        The type to check
+
+    Returns
+    -------
+    True if type_ subclasses 'ABC' or has a type of 'ABCMeta'. False otherwise
+    """
+    try:
+        subclasses_abc = issubclass(type_, abc.ABC)
+    except TypeError:
+        subclasses_abc = False
+    return subclasses_abc or type(type_) is abc.ABCMeta
 
 
 class DataclassKey:

--- a/sematic/types/tests/test_registry.py
+++ b/sematic/types/tests/test_registry.py
@@ -1,4 +1,5 @@
 # Standard Library
+from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, unique
 from typing import Any, List, Literal, Optional, Union
@@ -31,11 +32,25 @@ class FooStandard:
     pass
 
 
+class FooAbc(ABC):
+    @abstractmethod
+    def do_foo(self):
+        pass
+
+
+class FooAbcMeta(metaclass=ABCMeta):
+    @abstractmethod
+    def do_foo(self):
+        pass
+
+
 def test_validate_type_annotation():
     validate_type_annotation(int)
     validate_type_annotation(Color)
     validate_type_annotation(FooDataclass)
     validate_type_annotation(FooStandard)
+    validate_type_annotation(FooAbc)
+    validate_type_annotation(FooAbcMeta)
     validate_type_annotation(Union[int, float])
     validate_type_annotation(Optional[int])
     validate_type_annotation(List[int])
@@ -55,6 +70,8 @@ def test_validate_type_annotation():
 def test_is_supported_type_annotation():
     assert is_supported_type_annotation(FooDataclass)
     assert is_supported_type_annotation(Color)
+    assert is_supported_type_annotation(FooAbc)
+    assert is_supported_type_annotation(FooAbcMeta)
     assert not is_supported_type_annotation(Union)
 
 
@@ -62,6 +79,8 @@ def test_is_parameterized_generic():
     assert not is_parameterized_generic(FooDataclass)
     assert not is_parameterized_generic(FooStandard)
     assert not is_parameterized_generic(Color)
+    assert not is_parameterized_generic(FooAbc)
+    assert not is_parameterized_generic(FooAbcMeta)
     assert is_parameterized_generic(Union[int, float])
     assert is_parameterized_generic(Optional[int])
     assert is_parameterized_generic(List[int])
@@ -75,6 +94,8 @@ def test_validate_registry_keys():
     _validate_registry_keys(int, int)
     _validate_registry_keys(FooDataclass)
     _validate_registry_keys(FooStandard)
+    _validate_registry_keys(FooAbc)
+    _validate_registry_keys(FooAbcMeta)
     _validate_registry_keys(Color)
     _validate_registry_keys(Union)
     _validate_registry_keys(List)


### PR DESCRIPTION
Closes #92

Prior to this PR, you could not use an Abstract Base Class (ABC) as a type annotation in a Sematic func. This PR adds that capability.