### PR TITLE
Add sqlite version check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           command: python3 -m flake8 --max-line-length=90
       - run:
           name: MyPy
-          command: mypy sematic
+          command: mypy --version && mypy sematic
       - run:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above

--- a/requirements/ci-requirements.txt
+++ b/requirements/ci-requirements.txt
@@ -2,7 +2,7 @@
 # Linters and such. Pin them so that different devs
 # don't get different results from using them.
 flake8==5.0.4
-mypy>=0.971
+mypy==0.971
 black==22.6.0
 isort==5.10.1
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,4 +1,5 @@
 # Standard Library
+import sqlite3
 import typing
 
 # Represents the version of the client, server, and all other parts of
@@ -11,6 +12,23 @@ CURRENT_VERSION = (0, 19, 2)
 # at the CURRENT_VERSION. Should be updated any time a breaking change
 # is made to the web API.
 MIN_CLIENT_SERVER_SUPPORTS = (0, 19, 0)
+
+# Support for dropping columns added in 3.35.0
+MIN_SQLITE_VERSION = (3, 35, 0)
+
+
+def assert_sqlite_version():
+    version_tuple = sqlite3.sqlite_version.split(".")
+
+    # get major/minor as ints. Patch can sometimes have non-digit chars
+    major, minor = int(version_tuple[0]), int(version_tuple[1])
+    if (major, minor) < MIN_SQLITE_VERSION:
+        raise RuntimeError(
+            f"Sematic requires sqlite3 version to be at least "
+            f"{version_as_string(MIN_SQLITE_VERSION)}, but your python is using "
+            f"{sqlite3.sqlite_version}. Please upgrade. You may find this useful: "
+            f"https://stackoverflow.com/a/55729735/2540669"
+        )
 
 
 def version_as_string(version: typing.Tuple[int, int, int]) -> str:
@@ -30,7 +48,7 @@ def version_as_string(version: typing.Tuple[int, int, int]) -> str:
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
 MIN_CLIENT_SERVER_SUPPORTS_STR = version_as_string(MIN_CLIENT_SERVER_SUPPORTS)
-
+assert_sqlite_version()
 
 if __name__ == "__main__":
     # It can be handy for deployment scripts and similar things to be able to get quick

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -17,7 +17,7 @@ MIN_CLIENT_SERVER_SUPPORTS = (0, 19, 0)
 MIN_SQLITE_VERSION = (3, 35, 0)
 
 
-def assert_sqlite_version():
+def _assert_sqlite_version():
     version_tuple = sqlite3.sqlite_version.split(".")
 
     # get major/minor as ints. Patch can sometimes have non-digit chars
@@ -48,7 +48,7 @@ def version_as_string(version: typing.Tuple[int, int, int]) -> str:
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
 MIN_CLIENT_SERVER_SUPPORTS_STR = version_as_string(MIN_CLIENT_SERVER_SUPPORTS)
-assert_sqlite_version()
+_assert_sqlite_version()
 
 if __name__ == "__main__":
     # It can be handy for deployment scripts and similar things to be able to get quick


### PR DESCRIPTION
If users have a sqlite3 version less than 3.35.0, they won't be able to use Sematic, but the failure mode is just that the automatic db migrations fail. This makes a more clear error message that will show up when the`versions` module is loaded. Since `versions` is imported in `sematic/__init__`, this should mean that the first time the interpreter imports `sematic`, the sqlite version check should be performed.

Testing
-------
`bazel run //sematic/cli:main -- --help`, then the same with `MIN_SQLITE_VERSION` changed to `(3, 35, 0)` to force it to fail. Failure message:
```python
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/cli/main.py", line 2, in <module>
    import sematic.cli.cancel  # noqa: F401
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/__init__.py", line 20, in <module>
    import sematic.future_operators  # noqa: F401,E402
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/future_operators/__init__.py", line 2, in <module>
    import sematic.future_operators.getitem  # noqa: F401
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/future_operators/getitem.py", line 9, in <module>
    from sematic.calculator import func
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/calculator.py", line 24, in <module>
    from sematic.future import Future
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/future.py", line 7, in <module>
    from sematic.resolvers.local_resolver import LocalResolver
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/resolvers/local_resolver.py", line 11, in <module>
    import sematic.api_client as api_client
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/api_client.py", line 20, in <module>
    from sematic.versions import CURRENT_VERSION, version_as_string
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/versions.py", line 51, in <module>
    _assert_sqlite_version()
  File "/private/var/tmp/_bazel_josh/2e6587ba58699c2ae305f4c72e05bdb6/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main.runfiles/sematic/sematic/versions.py", line 26, in _assert_sqlite_version
    raise RuntimeError(
RuntimeError: Sematic requires sqlite3 version to be at least 3.35000.0, but your python is using 3.38.3. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
```