### PR TITLE
Temporarily remove drop column from up migrations

### DIFF
--- a/sematic/db/migrations/20221004183943_remove_exception_from_runs.sql
+++ b/sematic/db/migrations/20221004183943_remove_exception_from_runs.sql
@@ -1,6 +1,7 @@
 -- migrate:up
 
-ALTER TABLE runs DROP COLUMN exception;
+-- TODO #302: implement sustainable way to upgrade sqlite3 DBs
+-- ALTER TABLE runs DROP COLUMN exception;
 
 -- migrate:down
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,6 +1,9 @@
 # Standard Library
+import logging
 import sqlite3
 import typing
+
+logger = logging.getLogger(__name__)
 
 # Represents the version of the client, server, and all other parts of
 # the sdk. Should be bumped any time a release is made. Should be set
@@ -17,17 +20,19 @@ MIN_CLIENT_SERVER_SUPPORTS = (0, 19, 0)
 MIN_SQLITE_VERSION = (3, 35, 0)
 
 
-def _assert_sqlite_version():
+def _check_sqlite_version():
     version_tuple = sqlite3.sqlite_version.split(".")
 
     # get major/minor as ints. Patch can sometimes have non-digit chars
     major, minor = int(version_tuple[0]), int(version_tuple[1])
     if (major, minor) < MIN_SQLITE_VERSION:
-        raise RuntimeError(
-            f"Sematic requires sqlite3 version to be at least "
-            f"{version_as_string(MIN_SQLITE_VERSION)}, but your python is using "
-            f"{sqlite3.sqlite_version}. Please upgrade. You may find this useful: "
-            f"https://stackoverflow.com/a/55729735/2540669"
+        # TODO #302: implement sustainable way to upgrade sqlite3 DBs
+        logger.warning(
+            "Sematic will soon require the sqlite3 version to be at least %s, but your "
+            "Python is using %s. Please upgrade. You may find this useful: "
+            "https://stackoverflow.com/a/55729735/2540669",
+            version_as_string(MIN_SQLITE_VERSION),
+            sqlite3.sqlite_version,
         )
 
 
@@ -48,7 +53,7 @@ def version_as_string(version: typing.Tuple[int, int, int]) -> str:
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
 MIN_CLIENT_SERVER_SUPPORTS_STR = version_as_string(MIN_CLIENT_SERVER_SUPPORTS)
-_assert_sqlite_version()
+_check_sqlite_version()
 
 if __name__ == "__main__":
     # It can be handy for deployment scripts and similar things to be able to get quick


### PR DESCRIPTION
This removes the drop column operations from the up direction DB migrations in order to unblock users who are impacted by this issue: #302.

The check that sqlite3 has a minimum version of 3.35.0 is also relaxed to just warn instead of fail the starting of the server.

The effect is that users will be able to migrate to newer versions of Sematic on both their local and cloud deployments even if their Python installation did not come with sqlite3 >= 3.35.0, without requiring them to install a newer version from sources.

This is a temporary measure until the issue is resolved in a more sustainable way. The column that was previously removed will be kept in the DB until we address the issue.

Tested by starting the server without a database file, and by migrating down a database that contained relevant exception data, and back up again.