### PR TITLE
Simplify logs processing logic #354

### DIFF
--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -1,5 +1,5 @@
-import { Alert, Box } from "@mui/material";
-import { useState } from "react";
+import { Alert, Box, TextField } from "@mui/material";
+import { useCallback, useState } from "react";
 import { Run } from "../Models";
 import { Exception, ExternalException } from "./Exception";
 import ScrollingLogView from "./ScrollingLogView";
@@ -7,9 +7,18 @@ import ScrollingLogView from "./ScrollingLogView";
 export default function LogPanel(props: { run: Run }) {
   const { run } = props;
   const [error, setError] = useState<Error | undefined>(undefined);
+  const [filterString, setFilterString] = useState<string>("");
+
+  const onFilterStringChange = useCallback(
+    (evt: any) => {
+      setFilterString(evt.target.value);
+    },
+    [setFilterString]
+  );
 
   const standardLogView = (
-    <ScrollingLogView key={run.id} logSource={run.id} onError={setError} />
+    <ScrollingLogView key={`${run.id}---${filterString}`} logSource={run.id} onError={setError} 
+      filterString={filterString} />
   );
   const logErrorView = (
     <Alert severity="error">
@@ -29,6 +38,12 @@ export default function LogPanel(props: { run: Run }) {
             <Exception exception_metadata={run.exception_metadata_json} />}
       </Box>
       <Box sx={{ gridRow: 3, paddingBottom: 4, }} >
+        <TextField
+          variant="standard"
+          fullWidth={true}
+          placeholder={"Filter..."}
+          onChange={onFilterStringChange}
+        />
         {logView}
       </Box>
     </Box>

--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -1,51 +1,15 @@
 import { Alert, Box } from "@mui/material";
-import { useCallback, useContext, useState } from "react";
-import { UserContext } from "..";
+import { useState } from "react";
 import { Run } from "../Models";
-import { LogLineRequestResponse } from "../Payloads";
-import { fetchJSON } from "../utils";
 import { Exception, ExternalException } from "./Exception";
-import ScrollingLogView, { MoreLinesCallback } from "./ScrollingLogView";
+import ScrollingLogView from "./ScrollingLogView";
 
 export default function LogPanel(props: { run: Run }) {
   const { run } = props;
-  const { user } = useContext(UserContext);
   const [error, setError] = useState<Error | undefined>(undefined);
 
-  const loadLogs = useCallback(
-    (
-      source: string,
-      cursor: string | null,
-      filterString: string,
-      callback: MoreLinesCallback
-    ) => {
-      var url = "/api/v1/runs/" + source + "/logs?max_lines=2000";
-      if (cursor != null) {
-        url += "&continuation_cursor=" + cursor;
-      }
-      if (filterString.length !== 0) {
-        url += "&filter_string=" + filterString;
-      }
-      fetchJSON({
-        url: url,
-        apiKey: user?.api_key,
-        callback: (payload: LogLineRequestResponse) => {
-          callback(
-            source,
-            filterString,
-            payload.content.lines,
-            payload.content.continuation_cursor,
-            payload.content.log_unavailable_reason
-          );
-        },
-        setError: setError,
-      });
-    },
-    [user?.api_key]
-  );
-
   const standardLogView = (
-    <ScrollingLogView getLines={loadLogs} logSource={run.id} />
+    <ScrollingLogView key={run.id} logSource={run.id} onError={setError} />
   );
   const logErrorView = (
     <Alert severity="error">

--- a/sematic/ui/src/components/ScrollingLogView.tsx
+++ b/sematic/ui/src/components/ScrollingLogView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { Alert, Box, Button, TextField, useTheme } from "@mui/material";
+import { useEffect, useCallback, useMemo } from "react";
+import { Alert, Box, Button, useTheme } from "@mui/material";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Loading from "./Loading";
 import { useAccumulateLogsUntilEnd, useLogStream } from "../hooks/logHooks";
@@ -8,12 +8,12 @@ const DEFAULT_NO_LINES_REASON = "No more matching lines";
 
 export default function ScrollingLogView(props: {
   logSource: string;
+  filterString: string;
   onError: (error: Error) => void
 }) {
-  const { logSource, onError } = props;
+  const { logSource, filterString, onError } = props;
   const theme = useTheme();
 
-  const [filterString, setFilterString] = useState<string>("");
   const scrollerId = useMemo(() => `scrolling-logs-${logSource}`, [logSource]) ;
 
   // Single pull logic
@@ -30,13 +30,6 @@ export default function ScrollingLogView(props: {
       onError(error);
     }
   }, [onError, error])
-
-  const onFilterStringChange = useCallback(
-    (evt: any) => {
-      setFilterString(evt.target.value);
-    },
-    [setFilterString]
-  );
 
   const onScroll = useCallback(
     (evt: any) => {
@@ -107,12 +100,7 @@ export default function ScrollingLogView(props: {
         top: 0,
       }}
     >
-      <TextField
-        variant="standard"
-        fullWidth={true}
-        placeholder={"Filter..."}
-        onChange={onFilterStringChange}
-      />
+      
       <Box
         id={scrollerId}
         sx={{
@@ -130,7 +118,7 @@ export default function ScrollingLogView(props: {
           next={infiniteScrollGetNext}
           scrollableTarget={scrollerId}
           hasMore={hasMore}
-          loader={<Loading isLoaded={false} />}
+          loader={<Loading isLoaded={!isLoading} />}
           onScroll={onScroll}
           endMessage={noMoreLinesIndicator}
         >

--- a/sematic/ui/src/components/ScrollingLogView.tsx
+++ b/sematic/ui/src/components/ScrollingLogView.tsx
@@ -2,180 +2,40 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import { Alert, Box, Button, TextField, useTheme } from "@mui/material";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Loading from "./Loading";
-
-// Callback to be used when more log lines are loaded.
-export type MoreLinesCallback = (
-  source: string,
-  usedFilter: string,
-  lines: string[],
-  cursor: string | null,
-  noLinesReason: string | null
-) => void;
-
-// Function to get more logs. It should call moreLinesCallback
-// once it has more log lines.
-export type GetLines = (
-  source: string,
-  cursor: string | null,
-  filterString: string,
-  moreLinesCallback: MoreLinesCallback
-) => void;
+import { useAccumulateLogsUntilEnd, useLogStream } from "../hooks/logHooks";
 
 const DEFAULT_NO_LINES_REASON = "No more matching lines";
 
 export default function ScrollingLogView(props: {
-  getLines: GetLines;
   logSource: string;
+  onError: (error: Error) => void
 }) {
-  const { getLines, logSource } = props;
+  const { logSource, onError } = props;
   const theme = useTheme();
-  const [hasMore, setHasMore] = useState(true);
-  const [fastForwarding, setFastForwarding] = useState(false);
-  const [currentNoLinesReason, setNoLinesReason] = useState<string | null>(
-    DEFAULT_NO_LINES_REASON
-  );
-  const [loadingMessage, setLoadingMessage] = useState<string>("Loading...");
-
-  const [lineState, setLineState] = useState<{
-    lines: string[]; // the log lines themselves
-    cursor: string | null; // the cursor to continue getting the lines after these ones
-    source: string; // the id of the source these log lines are for
-    filterString: string; // the filter string that was used to produce these lines
-
-    // initialize the state to no logs from an unknown source/filter.
-    // An on-render effect will do the first load from the actual source.
-  }>({ lines: [], cursor: null, source: "", filterString: "" });
 
   const [filterString, setFilterString] = useState<string>("");
+  const scrollerId = useMemo(() => `scrolling-logs-${logSource}`, [logSource]) ;
 
-  // display log lines once they have been loaded from the server.
-  const handleLogLines = useCallback(
-    (
-      source: string,
-      usedFilter: string,
-      lines: string[],
-      cursor: string | null,
-      noLinesReason: string | null
-    ) => {
-      const newSource =
-        source !== lineState.source || usedFilter !== lineState.filterString;
-      var newLines: string[] = newSource
-        ? lines
-        : lineState.lines.concat(lines);
-      setLineState({
-        ...lineState,
-        lines: newLines,
-        cursor: cursor,
-        source: source,
-        filterString: usedFilter,
-      });
-      setHasMore(cursor != null);
-      setNoLinesReason(
-        noLinesReason === "" || noLinesReason === null
-          ? DEFAULT_NO_LINES_REASON
-          : noLinesReason
-      );
-    },
-    [lineState]
-  );
-
-  // load the next log lines after the ones currently being displayed
-  const next = useCallback(() => {
-    if (fastForwarding) return;
-    const sameSource =
-      lineState.source === logSource && lineState.filterString === filterString;
-    getLines(
-      logSource,
-      sameSource ? lineState.cursor : null,
-      filterString,
-      handleLogLines
-    );
-  }, [
-    getLines,
-    lineState.cursor,
-    handleLogLines,
-    logSource,
-    filterString,
-    fastForwarding,
-  ]);
-
-  // on render: if the current lines didn't come from the source & filter that
-  // are currently set, load new logs with the current settings.
-  useEffect(() => {
-    if (
-      lineState.source !== logSource ||
-      lineState.filterString !== filterString
-    ) {
-      next();
+  // Single pull logic
+  const { lines, isLoading, error, hasMore, 
+    noMoreLinesReason, getNext, hasPulledData } = useLogStream(logSource, filterString);
+  
+  // Accumulator (logs draining) logic
+  const { accumulateLogsUntilEnd, isLoading: isAccumulatorLoading,
+    isAccumulating, accumulatedLines } = useAccumulateLogsUntilEnd(hasMore, getNext);
+  
+  // report to parent in case of errors.
+  useEffect(()=> {
+    if (!!error) {
+      onError(error);
     }
-  });
-
-  const noMoreLinesIndicator = (
-    <Alert severity="info" sx={{ mt: 3 }}>
-      {currentNoLinesReason}
-    </Alert>
-  );
-  const scrollerId = "scrolling-logs-" + lineState.source;
-
-  // repeatedly query the server until we have loaded as many log lines as
-  // it will give us.
-  const accumulateUntilEnd = useCallback(() => {
-    if (lineState.lines.length === 0) {
-      // run has no logs. No need to try to scroll to the end.
-      return;
-    }
-    setFastForwarding(true);
-    var accumulatedLines: string[] = [];
-    const accumulate = function (
-      source: string,
-      usedFilter: string,
-      lines: string[],
-      cursor: string | null,
-      noLinesReason: string | null
-    ) {
-      accumulatedLines.push(...lines);
-      if (
-        (cursor === null || lines.length === 0) &&
-        accumulatedLines.length > 0
-      ) {
-        setLoadingMessage("Rendering...");
-
-        setFastForwarding(false);
-        handleLogLines(
-          source,
-          usedFilter,
-          accumulatedLines,
-          cursor,
-          noLinesReason
-        );
-
-        // start the scroll-to-bottom asynchronously so the lines have time
-        // to actually render before it scrolls.
-        setTimeout(() => {
-          const scroller = document.getElementById(scrollerId);
-          scroller?.scrollTo(0, scroller.scrollHeight);
-        }, 0);
-      } else {
-        setLoadingMessage("Loaded " + accumulatedLines.length + " lines...");
-        getLines(source, cursor, usedFilter, accumulate);
-      }
-    };
-    accumulate(logSource, filterString, [], null, null);
-  }, [getLines, handleLogLines, logSource, scrollerId]);
-
-  // scroll to the bottom when fast forwarding/jumping to end is done
-  useMemo(() => {
-    if (!fastForwarding) {
-      const scroller = document.getElementById(scrollerId);
-      scroller?.scrollTo(0, scroller.scrollHeight);
-    }
-  }, [fastForwarding, scrollerId]);
+  }, [onError, error])
 
   const onFilterStringChange = useCallback(
     (evt: any) => {
       setFilterString(evt.target.value);
     },
-    [filterString, next]
+    [setFilterString]
   );
 
   const onScroll = useCallback(
@@ -189,12 +49,54 @@ export default function ScrollingLogView(props: {
       // the user gets too close to it which will provide a smoother experience.
       const distanceFromScrollBottom =
         evt.target.scrollHeight - evt.target.scrollTop;
-      if (lineState.cursor !== null && distanceFromScrollBottom < 100) {
-        next();
+      if (hasMore && distanceFromScrollBottom < 100) {
+        getNext();
       }
     },
-    [filterString, next]
+    [getNext, hasMore]
   );
+
+  const infiniteScrollGetNext = useCallback(() => {
+    // If the accumulator is under way, don't initiate a pull 
+    // from the <InfiniteScroll />
+    if (isAccumulating) {
+      return;
+    }
+    getNext();
+  }, [getNext, isAccumulating]);
+
+  const noMoreLinesIndicator = useMemo(() =>
+    <Alert severity="info" sx={{ mt: 3 }}>
+      {isLoading? "Loading..." : (noMoreLinesReason || DEFAULT_NO_LINES_REASON)}
+    </Alert>
+    , [noMoreLinesReason, isLoading]);
+
+  const accumulatorButtonMessage = useMemo(() => {
+    if (!isAccumulating && hasMore) {
+      return "Jump to the end";
+    }
+    if (isAccumulatorLoading) {
+      return `Loaded ${accumulatedLines} lines...`;
+    }
+    return "Rendering...";
+  }, [isAccumulating, isAccumulatorLoading, accumulatedLines, hasMore]);
+
+  // scroll to the bottom when fast forwarding/jumping to end 
+  // (aka accumulating) has gotten data
+  useEffect(() => {
+    if (!isAccumulatorLoading) {
+      const scroller = document.getElementById(scrollerId);
+      scroller?.scrollTo(0, scroller.scrollHeight);
+    }
+  }, [isAccumulatorLoading, scrollerId]);
+
+  useEffect(() => {
+    // not sure why <InfiniteScroll /> does not do an initial pull,
+    // this mitigates that issue.
+    if (!hasPulledData) { 
+      getNext();
+    }
+  }, [getNext, hasPulledData]);
 
   return (
     <Box
@@ -224,15 +126,15 @@ export default function ScrollingLogView(props: {
         }}
       >
         <InfiniteScroll
-          dataLength={lineState.lines.length}
-          next={next}
+          dataLength={lines.length}
+          next={infiniteScrollGetNext}
           scrollableTarget={scrollerId}
           hasMore={hasMore}
           loader={<Loading isLoaded={false} />}
           onScroll={onScroll}
           endMessage={noMoreLinesIndicator}
         >
-          {lineState.lines.map((line, index) => (
+          {lines.map((line, index) => (
             <Box
               sx={{
                 borderTop: 1,
@@ -251,13 +153,13 @@ export default function ScrollingLogView(props: {
           ))}
         </InfiniteScroll>
       </Box>
-      {hasMore && (
+      {(hasMore && 
         <Button
-          onClick={accumulateUntilEnd}
+          onClick={accumulateLogsUntilEnd}
           sx={{ width: "100%" }}
-          disabled={fastForwarding}
+          disabled={isAccumulating || isLoading}
         >
-          {fastForwarding ? loadingMessage : "Jump to the end"}
+          {accumulatorButtonMessage}
         </Button>
       )}
     </Box>

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useMemo } from "react";
 import { UserContext } from "../index";
+import { useLogger } from "../utils";
 
 interface HttpClient {
     fetch: (params: { url: string, method?: string, body?: any }) => Promise<any>;
@@ -19,6 +20,8 @@ export function useHttpClient(): HttpClient {
         return headers;
     }, [user?.api_key]);
 
+    const { devLogger } = useLogger();
+
     return {
         fetch: useCallback(async ({
             url,
@@ -29,9 +32,7 @@ export function useHttpClient(): HttpClient {
 
             const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
 
-            if (process.env.NODE_ENV === "development") {
-                console.log("HttpClient.fetch", method, url, reqBody);
-            }
+            devLogger("fetch() ", method, url, reqBody);
 
             const response = await fetch(url, { method: method, headers: headers, body: reqBody });
 
@@ -40,6 +41,6 @@ export function useHttpClient(): HttpClient {
             }
 
             return response.json();
-        }, [headers])
+        }, [headers, devLogger])
     };
 }

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -1,9 +1,10 @@
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { UserContext } from "../index";
 import { useLogger } from "../utils";
 
 interface HttpClient {
     fetch: (params: { url: string, method?: string, body?: any }) => Promise<any>;
+    cancel: () => void
 }
 
 export function useHttpClient(): HttpClient {
@@ -22,25 +23,58 @@ export function useHttpClient(): HttpClient {
 
     const { devLogger } = useLogger();
 
-    return {
-        fetch: useCallback(async ({
-            url,
-            method,
-            body
-        }: { url: string, method?: string, body?: any }) => {
-            method = method || "GET";
+    const abortControllerRef = useRef<AbortController | null>(null);
 
-            const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
+    const fetchCallback = useCallback(async ({
+        url,
+        method,
+        body
+    }: { url: string, method?: string, body?: any }) => {
+        method = method || "GET";
 
-            devLogger("fetch() ", method, url, reqBody);
+        const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
 
-            const response = await fetch(url, { method: method, headers: headers, body: reqBody });
+        devLogger("fetch() ", method, url, reqBody);
 
+        const abortController = new AbortController();
+        abortControllerRef.current = (abortController);
+
+        try{
+            const response = await fetch(url, { 
+                method: method, headers: headers, body: reqBody, signal: abortController.signal
+            });
+            abortControllerRef.current = null;
+    
             if (!response.ok) {
                 throw Error(response.statusText);
             }
 
             return response.json();
-        }, [headers, devLogger])
+        } catch (e: any) {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+                devLogger("fetch() was voluntarily cancelled.")
+            }
+            throw e;
+        }
+
+    }, [headers, devLogger]);
+
+    const cancel = useCallback(() => {
+        const abortController = abortControllerRef.current;
+        if (!!abortController && !abortController.signal.aborted) {
+            abortController.abort();
+        }
+    }, [abortControllerRef]);
+
+    useEffect(() => {
+        return ()=> {
+            // Automatically cancel the request when the calling component will unmount.
+            cancel();
+        }
+    }, [cancel]);
+
+    return {
+        fetch: fetchCallback,
+        cancel
     };
 }

--- a/sematic/ui/src/hooks/logHooks.ts
+++ b/sematic/ui/src/hooks/logHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useAsyncFn from "react-use/lib/useAsyncFn";
 import useList from "react-use/lib/useList";
 import useLatest from "react-use/lib/useLatest";
@@ -12,7 +12,7 @@ export interface GetNextResult {
 }
 
 export function useLogStream(source: string, filterString: string) {
-    const [lines, {clear: clearLines, push: pushLines}] = useList<string>([]);
+    const [lines, {push: pushLines}] = useList<string>([]);
     const [cursor, setCursor] = useState<string | null>(null);
     const [noMoreLinesReason, setNoMoreLinesReason] = useState<string | null>(null);
     const [hasPulledData, setHasPulledData] = useState(false);
@@ -20,13 +20,6 @@ export function useLogStream(source: string, filterString: string) {
     const hasMore = useMemo(() => {
         return !hasPulledData || cursor != null;
     }, [cursor, hasPulledData]);
-
-    useEffect(() => {
-        // if source or filterString changed, clear the state
-        clearLines();
-        setCursor(null);
-        setHasPulledData(false);
-    }, [source, filterString, clearLines, setHasPulledData]);
 
     const { fetch } = useHttpClient();
     const { devLogger } = useLogger();
@@ -81,13 +74,34 @@ export function useAccumulateLogsUntilEnd(hasMore: boolean, getNext: () => Promi
     const [accumulatedLines, setAccumulatedLines] = useState<number>(0);
     const [isLoading, setIsLoading] = useState(false);
 
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const { devLogger } = useLogger();
+
+    const cancelAccumulation = useCallback(() => {
+        if (!!abortControllerRef.current) {
+            abortControllerRef.current.abort();
+            devLogger('Logs accumulation aborted.')
+        }
+    }, [abortControllerRef, devLogger]);
+
     const accumulateLogsUntilEnd = useCallback(async () => {
         setIsAccumlating(true);
         let accumulatedLines = 0;
         setAccumulatedLines(accumulatedLines);
+
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
         while(latestHasMore.current === true) {
+            if (abortController.signal.aborted) {
+                break;
+            }
+
             setIsLoading(true);
             const {pulledLines} = await latestGetNext.current();
+
+            if (abortController.signal.aborted) {
+                break;
+            }
             setIsLoading(false);
             
             accumulatedLines += pulledLines;
@@ -100,6 +114,13 @@ export function useAccumulateLogsUntilEnd(hasMore: boolean, getNext: () => Promi
         }
         setIsAccumlating(false);
     }, [latestHasMore, latestGetNext]);
+
+    useEffect(() => {
+        // always cancel ongoing accumulation if the component will unmount
+        return () => {
+            cancelAccumulation();
+        }
+    }, [cancelAccumulation])
 
     return {
         accumulateLogsUntilEnd,

--- a/sematic/ui/src/hooks/logHooks.ts
+++ b/sematic/ui/src/hooks/logHooks.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import useAsyncFn from "react-use/lib/useAsyncFn";
+import useList from "react-use/lib/useList";
+import useLatest from "react-use/lib/useLatest";
+import { LogLineRequestResponse } from "../Payloads";
+import { useLogger } from "../utils";
+import { useHttpClient } from "./httpHooks";
+
+const MAX_LINES = 2000;
+export interface GetNextResult {
+    pulledLines: number
+}
+
+export function useLogStream(source: string, filterString: string) {
+    const [lines, {clear: clearLines, push: pushLines}] = useList<string>([]);
+    const [cursor, setCursor] = useState<string | null>(null);
+    const [noMoreLinesReason, setNoMoreLinesReason] = useState<string | null>(null);
+    const [hasPulledData, setHasPulledData] = useState(false);
+
+    const hasMore = useMemo(() => {
+        return !hasPulledData || cursor != null;
+    }, [cursor, hasPulledData]);
+
+    useEffect(() => {
+        // if source or filterString changed, clear the state
+        clearLines();
+        setCursor(null);
+        setHasPulledData(false);
+    }, [source, filterString, clearLines, setHasPulledData]);
+
+    const { fetch } = useHttpClient();
+    const { devLogger } = useLogger();
+
+    const [{ loading: isLoading, error }, getNext] = useAsyncFn(
+        async (): Promise<GetNextResult> => {
+            devLogger(`logHooks.ts getNext() started hasMore ${hasMore} `
+                + `cursor: ${cursor?.slice(0, 15) || null} filter_string: ${filterString}`);
+            let queryParams: any = {
+                max_lines: '' + MAX_LINES
+            };
+
+            if (!!cursor) {
+                queryParams['continuation_cursor'] = cursor;
+            }
+            if (!!filterString) {
+                queryParams['filter_string'] = filterString;
+            }
+
+            const qString = (new URLSearchParams(queryParams)).toString();
+            const url = `/api/v1/runs/${source}/logs?${qString}`;
+
+            const payload: LogLineRequestResponse = await fetch({ url });
+
+            const { content: { lines, continuation_cursor,
+                log_unavailable_reason } } = payload;
+
+            devLogger(`logHooks.ts getNext() ${url} completed. `
+                + `# of lines: ${(lines && lines.length) || NaN} `
+                + `continuation_cursor: ${continuation_cursor?.slice(0, 15)} `
+                + `noLinesReason: ${log_unavailable_reason || 'N/A'} `);
+
+            pushLines(...lines);
+            setCursor(continuation_cursor);
+            setNoMoreLinesReason(log_unavailable_reason);
+            setHasPulledData(true);
+            return {
+                pulledLines: lines.length
+            }
+        }, [source, setHasPulledData, hasMore, filterString, cursor, MAX_LINES, devLogger]);
+
+    return { lines, isLoading, error, hasMore, noMoreLinesReason, getNext, hasPulledData };
+}
+
+export function useAccumulateLogsUntilEnd(hasMore: boolean, getNext: () => Promise<GetNextResult>) {
+    // useLatest() ensures that the multi-stage async function always see the 
+    // latest state of those variables, instead of the state attached to the 
+    // function clousure at the beginning.
+    const latestHasMore = useLatest(hasMore);
+    const latestGetNext = useLatest(getNext);
+    const [isAccumulating, setIsAccumlating] = useState(false);
+    const [accumulatedLines, setAccumulatedLines] = useState<number>(0);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const accumulateLogsUntilEnd = useCallback(async () => {
+        setIsAccumlating(true);
+        let accumulatedLines = 0;
+        setAccumulatedLines(accumulatedLines);
+        while(latestHasMore.current === true) {
+            setIsLoading(true);
+            const {pulledLines} = await latestGetNext.current();
+            setIsLoading(false);
+            
+            accumulatedLines += pulledLines;
+            setAccumulatedLines(accumulatedLines);
+
+            // Yield to rendering cycles
+            await new Promise(
+                resolve => setTimeout(resolve, 10)
+            );
+        }
+        setIsAccumlating(false);
+    }, [latestHasMore, latestGetNext]);
+
+    return {
+        accumulateLogsUntilEnd,
+        isAccumulating,
+        isLoading,
+        accumulatedLines
+    };
+}

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import io from "socket.io-client";
 
 interface IFetchJSON {
@@ -55,6 +56,16 @@ export function fetchJSON({
       }
     );
 }
+
+export function useLogger() {
+  const devLogger = useMemo(() => process.env.NODE_ENV === "development" ?
+    (...args: any[]) => console.log("DEV DEBUG: ", ...args) :
+    () => { }, []);
+
+  return {
+    devLogger
+  }
+} 
 
 export const graphSocket = io("/graph");
 


### PR DESCRIPTION
Simplify the logs processing logic

- Now, we don't pass the logs retrieving function from `<LogPanel>` to `<ScrollingLogView>.` The logs retrieving logics are encapsulated in `logHooks.ts.`
- Callback style procedures are converted to async/await style. Code flows more naturally.
- The logics in `logHooks.ts` are much shorter now!

This should fix #354