### PR TITLE
Support automatic conversion of tuple-of-futures to future-tuple

### DIFF
--- a/docs/future-algebra.md
+++ b/docs/future-algebra.md
@@ -111,7 +111,7 @@ turning `Tuple[Future[float], Future[str]]` into
 `Future[Tuple[float, str]]`. Note that using futures nested in
 tuples-in-lists is not supported. Other collections, such as `Dict`,
 `Set`, etc. do NOT currently perform these kinds of automatic
-conversions--you will need to do them explicitly.
+conversions; you will need to do them explicitly.
 
 ### Item access
 

--- a/docs/future-algebra.md
+++ b/docs/future-algebra.md
@@ -84,7 +84,7 @@ you call `.resolve()`) must all be [concrete](./glossary.md#concrete-inputs).
 {% endhint %}
 
 
-### Passing and returning lists of futures
+### Passing and returning collections of futures
 
 The following example is supported:
 
@@ -106,7 +106,12 @@ def pipeline(a: float, b: float) -> List[float]:
 ```
 
 Here Sematic will know how to convert `List[Future[float]]` into
-`Future[List[float]]`.
+`Future[List[float]]`. Sematic will perform analogous conversion for
+turning `Tuple[Future[float], Future[str]]` into
+`Future[Tuple[float, str]]`. Note that using futures nested in
+tuples-in-lists is not supported. Other collections, such as `Dict`,
+`Set`, etc. do NOT currently perform these kinds of automatic
+conversions--you will need to do them explicitly.
 
 ### Item access
 

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -12,7 +12,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -390,7 +389,6 @@ def _make_tuple(
     if not isinstance(tuple_with_futures, collections.abc.Sequence):
         raise TypeError("tuple_with_futures must be a collections.Sequence.")
 
-    element0_type = get_args(type_)[0]  # type: ignore
     if len(get_args(type_)) > 1:
         if get_args(type_)[-1] is ...:
             raise TypeError("Sematic does not support Ellipsis in Tuples yet (...)")

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -12,9 +12,11 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
+    get_args,
     get_origin,
 )
 
@@ -98,6 +100,12 @@ class Calculator(AbstractCalculator):
             if isinstance(argument_map[name], list):
                 argument_map[name] = _convert_lists(argument_map[name])
 
+            if isinstance(argument_map[name], tuple):
+                argument_map[name] = _convert_tuples(
+                    argument_map[name],
+                    self._input_types[name],
+                )
+
         cast_arguments = self.cast_inputs(argument_map)
 
         return Future(
@@ -123,6 +131,8 @@ class Calculator(AbstractCalculator):
         # Support for lists of futures
         if isinstance(output, list):
             output = _convert_lists(output)
+        if isinstance(output, tuple):
+            output = _convert_tuples(output, self.output_type)
 
         return output
 
@@ -360,3 +370,72 @@ def _convert_lists(value_):
         return _make_list(List[output_type], value_)
 
     return value_
+
+
+TupleOutputType = TypeVar("TupleOutputType")
+
+
+def _make_tuple(
+    type_: Type[TupleOutputType], tuple_with_futures: Sequence[Any]
+) -> TupleOutputType:
+    """
+    Given a tuple with futures, returns a future Tuple.
+    """
+    if get_origin(type_) is not tuple:
+        raise TypeError(
+            "type_ must be a Tuple type, and it must be parameterized as "
+            f"Tuple[SomeTypeA, SomeTypeB]. Got: {type_}"
+        )
+
+    if not isinstance(tuple_with_futures, collections.abc.Sequence):
+        raise TypeError("tuple_with_futures must be a collections.Sequence.")
+
+    element0_type = get_args(type_)[0]  # type: ignore
+    if len(get_args(type_)) > 1:
+        if get_args(type_)[-1] is ...:
+            raise TypeError("Sematic does not support Ellipsis in Tuples yet (...)")
+
+    input_types = {}
+    inputs = {}
+
+    for i, item in enumerate(tuple_with_futures):
+        element_type = get_args(type_)[i]
+        if isinstance(item, Future):
+            can_cast, error = can_cast_type(item.calculator.output_type, element_type)
+            if not can_cast:
+                raise TypeError("Invalid value: {}".format(error))
+        else:
+            _, error = safe_cast(item, element_type)
+            if error is not None:
+                raise TypeError("Invalid value: {}".format(error))
+
+        input_types["v{}".format(i)] = element_type
+        inputs["v{}".format(i)] = item
+
+    source_code = """
+def _make_tuple({inputs}):
+    return tuple([{inputs}])
+    """.format(
+        inputs=", ".join("v{}".format(i) for i in range(len(tuple_with_futures)))
+    )
+    scope: Dict[str, Any] = {"__name__": __name__}
+    exec(source_code, scope)
+    _make_tuple = scope["_make_tuple"]
+
+    return Calculator(
+        _make_tuple, input_types=input_types, output_type=type_, inline=True
+    )(**inputs)
+
+
+def _convert_tuples(value_, expected_type):
+    value_as_list = list(value_)
+    for idx, item in enumerate(value_as_list):
+        if isinstance(item, tuple):
+            value_as_list[idx] = _convert_tuples(item, get_args(expected_type)[idx])
+        elif isinstance(item, list):
+            value_as_list[idx] = _convert_lists(item)
+
+    if any(isinstance(item, Future) for item in value_as_list):
+        return _make_tuple(expected_type, tuple(value_as_list))
+
+    return tuple(value_as_list)

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -159,7 +159,7 @@ def main(
 
         else:
             logger.info("Executing %s", func.__name__)
-            output = func.func(**kwargs)
+            output = func.calculate(**kwargs)
             _set_run_output(run, output, func.output_type, edges)
 
     except Exception as e:

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -1,12 +1,19 @@
 # Standard Library
-from typing import List, Union
+from typing import List, Tuple, Union
 
 # Third-party
 import pytest
 
 # Sematic
 from sematic.abstract_calculator import CalculatorError
-from sematic.calculator import Calculator, _convert_lists, _make_list, func
+from sematic.calculator import (
+    Calculator,
+    _convert_lists,
+    _convert_tuples,
+    _make_list,
+    _make_tuple,
+    func,
+)
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.future import Future
 from sematic.resolvers.resource_requirements import (  # noqa: F401
@@ -163,6 +170,11 @@ def bar() -> str:
     return "bar"
 
 
+@func
+def baz() -> int:
+    return 42
+
+
 def test_make_list():
     future = _make_list(List[str], [foo(), bar()])
 
@@ -171,14 +183,33 @@ def test_make_list():
     assert len(future.calculator.input_types) == 2
 
 
+def test_make_tuple():
+    future = _make_tuple(Tuple[str, int], (bar(), baz()))
+
+    assert isinstance(future, Future)
+    assert future.calculator.output_type is Tuple[str, int]
+    assert len(future.calculator.input_types) == 2
+    assert future.calculator.calculate(v0="a", v1=42) == ("a", 42)
+
+
 @func
 def pipeline() -> List[str]:
     return [foo(), bar(), "baz"]
 
 
+@func
+def tuple_pipeline() -> Tuple[str, int, str]:
+    return (foo(), baz(), "qux")
+
+
 def test_pipeline():
     output = pipeline().resolve(tracking=False)
     assert output == ["foo", "bar", "baz"]
+
+
+def test_tuple_pipeline():
+    output = tuple_pipeline().resolve(tracking=False)
+    assert output == ("foo", 42, "qux")
 
 
 def test_convert_lists():
@@ -219,6 +250,10 @@ def test_convert_lists():
         3,
         [4, [5, "foo"]],
     ]
+
+
+def test_convert_tuples():
+    pass
 
 
 def test_inline_default():

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -253,7 +253,17 @@ def test_convert_lists():
 
 
 def test_convert_tuples():
-    pass
+    value = (42, [1, baz(), 3], (foo(), bar()), foo())
+    expected_type = Tuple[int, List[int], Tuple[str, str], str]
+    result = _convert_tuples(value, expected_type)
+    assert isinstance(result, Future)
+    assert result.props.inline is True
+
+    @func
+    def pipeline() -> expected_type:
+        return value
+
+    assert pipeline().resolve(tracking=False) == (42, [1, 42, 3], ("foo", "bar"), "foo")
 
 
 def test_inline_default():

--- a/sematic/types/registry.py
+++ b/sematic/types/registry.py
@@ -25,7 +25,7 @@ _SUPPORTED_TYPES_DOCS = (
 # this lists them. It also includes the "origin" types they
 # map to (which is essentially the unparameterized version
 # of them; see python typing docs). The origin types are
-# what we ant in the registry.
+# what we want in the registry.
 SUPPORTED_GENERIC_TYPING_ANNOTATIONS = {
     Tuple: get_origin(Tuple[int, int]),
     List: get_origin(List[int]),


### PR DESCRIPTION
Closes #86, #217

We already support this for lists:

```
@sematic.func
def pipeline() -> typing.List[int]:
    return [foo(), bar()]
```
where `foo` and `bar` are Sematic funcs (thus returning futures). This PR makes it so we also support this:
```
@sematic.func
def pipeline() -> typing.Tuple[int]:
    return (foo(), bar())
```

Additionally, the code above would fail for a remote execution if the funcs were not inline (see #217). This PR also fixes that bug.

Testing
-------
In addition to unit tests, I also executed some remote runs:

- [returning a list of futures](https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/061fdf4f4b4a4ed6951495cc794c27d3)
- [returning a tuple of futures](https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/da76ced2672f46118501bcea02d2505f)
- [raising an error](https://dev.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/fbadf38fc4b04e8bb7423dcadd50418c) (to confirm that the fix for #217 didn't disrupt error handling)