### PR TITLE
Update sklearn to scikit-learn in requirements.txt of examples

### DIFF
--- a/sematic/examples/liver_cirrhosis/requirements.txt
+++ b/sematic/examples/liver_cirrhosis/requirements.txt
@@ -2,6 +2,6 @@ pandas
 seaborn
 matplotlib
 statsmodels
-sklearn
+scikit-learn
 xgboost
 numpy

--- a/sematic/examples/mnist/pytorch/requirements.txt
+++ b/sematic/examples/mnist/pytorch/requirements.txt
@@ -3,4 +3,4 @@ torchvision
 torchmetrics
 plotly
 pandas
-sklearn
+scikit-learn


### PR DESCRIPTION
I have updated the references for sklearn to scikit-learn. The only place we reference sklearn is in the `requirements.txt` for the mnist and the liver cirrhosis examples. I have verified that we are not using this reference in the `requirements.in` used for the installation of sematic.