### PR TITLE
Fix mypy issues on main

### DIFF
--- a/sematic/api/wsgi.py
+++ b/sematic/api/wsgi.py
@@ -1,3 +1,6 @@
+# Standard Library
+from typing import Any, Dict, Optional
+
 # Third-party
 import flask
 import gunicorn.app.base  # type: ignore
@@ -11,7 +14,9 @@ class SematicWSGI(gunicorn.app.base.BaseApplication):
 
     """
 
-    def __init__(self, app: flask.app.Flask, options: dict = None) -> None:
+    def __init__(
+        self, app: flask.app.Flask, options: Optional[Dict[Any, Any]] = None
+    ) -> None:
         """Initializer for the standalone application class for
         gunicorn.
 

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -249,7 +249,7 @@ def _repr_str_iterable(str_iterable: Iterable[str]) -> str:
 
 
 def func(
-    func: Callable = None,
+    func: Optional[Callable] = None,
     inline: bool = True,
     resource_requirements: Optional[ResourceRequirements] = None,
     retry: Optional[RetrySettings] = None,

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -67,14 +67,6 @@ pytest_test(
 )
 
 pytest_test(
-    name = "test_client",
-    srcs = ["test_client.py"],
-    deps = [
-        "//sematic:client",
-    ],
-)
-
-pytest_test(
     name = "test_log_reader",
     srcs = ["test_log_reader.py"],
     deps = [

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -67,6 +67,14 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_client",
+    srcs = ["test_client.py"],
+    deps = [
+        "//sematic:client",
+    ],
+)
+
+pytest_test(
     name = "test_log_reader",
     srcs = ["test_log_reader.py"],
     deps = [

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -143,7 +143,7 @@ def test_none_types():
 def test_types_specified():
     @func
     def f(a: float) -> int:
-        pass
+        return int(a)
 
     assert f.input_types == dict(a=float)
     assert f.output_type is int

--- a/sematic/tests/test_client.py
+++ b/sematic/tests/test_client.py
@@ -1,0 +1,10 @@
+# Sematic
+from sematic import client
+
+
+def test_client():
+    try:
+        # validate that this function is imported and exposed in the module
+        client.get_artifact_value  # type: ignore
+    except AttributeError as e:
+        assert False, str(e)

--- a/sematic/tests/test_client.py
+++ b/sematic/tests/test_client.py
@@ -1,6 +1,0 @@
-# Sematic
-from sematic import client
-
-
-def test_client():
-    assert client.get_artifact_value


### PR DESCRIPTION
Mypy errors started happening on `main` (without reproducing locally), causing all new PRs' builds to fail. This fixes the issues to unblock new PRs, pending an investigation regarding the discrepancy between Circleci and local mypy linters.