### PR TITLE
Refactor the hook usage on pipeline related scenarios

### DIFF
--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -91,7 +91,7 @@ export default function Home() {
       <Typography variant="h1">{h1}</Typography>
       <Box sx={{ mt: 15, mb: 10, minHeight: "1px" }}>
         {!!error && <Alert severity="error">
-          There is an error loading the latest runs {error.message}</Alert>}
+          Encountered an error loading the latest runs: {error.message}</Alert>}
         {prompt ? (
           prompt
         ) : user && isLoaded ? (

--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -1,5 +1,6 @@
 import { ContentCopy } from "@mui/icons-material";
 import {
+  Alert,
   Box,
   ButtonBase,
   Container,
@@ -10,17 +11,15 @@ import {
   useTheme,
 } from "@mui/material";
 import {
-  ReactElement,
   useCallback,
   useContext,
-  useEffect,
+  useMemo,
   useState,
 } from "react";
 import { SiDiscord, SiReadthedocs, SiGithub } from "react-icons/si";
 import { UserContext } from ".";
 import RunStateChip from "./components/RunStateChip";
-import { RunListPayload } from "./Payloads";
-import { fetchJSON } from "./utils";
+import { useFetchRuns } from "./hooks/pipelineHooks";
 
 function ShellCommand(props: { command: string }) {
   const { command } = props;
@@ -57,35 +56,32 @@ function ShellCommand(props: { command: string }) {
 }
 
 export default function Home() {
-  const [prompt, setPrompt] = useState<ReactElement | undefined>(undefined);
-
   const { user } = useContext(UserContext);
 
-  useEffect(() => {
-    let filters = JSON.stringify({
-      parent_id: { eq: null },
-    });
+  const runFilters = useMemo(() => ({
+    parent_id: { eq: null },
+  }), []);
 
-    fetchJSON({
-      url: "/api/v1/runs?limit=1&filters=" + filters,
-      apiKey: user?.api_key,
-      callback: (payload: RunListPayload) => {
-        if (payload.content.length > 0) {
-          const run = payload.content[0];
-          setPrompt(
-            <Typography
-              fontSize="medium"
-              component="span"
-              sx={{ display: "flex", alignItems: "center" }}
-            >
-              Your latest run:&nbsp; <RunStateChip state={run.future_state} />
-              <Link href={"/pipelines/" + run.calculator_path}>{run.name}</Link>
-            </Typography>
-          );
-        }
-      },
-    });
-  }, []);
+  const otherQueryParams = useMemo(() => ({
+      limit: '1'
+  }), [])
+
+  const {isLoaded, error, runs} = useFetchRuns(runFilters, otherQueryParams);
+
+  const prompt = useMemo(() => {
+    if (!isLoaded || runs.length === 0) {
+      return null;
+    }
+    const run = runs[0];
+    return <Typography
+      fontSize="medium"
+      component="span"
+      sx={{ display: "flex", alignItems: "center" }}
+    >
+      Your latest run:&nbsp; <RunStateChip state={run.future_state} />
+      <Link href={"/pipelines/" + run.calculator_path}>{run.name}</Link>
+    </Typography>;
+  }, [isLoaded, runs]);
 
   const h1 = user ? "Hi " + user.first_name : "Welcome to Sematic";
 
@@ -94,9 +90,11 @@ export default function Home() {
       {/*sx={{ pt: 20, mx: 5, height: "100vh", overflowY: "scroll" }}>*/}
       <Typography variant="h1">{h1}</Typography>
       <Box sx={{ mt: 15, mb: 10, minHeight: "1px" }}>
+        {!!error && <Alert severity="error">
+          There is an error loading the latest runs {error.message}</Alert>}
         {prompt ? (
           prompt
-        ) : user ? (
+        ) : user && isLoaded ? (
           <Box sx={{ width: 600 }}>
             <Typography variant="h4" sx={{ mb: 4 }}>
               To get started, set your API key:

--- a/sematic/ui/src/components/PipelineBar.tsx
+++ b/sematic/ui/src/components/PipelineBar.tsx
@@ -10,19 +10,18 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo } from "react";
 import { UserContext } from "..";
 import { Resolution, Run } from "../Models";
-import { RunListPayload } from "../Payloads";
 import { fetchJSON, pipelineSocket } from "../utils";
 import CalculatorPath from "./CalculatorPath";
 import GitInfoBox from "./GitInfo";
 import Loading from "./Loading";
-import { RunFilterType } from "./RunList";
 import RunStateChip from "./RunStateChip";
 import TimeAgo from "./TimeAgo";
 import { ActionMenu, ActionMenuItem } from "./ActionMenu";
 import { SnackBarContext } from "./SnackBarProvider";
+import { useFetchRuns } from "../hooks/pipelineHooks";
 
 function PipelineActionMenu(props: {
   rootRun: Run;
@@ -133,61 +132,40 @@ export default function PipelineBar(props: {
 }) {
   const { calculatorPath, onRootIdChange, rootRun, resolution } =
     props;
-  const [error, setError] = useState<Error | undefined>(undefined);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [latestRuns, setLatestRuns] = useState<Run[]>([]);
-  const { user } = useContext(UserContext);
   const { setSnackMessage } = useContext(SnackBarContext);
 
   const theme = useTheme();
 
-  const fetchLatestRuns = useCallback(
-    (calcPath: string, onResults: (runs: Run[]) => void) => {
-      const runFilters: RunFilterType = {
-        AND: [
-          { parent_id: { eq: null } },
-          { calculator_path: { eq: calcPath } },
-        ],
-      };
+  const runFilters = useMemo(() => ({
+    AND: [
+      { parent_id: { eq: null } },
+      { calculator_path: { eq: calculatorPath } },
+    ],
+  }), [calculatorPath]);
 
-      fetchJSON({
-        url: "/api/v1/runs?limit=10&filters=" + JSON.stringify(runFilters),
-        apiKey: user?.api_key,
-        callback: (response: RunListPayload) => {
-          onResults(response.content);
-        },
-        setError: setError,
-        setIsLoaded: setIsLoaded,
-      });
-    },
-    []
-  );
+  const otherQueryParams = useMemo(() => ({
+      limit: '10'
+  }), []);
 
-  useEffect(() => {
-    fetchLatestRuns(calculatorPath, (runs: Run[]) => {
-      setLatestRuns(runs);
-    });
-  }, [calculatorPath]);
+  const {isLoaded, error, runs: latestRuns, reloadRuns } = useFetchRuns(runFilters, otherQueryParams);
 
   useEffect(() => {
     pipelineSocket.removeAllListeners("update");
-    pipelineSocket.on("update", (args: { calculator_path: string }) => {
+    pipelineSocket.on("update", async (args: { calculator_path: string }) => {
       if (args.calculator_path === calculatorPath) {
-        fetchLatestRuns(calculatorPath, (runs) => {
-          if (runs[0].id !== latestRuns[0].id) {
-            setSnackMessage({
-              message: "New run available.",
-              actionName: "view",
-              autoHide: false,
-              closable: true,
-              onClick: () => onRootIdChange(runs[0].id),
-            });
-          }
-          setLatestRuns(runs);
-        });
+        const runs = await reloadRuns();
+        if (runs[0].id !== latestRuns[0].id) {
+          setSnackMessage({
+            message: "New run available.",
+            actionName: "view",
+            autoHide: false,
+            closable: true,
+            onClick: () => onRootIdChange(runs[0].id),
+          });
+        }
       }
     });
-  }, [latestRuns, calculatorPath, fetchLatestRuns]);
+  }, [latestRuns, calculatorPath, onRootIdChange, reloadRuns, setSnackMessage]);
 
   const onSelect = useCallback(
     (event: SelectChangeEvent) => {
@@ -196,11 +174,7 @@ export default function PipelineBar(props: {
     [onRootIdChange]
   );
 
-  const onCancel = useCallback(() => {
-    fetchLatestRuns(calculatorPath, (runs) => {
-      setLatestRuns(runs);
-    });
-  }, [setLatestRuns, fetchLatestRuns]);
+  const onCancel = reloadRuns;
 
   if (error || !isLoaded) {
     return (

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -1,0 +1,47 @@
+import { useCallback, useContext } from "react";
+import { UserContext } from "../index";
+
+interface HttpClient {
+    fetch: (params: { url: string, method: string, body: any }) => Promise<any>;
+}
+
+export function useHttpClient(): HttpClient {
+    const { user } = useContext(UserContext);
+
+    if (!user) {
+        throw Error('There is no provider who provide value for `UserContext`. '
+            + 'Please ensure a higher level `UserContext` provider exists in the '
+            + 'Component hierarchy.');
+    }
+
+    const headers: HeadersInit = new Headers();
+    headers.set("Content-Type", "application/json");
+
+    if (user?.api_key) {
+        headers.set("X-API-KEY", user?.api_key);
+    }
+
+    return {
+        fetch: useCallback(async ({
+            url,
+            method,
+            body
+        }: { url: string, method: string, body: any }) => {
+            method = method || "GET";
+
+            const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
+
+            if (process.env.NODE_ENV === "development") {
+                console.log("fetchJSON", method, url, reqBody);
+            }
+
+            const response = await fetch(url, { method: method, headers: headers, body: reqBody });
+
+            if (!response.ok) {
+                throw Error(response.statusText);
+            }
+
+            return response.json();
+        }, [])
+    };
+}

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -1,32 +1,30 @@
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { UserContext } from "../index";
 
 interface HttpClient {
-    fetch: (params: { url: string, method: string, body: any }) => Promise<any>;
+    fetch: (params: { url: string, method?: string, body?: any }) => Promise<any>;
 }
 
 export function useHttpClient(): HttpClient {
     const { user } = useContext(UserContext);
 
-    if (!user) {
-        throw Error('There is no provider who provide value for `UserContext`. '
-            + 'Please ensure a higher level `UserContext` provider exists in the '
-            + 'Component hierarchy.');
-    }
+    const headers = useMemo(() => {
+        const headers: HeadersInit = new Headers();
+        headers.set("Content-Type", "application/json");
 
-    const headers: HeadersInit = new Headers();
-    headers.set("Content-Type", "application/json");
+        if (user?.api_key) {
+            headers.set("X-API-KEY", user?.api_key);
+        }
 
-    if (user?.api_key) {
-        headers.set("X-API-KEY", user?.api_key);
-    }
+        return headers;
+    }, [user?.api_key]);
 
     return {
         fetch: useCallback(async ({
             url,
             method,
             body
-        }: { url: string, method: string, body: any }) => {
+        }: { url: string, method?: string, body?: any }) => {
             method = method || "GET";
 
             const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
@@ -42,6 +40,6 @@ export function useHttpClient(): HttpClient {
             }
 
             return response.json();
-        }, [])
+        }, [headers])
     };
 }

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -30,7 +30,7 @@ export function useHttpClient(): HttpClient {
             const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
 
             if (process.env.NODE_ENV === "development") {
-                console.log("fetchJSON", method, url, reqBody);
+                console.log("HttpClient.fetch", method, url, reqBody);
             }
 
             const response = await fetch(url, { method: method, headers: headers, body: reqBody });

--- a/sematic/ui/src/pipelines/PipelineView.tsx
+++ b/sematic/ui/src/pipelines/PipelineView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import Loading from "../components/Loading";
-import { useFetchLatestRuns, usePipelineNavigation } from "../hooks/pipelineHooks";
+import { useFetchRuns, usePipelineNavigation } from "../hooks/pipelineHooks";
 import { Alert } from "@mui/material";
 
 /**
@@ -22,7 +22,11 @@ export default function PipelineView() {
         ]
       }), [calculatorPath]);
 
-    const {isLoaded, error, latestRuns} = useFetchLatestRuns(runFilters);
+    const otherQueryParams = useMemo(() => ({
+        limit: '10'
+    }), []);
+
+    const {isLoaded, error, runs: latestRuns} = useFetchRuns(runFilters, otherQueryParams);
 
     const navigate = usePipelineNavigation(calculatorPath!);
 


### PR DESCRIPTION
Key points of this PR

- The scope of the refactor lies only at certain critical pipeline-related scenarios. It should be sufficient to demonstrate how hooks can be used to satisfy different use cases.
- Refactors the callback-style procedures (`fetch_json`) to async/await style.
- Delegate state management to hooks, instead of manually initiating state change in the business logic layer.
- Leverage [`useAsyncFn`](https://github.com/streamich/react-use/blob/master/docs/useAsyncFn.md) in [`react-use`](https://github.com/streamich/react-use)
- Introduces a httpClient middleware (`useHttpClient`), which could be further refactored to add caching mechanism or to hook up with a 3rd party library. For now, it is only an abstraction and needs to be extracted first.
- The ultimate goal is to get rid of `fetch_json` and use hook-based, async/await-style procedures instead.