### PR TITLE
More & earlier validation when using @func

### DIFF
--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -61,7 +61,10 @@ class Calculator(AbstractCalculator):
         self.__doc__ = func.__doc__
         self.__module__ = func.__module__
         self.__name__ = func.__name__
-        for key, annotation in input_types.items():
+        self._validate()
+
+    def _validate(self):
+        for key, annotation in self._input_types.items():
             try:
                 validate_type_annotation(annotation)
             except TypeError as e:

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -326,7 +326,7 @@ def _is_method_like(func) -> bool:
 def _is_coroutine_like(func) -> bool:
     """Return True if and only if 'func' appears to be async, a coroutine, or similar"""
     return any(
-        is_(func)
+        is_(func)  # type: ignore
         for is_ in (
             inspect.isawaitable,
             inspect.isasyncgenfunction,

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import List, Union
+from typing import Any, List, Union
 
 # Third-party
 import pytest
@@ -30,6 +30,23 @@ def test_decorator_with_params():
         pass
 
     assert isinstance(f, Calculator)
+
+
+def test_any():
+    expected = (
+        r"Invalid type annotation for argument 'x' "
+        r"of sematic.tests.test_calculator.f: 'Any' is "
+        r"not a Sematic-supported type. Use 'object' instead."
+    )
+    with pytest.raises(TypeError, match=expected):
+
+        @func
+        def f(x: Any) -> None:
+            pass
+
+    @func
+    def f(x: object) -> None:
+        pass
 
 
 def test_doc():

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -35,7 +35,7 @@ def test_decorator_with_params():
 def test_any():
     expected = (
         r"Invalid type annotation for argument 'x' "
-        r"of sematic.tests.test_calculator.f: 'Any' is "
+        r"of sematic.tests.test_calculator.f1: 'Any' is "
         r"not a Sematic-supported type. Use 'object' instead."
     )
     with pytest.raises(TypeError, match=expected):

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -67,8 +67,37 @@ def test_name():
 
 
 def test_not_a_function():
-    with pytest.raises(ValueError, match="not a function"):
+    with pytest.raises(
+        TypeError, match=r".*can only be used with functions. But 'abc' is a 'str'."
+    ):
         Calculator("abc", {}, None)
+
+    with pytest.raises(
+        TypeError, match=r".*can only be used with functions, not methods.*"
+    ):
+
+        class SomeClass:
+            @func
+            def some_method(self: object) -> None:
+                pass
+
+    with pytest.raises(
+        TypeError,
+        match=r".*can't be used with async functions, generators, or coroutines.*",
+    ):
+
+        @func
+        def a_generator() -> None:
+            yield 42
+
+    with pytest.raises(
+        TypeError,
+        match=r".*can't be used with async functions, generators, or coroutines.*",
+    ):
+
+        @func
+        async def an_async_func() -> int:
+            return 42
 
 
 def test_inline_and_resource_reqs():

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -87,7 +87,7 @@ def test_not_a_function():
     ):
 
         @func
-        def a_generator() -> None:
+        def a_generator() -> object:
             yield 42
 
     with pytest.raises(

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -41,11 +41,11 @@ def test_any():
     with pytest.raises(TypeError, match=expected):
 
         @func
-        def f(x: Any) -> None:
+        def f1(x: Any) -> None:
             pass
 
     @func
-    def f(x: object) -> None:
+    def f2(x: object) -> None:
         pass
 
 

--- a/sematic/types/registry.py
+++ b/sematic/types/registry.py
@@ -294,6 +294,10 @@ def validate_type_annotation(*types: TypeAnnotation) -> None:
     """
 
     def assert_supported(type_):
+        if type_ is Any:
+            raise TypeError(
+                "'Any' is not a Sematic-supported type. Use 'object' instead."
+            )
         try:
             subclasses_type = issubclass(type_, type)
         except TypeError:

--- a/sematic/types/tests/test_registry.py
+++ b/sematic/types/tests/test_registry.py
@@ -46,9 +46,11 @@ def test_validate_type_annotation():
         validate_type_annotation(List[int], 42)
     with pytest.raises(TypeError, match=r"Expected a Sematic-supported type here"):
         validate_type_annotation(Literal[42])
-    with pytest.raises(TypeError, match="Expected a Sematic-supported type here"):
+    with pytest.raises(
+        TypeError, match=r"'Any' is not a Sematic-supported.*'object' instead."
+    ):
         validate_type_annotation(Any)
-    with pytest.raises(TypeError, match="typing.Union must be parametrized"):
+    with pytest.raises(TypeError, match=r"typing.Union must be parametrized.*"):
         validate_type_annotation(Union)
 
 


### PR DESCRIPTION
Closes #47, #133

Prior to now, if you used `Any` as a type annotation for a Sematic func, you got a general "not a supported type" message. We have a recommendation to use `object` instead. This makes it so the error message instructs users to use this alternative explicitly. It also makes it so that invalid type annotations are caught earlier--as soon as a function is decorated with `@func`. Additionally, there were several types of functions which would fail when decorated with `@func`, but which failed in unexpected ways. For example: methods, generators, and co-routines. This PR adds checks that detect these usages and raise a helpful error message.