### PR TITLE
Enable configurable worker sa

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ with nothing else on the line.
 -->
 * HEAD
     * [feature] Add CLI for reading/following logs for a run
+    * [feature] Enable configuration for the Kubernetes service account the workers will use
     * [improvement] BREAKING CHANGE: The existing settings have been split into specific
       user and server settings. User settings configure the Resolver and the pipeline
       submission, and server settings configure the backend Server behavior. User settings

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   AWS_S3_BUCKET: {{ .Values.aws.storage_bucket | quote }}
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
+  SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.app_config.worker_kubernetes_sa | default default | quote }}

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -14,4 +14,4 @@ data:
   AWS_S3_BUCKET: {{ .Values.aws.storage_bucket | quote }}
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
-  SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.app_config.worker_kubernetes_sa | default "default" | quote }}
+  SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -14,4 +14,4 @@ data:
   AWS_S3_BUCKET: {{ .Values.aws.storage_bucket | quote }}
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
-  SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.app_config.worker_kubernetes_sa | default default | quote }}
+  SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.app_config.worker_kubernetes_sa | default "default" | quote }}

--- a/helm/sematic-server/templates/serviceaccount.yaml
+++ b/helm/sematic-server/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,3 +9,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{ end }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -5,8 +5,6 @@ auth:
 aws:
   enabled: true
   storage_bucket: sematic-dev
-app_config:
-  worker_kubernetes_sa: default
 
 create_secret: true
 database:
@@ -22,6 +20,10 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+worker:
+  service_account:
+    name: default
 
 serviceAccount:
   # Should a new service account be created? Or should we use

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -5,6 +5,8 @@ auth:
 aws:
   enabled: true
   storage_bucket: sematic-dev
+app_config:
+  worker_kubernetes_sa: default
 
 create_secret: true
 database:

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -24,8 +24,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
+  # Should a new service account be created? Or should we use
+  # one that already exists
+  create: false
+
   # Annotations to add to the service account
   annotations: {}
+
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -29,7 +29,14 @@ class ServerSettingsVar(enum.Enum):
     GITHUB_OAUTH_CLIENT_ID = "GITHUB_OAUTH_CLIENT_ID"
 
     # Kubernetes
+
+    # Controls the Kubernetes namespace that the server will launch
+    # jobs into
     KUBERNETES_NAMESPACE = "KUBERNETES_NAMESPACE"
+
+    # Controls which Kubernetes Service Account the server
+    # uses for jobs.
+    SEMATIC_WORKER_KUBERNETES_SA = "SEMATIC_WORKER_KUBERNETES_SA"
 
     # GRAFANA
     GRAFANA_PANEL_URL = "GRAFANA_PANEL_URL"

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -643,7 +643,7 @@ def _schedule_kubernetes_job(
                     volumes=volumes,
                     tolerations=tolerations,
                     restart_policy="Never",
-                    service_account=service_account,
+                    service_account_name=service_account,
                 ),
             ),
             backoff_limit=0,
@@ -708,6 +708,9 @@ def schedule_run_job(
     """Schedule a job on k8s for a calculator execution."""
     # "User" in this case is the server.
     namespace = get_server_settings(ServerSettingsVar.KUBERNETES_NAMESPACE)
+    service_account = get_server_settings(
+        ServerSettingsVar.SEMATIC_WORKER_KUBERNETES_SA, DEFAULT_WORKER_SERVICE_ACCOUNT
+    )
     external_job = KubernetesExternalJob.new(
         try_number, run_id, namespace, JobType.worker
     )
@@ -721,6 +724,7 @@ def schedule_run_job(
         image=image,
         environment_vars=user_settings,
         namespace=namespace,
+        service_account=service_account,
         resource_requirements=resource_requirements,
         args=args,
     )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -53,6 +53,8 @@ RESOLUTION_RESOURCE_REQUIREMENTS = ResourceRequirements(
     )
 )
 
+DEFAULT_WORKER_SERVICE_ACCOUNT = "default"
+
 
 @unique
 class KubernetesJobCondition(Enum):
@@ -539,6 +541,7 @@ def _schedule_kubernetes_job(
     image: str,
     environment_vars: Dict[str, str],
     namespace: str,
+    service_account: str = DEFAULT_WORKER_SERVICE_ACCOUNT,
     resource_requirements: Optional[ResourceRequirements] = None,
     args: Optional[List[str]] = None,
 ):
@@ -640,6 +643,7 @@ def _schedule_kubernetes_job(
                     volumes=volumes,
                     tolerations=tolerations,
                     restart_policy="Never",
+                    service_account=service_account,
                 ),
             ),
             backoff_limit=0,
@@ -661,6 +665,9 @@ def schedule_resolution_job(
 ) -> ExternalJob:
 
     namespace = get_server_settings(ServerSettingsVar.KUBERNETES_NAMESPACE)
+    service_account = get_server_settings(
+        ServerSettingsVar.SEMATIC_WORKER_KUBERNETES_SA, DEFAULT_WORKER_SERVICE_ACCOUNT
+    )
 
     external_job = KubernetesExternalJob.new(
         try_number=0,
@@ -684,6 +691,7 @@ def schedule_resolution_job(
         image=image,
         environment_vars=user_settings,
         namespace=namespace,
+        service_account=service_account,
         resource_requirements=RESOLUTION_RESOURCE_REQUIREMENTS,
         args=args,
     )


### PR DESCRIPTION
Closes #372 

Currently the server launches all workloads to use the `default` service account. We should add a new server configuration that allows you to launch jobs with a different SA.

- [Server settings definition](https://github.com/sematic-ai/sematic/blob/main/sematic/config/server_settings.py)
- [job launch](https://github.com/sematic-ai/sematic/blob/main/sematic/scheduling/kubernetes.py#L587)

Made changes to the helm chart to make this configurable. Also made some changes to the helm chart so I could deploy this to dev1 and test it.

Testing
-------
- Deployed to dev1 using:
```
helm upgrade sematic ./ --namespace=dev1 -f values.yaml --set image.repository=$IMAGE --set image.tag=$TAG --set namespace=dev1 --set auth.google_oauth_client_id=$GOOGLE_OAUTH_CLIENT_ID --set database.url=$DATABASE_URL --set app_config.worker_kubernetes_sa=sematic-worker
```

- Launched [a run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/76b02e7e3622455aaa29cc420dae6149)
- confirmed that the resolver job and the worker job were using the service account `sematic-worker`