### PR TITLE
Bump versions for 0.20.1 and introduce a Special Release Procedure

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -65,8 +65,11 @@ SEMATIC_API_KEY: <my_prod1_api_key>
 ```
 
 ## Releasing
+
 **Note:** Actually pushing the released wheel can only be done if you have
 access to the PyPi repo, which is limited to employees of Sematic.
+
+We cut releases from the `main` branch, following these steps:
 
 - Bump the version in `wheel_version.bzl`, `sematic/versions.py`,
   `helm/sematic-server/values.yaml`, and `helm/sematic-server/Chart.yaml`
@@ -119,3 +122,15 @@ $ TAG=v$(python3 sematic/versions.py) make release-server
 Finally, draft the release on GitHub. Add a "What's Changed" section, a
 "New Contributors" section, a "Full Changelog" link, and attach the wheel in
 the assets section.
+
+### Special Releases
+
+Sometimes we want to cut releases that contain only a subset of changes that
+have been included in the `main` branch since the previous release. In these
+cases, instead of performing the release from the `main` branch, we:
+- create a separate release branch starting from the previous release tag and
+  switch to that branch
+- cherry-pick the commits we want to include
+- follow all the other steps from the [Releasing](#releasing) section
+- switch to the `main` branch, make a commit that contains the previous version
+  increases and reconciles the changelog, and merge a PR with this commit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@ with nothing else on the line.
     * [bugfix] Fix a bug deserializing `Union` values. Note that once you are using this release,
       if you try to "rerun from here" using a pipeline that has `Union` values in it that were
       produced prior to this version of Sematic, the rerun will likely fail with a serialization issue.
+* [0.20.1](https://pypi.org/project/sematic/0.20.1/)
+    * [bugfix] Add support for subclasses of ABCMeta
 * [0.20.0](https://pypi.org/project/sematic/0.20.0/)
     * [feature] Add datetime class and basic visualization
     * [feature] Support for switching between environment profiles

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.20.0
+appVersion: v0.20.1

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 image:
   repository: sematicai/sematic-server
   pullPolicy: IfNotPresent
-  tag: v0.20.0
+  tag: v0.20.1
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 # the sdk. Should be bumped any time a release is made. Should be set
 # to whatever is the version after the most recent one in changelog.md,
 # as well as the version for the sematic wheel in wheel_version.bzl
-CURRENT_VERSION = (0, 20, 0)
+CURRENT_VERSION = (0, 20, 1)
 
 # Represents the smallest client version that works with the server
 # at the CURRENT_VERSION. Should be updated any time a breaking change

--- a/sematic/wheel_version.bzl
+++ b/sematic/wheel_version.bzl
@@ -2,4 +2,4 @@
 # changelog.md.
 # This is the version that will be attached to the
 # wheel that bazel builds for sematic.
-wheel_version_string = "0.20.0"
+wheel_version_string = "0.20.1"


### PR DESCRIPTION
Includes the bumped versions and changelog from [the special 0.20.1 release](https://github.com/sematic-ai/sematic/releases/tag/v0.20.1), and creates a Special Release Procedure to describe this very process.