### PR TITLE
Add support to subclasses of `ABCMeta`

### DIFF
--- a/sematic/types/registry.py
+++ b/sematic/types/registry.py
@@ -445,7 +445,7 @@ def _is_abc(type_: Any) -> bool:
         subclasses_abc = issubclass(type_, abc.ABC)
     except TypeError:
         subclasses_abc = False
-    return subclasses_abc or type(type_) is abc.ABCMeta
+    return subclasses_abc or issubclass(type(type_), abc.ABCMeta)
 
 
 class DataclassKey:


### PR DESCRIPTION
For instance pydantic uses a custom metaclass intead of `ABCMeta` (see https://github.com/pydantic/pydantic/blob/1ac1199f08c42803dc7c5e6fae754afd53e3f1b4/pydantic/main.py#LL118C7-L118C16). This will add support for these cases.