### PR TITLE
#310 Fixes the multi-line docstring rendering.

### DIFF
--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -157,7 +157,7 @@ class Run(Base, JSONEncodableMixin, HasExternalJobsMixin):
     @validates("description")
     def strip_description(self, _, value) -> str:
         if value is not None:
-            value = re.sub(r"\n\s{4}", "\n", value.strip())
+            value = re.sub(r"\n( {4}|\t)", "\n", value.strip())
 
         return value
 

--- a/sematic/db/models/tests/test_run.py
+++ b/sematic/db/models/tests/test_run.py
@@ -15,6 +15,16 @@ def test_set_description():
     assert run.description == "abc"
 
 
+def test_description_format_indended_spaces():
+    run = Run(description="   line1\n\n    line2")
+    assert run.description == "line1\n\nline2"
+
+
+def test_description_format_remove_tab():
+    run = Run(description="   line1\n\n\tline2")
+    assert run.description == "line1\n\nline2"
+
+
 def test_external_jobs():
     run = Run()
     assert run.external_jobs_json is None


### PR DESCRIPTION
Fixes issue in #310 

Adopted one solution in https://github.com/remarkjs/react-markdown/issues/273#issuecomment-683754992

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/1046489/202506135-58709235-e5a3-4098-890d-7ec5c28d53df.png">

