### PR TITLE
Streamlining handling of artifacts in `LocalResolver` in order to fix a re-run bug

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -102,8 +102,6 @@ class CloudResolver(LocalResolver):
 
         self._storage = S3Storage()
 
-        self._output_artifacts_by_run_id: Dict[str, Artifact] = {}
-
     def resolve(self, future: AbstractFuture) -> Any:
         if not self._detach:
             return super().resolve(future)
@@ -261,13 +259,10 @@ class CloudResolver(LocalResolver):
                 raise RuntimeError("Missing output artifact")
 
             output_artifact = self._artifacts[output_edge.artifact_id]
-            self._output_artifacts_by_run_id[run.id] = output_artifact
+            self._artifacts_by_run_id[run.id][None] = output_artifact
             value = get_artifact_value(output_artifact, storage=self._storage)
 
         self._update_future_with_value(future, value)
-
-    def _get_output_artifact(self, run_id: str) -> Optional[Artifact]:
-        return self._output_artifacts_by_run_id.get(run_id)
 
     def _future_did_fail(self, failed_future: AbstractFuture) -> None:
         # Unlike LocalResolver._future_did_fail, we only care about

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -98,7 +98,11 @@ class StateMachineResolver(Resolver, abc.ABC):
         try:
             yield
         except Exception as e:
-            self._resolution_did_fail(error=e)
+            try:
+                self._resolution_did_fail(error=e)
+            except Exception as ee:
+                logger.error("Unable to fail resolution: %s", ee)
+
             if isinstance(e, CalculatorError) and hasattr(e, "__cause__"):
                 # this will simplify the stack trace so the user sees less
                 # from Sematic's stack and more from the error from their code.

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -288,3 +288,95 @@ def test_run_reverse_ordering(
     ]
 
     assert run_ids_by_reverse_order == expected_order
+
+
+@func
+def pipeline_fail(a: int) -> int:
+    b = add_fail(a, a)
+    c = add(a, b)
+    return add(a, c)
+
+
+def test_nested_fail(
+    mock_auth,  # noqa: F811
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_local_resolver_storage,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    future = pipeline_fail(1)
+    resolver = LocalResolver()
+
+    with pytest.raises(Exception, match="fail"):
+        future.resolve(resolver)
+
+    runs, artifacts, edges = api_client.get_graph(future.id, root=True)
+
+    graph = Graph(
+        runs=runs, edges=edges, artifacts=artifacts, storage=mock_local_resolver_storage
+    )
+    for run in runs:
+        graph.clone_futures(reset_from=run.id)
+
+
+"""
+b11a1bc4bfce4bb2b7bd9caa069d8d13
+5586162f0f9f4dd68d1ebce65e81f096
+564a74947532429f83faa5005aee43d1
+Edge(
+    id=f04255b451484770a10e17424e5a9e3b,
+    source_run_id=None,
+    destination_run_id=b11a1bc4bfce4bb2b7bd9caa069d8d13,
+    destination_name=a,
+    artifact_id=df56adbd1d6d197be682be18f527e8b4f311f9ae,
+    parent_id=None
+),
+Edge(
+    id=0755cb17414f493fb327e29e5b73555f,
+    source_run_id=b11a1bc4bfce4bb2b7bd9caa069d8d13,
+    destination_run_id=None,
+    destination_name=None,
+    artifact_id=None,
+    parent_id=None
+),
+Edge(
+    id=744b958798704dc1aa12f7da6fde4097,
+    source_run_id=None,
+    destination_run_id=564a74947532429f83faa5005aee43d1,
+    destination_name=a,
+    artifact_id=None,
+    parent_id=None
+),
+Edge(
+    id=9e941e9a3b854fa7a86e7b4b45bc7146,
+    source_run_id=5586162f0f9f4dd68d1ebce65e81f096,
+    destination_run_id=564a74947532429f83faa5005aee43d1,
+    destination_name=b,
+    artifact_id=None,
+    parent_id=None
+),
+Edge(
+    id=3969c572100b442297a7f5de517d8df1,
+    source_run_id=564a74947532429f83faa5005aee43d1,
+    destination_run_id=None,
+    destination_name=None,
+    artifact_id=None,
+    parent_id=0755cb17414f493fb327e29e5b73555f
+),
+Edge(
+    id=6d9d8224a4d042bda403d5e78c1429a7,
+    source_run_id=None,
+    destination_run_id=5586162f0f9f4dd68d1ebce65e81f096,
+    destination_name=a,
+    artifact_id=9eb1beb09bd13df4dd9e1847bab2adba006be8b8,
+    parent_id=None
+),
+Edge(
+    id=0274871099fa405f88d53b949ec2501b,
+    source_run_id=None,
+    destination_run_id=5586162f0f9f4dd68d1ebce65e81f096,
+    destination_name=b,
+    artifact_id=9eb1beb09bd13df4dd9e1847bab2adba006be8b8,
+    parent_id=None
+)
+"""

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -102,9 +102,7 @@ def test_clone_futures(
             assert future_.value == value
             if output_edge.destination_run_id is not None:
                 downstream_run = runs_by_id[output_edge.destination_run_id]
-                downstream_future = cloned_graph.futures_by_original_id[
-                    downstream_run.id
-                ]
+                downstream_future = cloned_graph.futures_by_original_id[downstream_run.id]
                 assert downstream_future.kwargs[output_edge.destination_name] is future_
 
 
@@ -164,9 +162,7 @@ def test_clone_futures_reset(
     ]
 
     assert len(top_level_add_futures) == 3
-    assert all(
-        future_.state is FutureState.RESOLVED for future_ in top_level_add_futures
-    )
+    assert all(future_.state is FutureState.RESOLVED for future_ in top_level_add_futures)
 
 
 @func
@@ -317,66 +313,3 @@ def test_nested_fail(
     )
     for run in runs:
         graph.clone_futures(reset_from=run.id)
-
-
-"""
-b11a1bc4bfce4bb2b7bd9caa069d8d13
-5586162f0f9f4dd68d1ebce65e81f096
-564a74947532429f83faa5005aee43d1
-Edge(
-    id=f04255b451484770a10e17424e5a9e3b,
-    source_run_id=None,
-    destination_run_id=b11a1bc4bfce4bb2b7bd9caa069d8d13,
-    destination_name=a,
-    artifact_id=df56adbd1d6d197be682be18f527e8b4f311f9ae,
-    parent_id=None
-),
-Edge(
-    id=0755cb17414f493fb327e29e5b73555f,
-    source_run_id=b11a1bc4bfce4bb2b7bd9caa069d8d13,
-    destination_run_id=None,
-    destination_name=None,
-    artifact_id=None,
-    parent_id=None
-),
-Edge(
-    id=744b958798704dc1aa12f7da6fde4097,
-    source_run_id=None,
-    destination_run_id=564a74947532429f83faa5005aee43d1,
-    destination_name=a,
-    artifact_id=None,
-    parent_id=None
-),
-Edge(
-    id=9e941e9a3b854fa7a86e7b4b45bc7146,
-    source_run_id=5586162f0f9f4dd68d1ebce65e81f096,
-    destination_run_id=564a74947532429f83faa5005aee43d1,
-    destination_name=b,
-    artifact_id=None,
-    parent_id=None
-),
-Edge(
-    id=3969c572100b442297a7f5de517d8df1,
-    source_run_id=564a74947532429f83faa5005aee43d1,
-    destination_run_id=None,
-    destination_name=None,
-    artifact_id=None,
-    parent_id=0755cb17414f493fb327e29e5b73555f
-),
-Edge(
-    id=6d9d8224a4d042bda403d5e78c1429a7,
-    source_run_id=None,
-    destination_run_id=5586162f0f9f4dd68d1ebce65e81f096,
-    destination_name=a,
-    artifact_id=9eb1beb09bd13df4dd9e1847bab2adba006be8b8,
-    parent_id=None
-),
-Edge(
-    id=0274871099fa405f88d53b949ec2501b,
-    source_run_id=None,
-    destination_run_id=5586162f0f9f4dd68d1ebce65e81f096,
-    destination_name=b,
-    artifact_id=9eb1beb09bd13df4dd9e1847bab2adba006be8b8,
-    parent_id=None
-)
-"""


### PR DESCRIPTION
It turns out it is possible that certain input edges have neither an `artifact_id` set nor a `source_run_id` set.

This is the case when the edge points to a value passed from outside the parent future. For example:

```python
@sematic.func
def pipeline(a: int) -> int:
    f = foo()
    b = bar(f, a)
    return b
```
In this case, the edge for the `a` input to `bar` will have neither `artifact_id` nor `source_run_id` set until `bar` is ready to be scheduled. This prevents the graph from being cloned in the case where an upstream run fails (e.g. `foo`).

This PR fixes this issue by creating artifacts as soon as there is a concrete value for it, it does not wait for `bar` to be ready to get scheduled.