### PR TITLE
Fix Union serdes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,9 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
+    * [bugfix] Fix a bug deserializing `Union` values. Note that once you are using this release,
+      if you try to "rerun from here" using a pipeline that has `Union` values in it that were
+      produced prior to this version of Sematic, the rerun will likely fail with a serialization issue.
 * [0.20.0](https://pypi.org/project/sematic/0.20.0/)
     * [feature] Add datetime class and basic visualization
     * [feature] Support for switching between environment profiles

--- a/sematic/types/types/tests/BUILD
+++ b/sematic/types/types/tests/BUILD
@@ -92,3 +92,13 @@ pytest_test(
         "//sematic/types:serialization",
     ],
 )
+
+pytest_test(
+    name = "test_union",
+    srcs = ["test_union.py"],
+    deps = [
+        "//sematic/types:casting",
+        "//sematic/types:init",
+        "//sematic/types:serialization",
+    ],
+)

--- a/sematic/types/types/tests/test_dict.py
+++ b/sematic/types/types/tests/test_dict.py
@@ -56,6 +56,7 @@ SERIALIZATION_EXAMPLES = [
     (dict(a=1.0), Dict[str, float], None),
     (dict(a="b"), Dict[str, str], None),
     ({1: "a", 2: "b"}, Dict[int, str], None),
+    ({1: "a", 2: "b"}, Union[Dict[int, str], None], None),
     (
         {1: "a", 2: StringSubclass("b")},
         Dict[int, str],

--- a/sematic/types/types/tests/test_union.py
+++ b/sematic/types/types/tests/test_union.py
@@ -1,0 +1,29 @@
+# Standard Library
+from typing import Dict, Union
+
+# Third-party
+import pytest
+
+# Sematic
+from sematic.types.serialization import (
+    value_from_json_encodable,
+    value_to_json_encodable,
+)
+
+SERIALIZATION_EXAMPLES = [
+    (1, Union[int, None]),
+    (None, Union[int, None]),
+    (1, Union[int, float]),
+    ("1", Union[int, str]),
+    ("1", Union[str, int]),
+    (1, Union[int, str]),
+    (1, Union[str, int]),
+    ({1: "a", 2: "b"}, Union[Dict[int, str], None]),
+]
+
+
+@pytest.mark.parametrize("value, type_", SERIALIZATION_EXAMPLES)
+def test_value_serdes(value, type_):
+    serialized = value_to_json_encodable(value, type_)
+    deserialized = value_from_json_encodable(serialized, type_)
+    assert deserialized == value


### PR DESCRIPTION
Prior to this PR, `Union` had logic for serializing to json, but not for deserializing from it. How could this have ever worked, you ask? Because the serialization logic for `Union` just forwarded straight to the serialization logic for the underlying type, and then on deserialization the fallback generally fell back to something that "just worked" (either pickle or assuming the object was already json encodable). However, in some cases, this would fail. So I now added an actual deserialize-from-json function for `Union`. It stores information about which of the Unioned types the deserialization should ultimately use. Note that this does NOT change the json summary logic, so the UI is not impacted by this change.