### PR TITLE
Chance/refactor view redirection

### DIFF
--- a/sematic/ui/src/Payloads.tsx
+++ b/sematic/ui/src/Payloads.tsx
@@ -77,13 +77,14 @@ export type EnvPayload = {
 };
 
 type Operator = "eq";
-type BooleanOperator = "AND" | "OR";
 
 type FilterCondition = {
-    [key: string]: {[op in Operator]: string}
+    [key: string]: {[eq in Operator]? : string | null} | undefined
 }
 
 export type Filter = FilterCondition | {
-    [op in BooleanOperator ] : Array<FilterCondition>
+    AND : Array<FilterCondition>
+} | {
+  OR : Array<FilterCondition>
 }
 

--- a/sematic/ui/src/Payloads.tsx
+++ b/sematic/ui/src/Payloads.tsx
@@ -75,3 +75,15 @@ export type AuthenticatePayload = {
 export type EnvPayload = {
   env: { [k: string]: string };
 };
+
+type Operator = "eq";
+type BooleanOperator = "AND" | "OR";
+
+type FilterCondition = {
+    [key: string]: {[op in Operator]: string}
+}
+
+export type Filter = FilterCondition | {
+    [op in BooleanOperator ] : Array<FilterCondition>
+}
+

--- a/sematic/ui/src/components/PipelineBar.tsx
+++ b/sematic/ui/src/components/PipelineBar.tsx
@@ -130,9 +130,8 @@ export default function PipelineBar(props: {
   onRootIdChange: (rootId: string) => void;
   rootRun?: Run;
   resolution?: Resolution;
-  setRootRun: boolean;
 }) {
-  const { calculatorPath, onRootIdChange, setRootRun, rootRun, resolution } =
+  const { calculatorPath, onRootIdChange, rootRun, resolution } =
     props;
   const [error, setError] = useState<Error | undefined>(undefined);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -167,11 +166,8 @@ export default function PipelineBar(props: {
   useEffect(() => {
     fetchLatestRuns(calculatorPath, (runs: Run[]) => {
       setLatestRuns(runs);
-      if (runs.length > 0 && setRootRun) {
-        onRootIdChange(runs[0].id);
-      }
     });
-  }, [setRootRun, calculatorPath]);
+  }, [calculatorPath]);
 
   useEffect(() => {
     pipelineSocket.removeAllListeners("update");

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -27,7 +27,7 @@ export function useFetchLatestRuns(runFilters: Filter | undefined = undefined) {
     return {isLoaded, error, latestRuns};
 }
 
-export function usePipelineNavigation(calculatorPath: string) {
+export function usePipelineNavigation(pipelinePath: string) {
     const navigate = useNavigate();
     const { rootId } = useParams();
 

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -1,26 +1,43 @@
-import { useContext, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { UserContext } from "../index";
 import { Run } from "../Models";
 import { Filter, RunListPayload } from "../Payloads";
 import { fetchJSON } from "../utils";
 
-export function useFetchLatestRuns(runFilters: Filter | undefined = undefined, qParams: {
-    [queryKey: string]: string
-} = {}) {
-
+export function useFetchLatestRuns(runFilters: Filter | undefined = undefined) {
     const { user } = useContext(UserContext);
     
     const [latestRuns, setLatestRuns] = useState<Run[]>([]);
     const [error, setError] = useState<Error | null>(null);
     const [isLoaded, setIsLoaded] = useState(false);
 
-    fetchJSON({
-        url: "/api/v1/runs?limit=10&filters=" + JSON.stringify(runFilters),
-        apiKey: user?.api_key,
-        callback: (response: RunListPayload) => {
-            setLatestRuns(response.content);
-        },
-        setError: (error => setError(error as (Error | undefined))),
-        setIsLoaded,
-      });
+    useEffect(() => {
+        fetchJSON({
+            url: "/api/v1/runs?limit=10&filters=" + JSON.stringify(runFilters),
+            apiKey: user?.api_key,
+            callback: (response: RunListPayload) => {
+                setLatestRuns(response.content);
+            },
+            setError: (error => setError(error as React.SetStateAction<Error | null>)),
+            setIsLoaded,
+          });
+    }, [setLatestRuns, setError, setIsLoaded, user, runFilters])
+
+    return {isLoaded, error, latestRuns};
+}
+
+export function usePipelineNavigation(calculatorPath: string) {
+    const navigate = useNavigate();
+    const { rootId } = useParams();
+
+    return useCallback((requestedRootId: string, replace: boolean) => {
+        if ( rootId === requestedRootId ) {
+            return
+        }
+
+        navigate(`/pipelines/${calculatorPath}/${requestedRootId}`, {
+            replace
+        });
+    }, [calculatorPath, rootId, navigate]);
 }

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -1,0 +1,26 @@
+import { useContext, useState } from "react";
+import { UserContext } from "../index";
+import { Run } from "../Models";
+import { Filter, RunListPayload } from "../Payloads";
+import { fetchJSON } from "../utils";
+
+export function useFetchLatestRuns(runFilters: Filter | undefined = undefined, qParams: {
+    [queryKey: string]: string
+} = {}) {
+
+    const { user } = useContext(UserContext);
+    
+    const [latestRuns, setLatestRuns] = useState<Run[]>([]);
+    const [error, setError] = useState<Error | null>(null);
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    fetchJSON({
+        url: "/api/v1/runs?limit=10&filters=" + JSON.stringify(runFilters),
+        apiKey: user?.api_key,
+        callback: (response: RunListPayload) => {
+            setLatestRuns(response.content);
+        },
+        setError: (error => setError(error as (Error | undefined))),
+        setIsLoaded,
+      });
+}

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -26,7 +26,7 @@ import { Alert, Paper } from "@mui/material";
 import logo from "./Fox.png";
 import { fetchJSON } from "./utils";
 import { SnackBarProvider } from "./components/SnackBarProvider";
-import PipelineCalculatorView from "./pipelines/PipelineCalculatorView";
+import PipelineView from "./pipelines/PipelineView";
 
 export const UserContext = React.createContext<{
   user: User | null;
@@ -120,7 +120,7 @@ function App() {
               />
               <Route
                 path="pipelines/:calculatorPath"
-                element={<PipelineCalculatorView />}
+                element={<PipelineView />}
               />
             </Route>
           </Routes>

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -6,7 +6,7 @@ import "@fontsource/roboto/700.css";
 import "./index.css";
 import { Route, BrowserRouter, Routes, useNavigate } from "react-router-dom";
 import PipelineIndex from "./pipelines/PipelineIndex";
-import PipelineView from "./pipelines/PipelineView";
+import PipelineRunView from "./pipelines/PipelineRunView";
 import Shell from "./components/Shell";
 import Loading from "./components/Loading";
 import Home from "./Home";
@@ -26,6 +26,7 @@ import { Alert, Paper } from "@mui/material";
 import logo from "./Fox.png";
 import { fetchJSON } from "./utils";
 import { SnackBarProvider } from "./components/SnackBarProvider";
+import PipelineCalculatorView from "./pipelines/PipelineCalculatorView";
 
 export const UserContext = React.createContext<{
   user: User | null;
@@ -115,11 +116,11 @@ function App() {
               <Route path="pipelines" element={<PipelineIndex />} />
               <Route
                 path="pipelines/:calculatorPath/:rootId"
-                element={<PipelineView />}
+                element={<PipelineRunView />}
               />
               <Route
                 path="pipelines/:calculatorPath"
-                element={<PipelineView />}
+                element={<PipelineCalculatorView />}
               />
             </Route>
           </Routes>

--- a/sematic/ui/src/pipelines/PipelineCalculatorView.tsx
+++ b/sematic/ui/src/pipelines/PipelineCalculatorView.tsx
@@ -1,8 +1,44 @@
+import { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
+import Loading from "../components/Loading";
+import { useFetchLatestRuns, usePipelineNavigation } from "../hooks/pipelineHooks";
+import { Alert } from "@mui/material";
 
+/**
+ * This page doesn't do detailed rendering, its main focus is to 
+ * load the latest runs, pick the first run, then redirect to that
+ * run's detail view.
+ * 
+ * @returns JSX.element
+ */
 export default function PipelineCalculatorView() {
     const params = useParams();
     const { calculatorPath } = params;
 
-    return <></>;
+    const runFilters = useMemo(() => ({
+        "AND": [
+          { parent_id: { eq: null } },
+          { calculator_path: { eq: calculatorPath! } },
+        ]
+      }), [calculatorPath]);
+
+    const {isLoaded, error, latestRuns} = useFetchLatestRuns(runFilters);
+
+    const navigate = usePipelineNavigation(calculatorPath!);
+
+    useEffect(() => {
+        if (!isLoaded || !!error) {
+            return;
+        }
+
+        if (latestRuns.length > 0) {
+            navigate(latestRuns[0].root_id, true);
+        }
+
+    }, [isLoaded, error, latestRuns, navigate])
+
+    return <>
+        { !isLoaded && <Loading isLoaded={false} /> }
+        { !!error && <Alert severity="error">{error.message}</Alert> }
+    </>;
 }

--- a/sematic/ui/src/pipelines/PipelineCalculatorView.tsx
+++ b/sematic/ui/src/pipelines/PipelineCalculatorView.tsx
@@ -1,0 +1,8 @@
+import { useParams } from "react-router-dom";
+
+export default function PipelineCalculatorView() {
+    const params = useParams();
+    const { calculatorPath } = params;
+
+    return <></>;
+}

--- a/sematic/ui/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunView.tsx
@@ -28,7 +28,7 @@ export default function PipelineRunView() {
         callback: (payload: RunViewPayload) => setRootRun(payload.content),
       });
     },
-    [setRootRun]
+    [setRootRun, user?.api_key]
   );
 
   const fetchResolution = useCallback(
@@ -40,18 +40,17 @@ export default function PipelineRunView() {
           setResolution(payload.content),
       });
     },
-    [setResolution]
+    [setResolution, user?.api_key]
   );
 
   useEffect(() => {
-    if (!rootId) return;
-    fetchRootRun(rootId);
-    fetchResolution(rootId);
-  }, [rootId]);
+    fetchRootRun(rootId!);
+    fetchResolution(rootId!);
+  }, [rootId, fetchRootRun, fetchResolution]);
 
   const changeRootRunId = useCallback(
     (rootId: string) => {
-      if (rootRun && rootRun.id == rootId) return;
+      if (rootRun && rootRun.id === rootId) return;
       var runURL =
         window.location.protocol +
         "//" +
@@ -64,7 +63,7 @@ export default function PipelineRunView() {
       fetchRootRun(rootId);
       fetchResolution(rootId);
     },
-    [calculatorPath, rootRun]
+    [calculatorPath, rootRun, fetchRootRun, fetchResolution]
   );
 
   if (calculatorPath) {
@@ -82,7 +81,6 @@ export default function PipelineRunView() {
           onRootIdChange={changeRootRunId}
           rootRun={rootRun}
           resolution={resolution}
-          setRootRun={rootId === undefined}
         />
         {rootRun && resolution && (
           <PipelinePanels

--- a/sematic/ui/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunView.tsx
@@ -8,7 +8,7 @@ import { Resolution, Run } from "../Models";
 import { ResolutionPayload, RunViewPayload } from "../Payloads";
 import { fetchJSON } from "../utils";
 
-export default function PipelineView() {
+export default function PipelineRunView() {
   const [rootRun, setRootRun] = useState<Run | undefined>(undefined);
   const [resolution, setResolution] = useState<Resolution | undefined>(
     undefined

--- a/sematic/ui/src/pipelines/PipelineView.tsx
+++ b/sematic/ui/src/pipelines/PipelineView.tsx
@@ -11,7 +11,7 @@ import { Alert } from "@mui/material";
  * 
  * @returns JSX.element
  */
-export default function PipelineCalculatorView() {
+export default function PipelineView() {
     const params = useParams();
     const { calculatorPath } = params;
 


### PR DESCRIPTION
Now we have a dedicated page to handle `pipelines/:calculatorPath` routes. Therefore the process of delegating a sub-component to find the correct run and redirect URL could be lifted to a higher level. This saves some unnecessary communication across component layers. 

This is also more consistent with the idea of deep linking, in that we grant different URL patterns different semantics. `pipelines/:calculatorPath` then has its own purpose and which does not overlap with the semantic of `pipelines/:calculatorPath/:rootId`.