### PR TITLE
Fix build checks for Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 node_modules
+
+# Vim
+.*swp

--- a/BUILD
+++ b/BUILD
@@ -10,7 +10,7 @@ load("@python3_8//:defs.bzl", interpreter38="interpreter")
 
 exports_files(["README.rst"])
 exports_files(["docs/changelog.md"])
-exports_files(["helm/sematic/values.yaml"])
+exports_files(["helm/sematic-server/Chart.yaml"])
 
 stamp_build_setting(name = "stamp")
 

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.15.1
+appVersion: v0.20.0

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -85,7 +85,7 @@ pytest_test(
     srcs = ["test_versions.py"],
     data = [
         "//:docs/changelog.md",
-        "//:helm/sematic/values.yaml",
+        "//:helm/sematic-server/Chart.yaml",
     ],
     env = {"BAZEL_WHEEL_VERSION": wheel_version_string},
     pip_deps = [

--- a/sematic/tests/test_versions.py
+++ b/sematic/tests/test_versions.py
@@ -36,16 +36,16 @@ def test_changelog():
 
 
 def test_helm_chart():
-    with open("helm/sematic/values.yaml", "r") as fp:
+    with open("helm/sematic-server/Chart.yaml", "r") as fp:
         encodable = yaml.load(fp, yaml.Loader)
 
-    image = encodable["server"]["image"]
-    prefix = "sematicai/sematic-server:v"
+    image = encodable["appVersion"]
+    prefix = "v"
     assert image.startswith(prefix)
     version_string = image.replace(prefix, "")
     values_version = tuple(int(v) for v in version_string.split("."))
     message = (
-        f"Latest version in values.yaml ({version_string}) doesn't "
+        f"Latest version in Chart.yaml ({version_string}) doesn't "
         f"match the version in versions.py ({CURRENT_VERSION})."
     )
     assert values_version == CURRENT_VERSION, message


### PR DESCRIPTION
Helm chart versions were moved to use the published chart version by default, which broke the build.  This fixes the reference to the new `appVersion` location.