### PR TITLE
Fix cli command arg passing

### DIFF
--- a/sematic/cli/run.py
+++ b/sematic/cli/run.py
@@ -66,11 +66,11 @@ def run(ctx, script_path: str):
         click.echo("Sematic is not started, issue `sematic start` first.")
         return
 
+    # This is ugly, better way to do this?
+    sys.argv = [sys.argv[0]] + ctx.args
+
     if is_example(script_path):
         _run_example(script_path)
         return
-
-    # This is ugly, better way to do this?
-    sys.argv = [sys.argv[0]] + ctx.args
 
     runpy.run_module(script_path, run_name="__main__")


### PR DESCRIPTION
Fixes #337.

The `cli` CLI command parser extracted its own options from `sys.args` and passed the remainder to executed scripts only when running non-example pipelines. When an example pipeline wanted to parse arguments, it would also get `cli`'s intended arguments, when executed by `cli`.

This fixes the issue by treating example pipelines as any other script launched by `cli`.
