### PR TITLE
Add list pods permissions to server SA

### DIFF
--- a/helm/sematic/Chart.yaml
+++ b/helm/sematic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sematic
-version: 0.2.0
+version: 0.3.0
 kubeVersion: ">=1.21.0-0"
 description: The open-source Continuous Learning tool
 home: https://sematic.dev

--- a/helm/sematic/templates/sematic-server-role.yaml
+++ b/helm/sematic/templates/sematic-server-role.yaml
@@ -10,3 +10,6 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs/status"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]


### PR DESCRIPTION
We have recently added an API call to list pods for a job. We need the server's K8s SA to have permissions to do that. This adds such permissions to our helm chart. [Here's](https://github.com/sematic-ai/sematic/blob/main/sematic/scheduling/kubernetes.py#L340) where we use the permissions