### PR TITLE
Make server not start if migration fails

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -14,4 +14,4 @@ COPY sematic-*.whl .
 RUN pip install sematic-*.whl
 
 EXPOSE 80
-CMD python3 -m sematic.db.migrate up --verbose --env cloud; python3 -m sematic.api.server --env cloud
+CMD python3 -m sematic.db.migrate up --verbose --env cloud && python3 -m sematic.api.server --env cloud


### PR DESCRIPTION
Closes #289 

Currently if the DB migration fails for any reason, the DB is left in an intermediate state with the last successful migration step applied, and the version of the Server which expected all the migration steps to have succeeded is started anyway, creating a discrepancy between the Server code and the DB version.

The Server should not start at all if the DB is not up-to-date.

This PR makes it so that when migration fails, the server does not start.

Testing
-------
I started the server on the webbox using this code, and confirmed the migration still worked and the server still started. Then, I made migration intentionally fail and confirmed that the server did not start.