### PR TITLE
Remove deprecated abstractproperty

### DIFF
--- a/sematic/abstract_calculator.py
+++ b/sematic/abstract_calculator.py
@@ -34,11 +34,13 @@ class AbstractCalculator(abc.ABC):
     def cast_output(self, value: typing.Any) -> typing.Any:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def input_types(self) -> typing.Dict[str, type]:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def output_type(self) -> type:
         pass
 


### PR DESCRIPTION
Removes usages if the deprecated `@abc.abstractproperty` decorator from the codebase:

```python
class abstractproperty(property):
    """A decorator indicating abstract properties.

    Deprecated, use 'property' with 'abstractmethod' instead:

        class C(ABC):
            @property
            @abstractmethod
            def my_abstract_property(self):
                ...

    """
```