### PR TITLE
Fixed a issue caused by variable renaming.

### DIFF
--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -36,8 +36,8 @@ export function usePipelineNavigation(pipelinePath: string) {
             return
         }
 
-        navigate(`/pipelines/${calculatorPath}/${requestedRootId}`, {
+        navigate(`/pipelines/${pipelinePath}/${requestedRootId}`, {
             replace
         });
-    }, [calculatorPath, rootId, navigate]);
+    }, [pipelinePath, rootId, navigate]);
 }


### PR DESCRIPTION
There was an issue that occurred during some prior code review process:

`calculatorPath` was suggested to rename to `pipelinePath`. But the function body wasn't modified by the refactoring tool. 

Unfortunately, this wasn't caught by CI either.