### PR TITLE
Fix test errors when ~/.semantic/data is missing during build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 test --test_tag_filters=nocov --test_output=all
+test --spawn_strategy='processwrapper-sandbox'

--- a/developer-docs/tips-for-bazel.md
+++ b/developer-docs/tips-for-bazel.md
@@ -93,3 +93,10 @@ You can also do *this* with specific python interpreters:
 ```
 $ bazel run //sematic/cli:main_py39 -- --help
 ```
+
+## Miscellaneous
+To clear the Bazel cache, run:
+
+```
+$ bazel clean --expunge
+```


### PR DESCRIPTION
Loosens Bazel sandboxing rules during build, such that the missing dirs are ignored.

Added a tip for clearing the Bazel cache.