### PR TITLE
Gets rid of passing down `changeRootRunId`

### DIFF
--- a/sematic/ui/src/components/Notes.tsx
+++ b/sematic/ui/src/components/Notes.tsx
@@ -1,4 +1,7 @@
 import { Box, ButtonBase, Typography, useTheme } from "@mui/material";
+import { useCallback } from "react";
+import { useParams } from "react-router-dom";
+import { usePipelineNavigation } from "../hooks/pipelineHooks";
 import { Note, User } from "../Models";
 import { CopyButton } from "./CopyButton";
 import TimeAgo from "./TimeAgo";
@@ -7,9 +10,8 @@ import UserAvatar from "./UserAvatar";
 export function NoteView(props: {
   note: Note;
   author: User;
-  onRootIdChange: (rootId: string) => void;
 }) {
-  const { note, author, onRootIdChange } = props;
+  const { note, author } = props;
   const theme = useTheme();
 
   return (
@@ -57,7 +59,7 @@ export function NoteView(props: {
           }}
         >
           <TimeAgo date={note.created_at} /> on run{" "}
-          <RunId runId={note.root_id} onClick={onRootIdChange} trim />
+          <RunId runId={note.root_id} trim />
         </Typography>
       </Box>
     </Box>
@@ -67,13 +69,20 @@ export function NoteView(props: {
 function RunId(props: {
   runId: string;
   trim?: boolean;
-  onClick?: (runId: string) => void;
 }) {
-  const { runId, trim = true, onClick } = props;
+  const { runId, trim = true } = props;
+
+  const { calculatorPath } = useParams();
+
+  const navigate = usePipelineNavigation(calculatorPath!);
+
+  const onClick = useCallback(() => {
+    navigate(runId);
+  }, [navigate, runId]);
 
   return (
     <>
-      <ButtonBase onClick={() => onClick && onClick(runId)} disabled={!onClick}>
+      <ButtonBase onClick={onClick} disabled={false}>
         <code
           style={{
             fontSize: 12,

--- a/sematic/ui/src/components/NotesPanel.tsx
+++ b/sematic/ui/src/components/NotesPanel.tsx
@@ -17,12 +17,11 @@ import { NoteView } from "./Notes";
 export default function NotesPanel(props: {
   rootRun: Run;
   selectedRun: Run;
-  onRootIdChange: (rootId: string) => void;
 }) {
   const theme = useTheme();
   const { user } = useContext(UserContext);
 
-  const { rootRun, selectedRun, onRootIdChange } = props;
+  const { rootRun, selectedRun } = props;
 
   const calculatorPath = useMemo(
     () => rootRun.calculator_path,
@@ -128,7 +127,6 @@ export default function NotesPanel(props: {
                   note={note}
                   key={idx}
                   author={authorsByEmail.get(note.author_id) || anonymousUser}
-                  onRootIdChange={onRootIdChange}
                 />
               ))}
             </Stack>

--- a/sematic/ui/src/components/PipelinePanels.tsx
+++ b/sematic/ui/src/components/PipelinePanels.tsx
@@ -13,9 +13,8 @@ export default function PipelinePanels(props: {
   rootRun: Run;
   resolution: Resolution;
   onRootRunUpdate: (run: Run) => void;
-  onRootIdChange: (rootId: string) => void;
 }) {
-  const { rootRun, resolution, onRootRunUpdate, onRootIdChange } = props;
+  const { rootRun, resolution, onRootRunUpdate } = props;
   const [selectedPanelItem, setSelectedPanelItem] = useState("run");
   const [graphsByRootId, setGraphsByRootId] = useState<Map<string, Graph>>(
     new Map()
@@ -130,7 +129,6 @@ export default function PipelinePanels(props: {
         <NotesPanel
           rootRun={rootRun}
           selectedRun={selectedRun}
-          onRootIdChange={onRootIdChange}
         />
       </>
     );

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -58,7 +58,7 @@ export function usePipelineNavigation(pipelinePath: string) {
     const navigate = useNavigate();
     const { rootId } = useParams();
 
-    return useCallback((requestedRootId: string, replace: boolean) => {
+    return useCallback((requestedRootId: string, replace: boolean = false) => {
         if ( rootId === requestedRootId ) {
             return
         }

--- a/sematic/ui/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunView.tsx
@@ -48,24 +48,6 @@ export default function PipelineRunView() {
     fetchResolution(rootId!);
   }, [rootId, fetchRootRun, fetchResolution]);
 
-  const changeRootRunId = useCallback(
-    (rootId: string) => {
-      if (rootRun && rootRun.id === rootId) return;
-      var runURL =
-        window.location.protocol +
-        "//" +
-        window.location.host +
-        "/pipelines/" +
-        calculatorPath +
-        "/" +
-        rootId;
-      window.history.pushState({ path: runURL }, "", runURL);
-      fetchRootRun(rootId);
-      fetchResolution(rootId);
-    },
-    [calculatorPath, rootRun, fetchRootRun, fetchResolution]
-  );
-
   if (calculatorPath) {
     return (
       <Box
@@ -78,7 +60,6 @@ export default function PipelineRunView() {
       >
         <PipelineBar
           calculatorPath={calculatorPath}
-          onRootIdChange={changeRootRunId}
           rootRun={rootRun}
           resolution={resolution}
         />
@@ -87,7 +68,6 @@ export default function PipelineRunView() {
             rootRun={rootRun}
             resolution={resolution}
             onRootRunUpdate={setRootRun}
-            onRootIdChange={changeRootRunId}
           />
         )}
       </Box>


### PR DESCRIPTION
Description:

There is no need to have `changeRootRunId` passed down from `<PipelineRunView />,` through  `<PipelineBar />,` then through `<NotesPanel />,` into `<NoteView />` (or similarly, from `<PipelineRunView />` into `<PipelineBar>`). If `<NoteView />` wants to change the root run, the best way is to make URL navigation and render a new page fresh. This doesn't have much performance drain because if a node is not changed on the virtual DOM tree, it will persist and potentially not be re-rendered. In the meantime, the code flow logic could be simplified. 

This idea also works well with the future's comprehensive deep-linking implementation.

