### PR TITLE
Enable Sematic context

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
 * [Deploy Sematic](deploy.md)
 * [Container images](container-images.md)
 * [Artifacts](artifacts.md)
+* [Advanced APIs](advanced-apis.md)
 * [Glossary](glossary.md)
 
 ## Integrations

--- a/docs/advanced-apis.md
+++ b/docs/advanced-apis.md
@@ -1,0 +1,35 @@
+# Advanced APIs
+
+## Context
+
+Sometimes you may want to record the results of an execution with
+a third party or custom tool. In this case, you would want to
+preserve the ability to reference the Sematic run that the results
+came from. Sematic provides an API you can use to do this directly
+within your Sematic funcs:
+
+```python
+import sematic
+
+@sematic.func
+def add(a: int, b: int) -> int:
+    result = a + b
+
+    # track this run's results with some hypothetical
+    # experiment management tool.
+    some_experiment_manager().record_result(
+        sematic.context().run_id, {
+            "a": a,
+            "b": b,
+            "result": result,
+        }
+    )
+    return result
+```
+
+The context object returned by `sematic.context()` contains both the `run_id` for the
+execution of the current func, as well as the run id for the root run of the pipeline
+currently being executed (in `root_id`).
+
+## Resource APIs
+Coming soon...

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -48,7 +48,9 @@ sematic_py_lib(
 sematic_py_lib(
     name = "future_context",
     srcs = ["future_context.py"],
-    deps = [],
+    deps = [
+        "//sematic:resolver"
+    ],
 )
 
 sematic_py_lib(

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -8,6 +8,7 @@ sematic_py_lib(
         ":container_images",
         ":resolver",
         ":retry_settings",
+        "//sematic:future_context",
         "//sematic/future_operators:init",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:local_resolver",
@@ -42,6 +43,12 @@ sematic_py_lib(
         "//sematic/db/models:run",
         "//sematic/utils:retry",
     ],
+)
+
+sematic_py_lib(
+    name = "future_context",
+    srcs = ["future_context.py"],
+    deps = [],
 )
 
 sematic_py_lib(

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -21,6 +21,7 @@ import sematic.future_operators  # noqa: F401,E402
 import sematic.types  # noqa: F401,E402
 from sematic.calculator import func  # noqa: F401,E402
 from sematic.container_images import has_container_image  # noqa: F401,E402
+from sematic.future_context import SematicContext, context  # noqa: F401,E402
 from sematic.resolver import Resolver  # noqa: F401,E402
 from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
 from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401,E402

--- a/sematic/future_context.py
+++ b/sematic/future_context.py
@@ -65,7 +65,7 @@ def set_context(ctx: SematicContext):
             f"Sematic will ensure that the future is resolved before it starts the "
             f"new func. For more information, read {FUTURE_ALGEBRA_DOC_LINK}"
         )
-    
+
     if not isinstance(ctx, SematicContext):
         raise ValueError(f"Expecting a `SematicContext`, got: {ctx}")
     _current_context = ctx

--- a/sematic/future_context.py
+++ b/sematic/future_context.py
@@ -2,15 +2,21 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, Optional, Type
+from typing import Optional, Type
+
+# Sematic
+from sematic.resolver import Resolver
+
+FUTURE_ALGEBRA_DOC_LINK = "https://docs.sematic.dev/diving-deeper/future-algebra"
 
 
 @dataclass(frozen=True)
 class SematicContext:
     """Contextual information about the execution of the current Sematic function
+
     Attributes
     ----------
-    id:
+    run_id:
         The id of the future for the current execution. For cloud executions, this
         is equivalent to the id for the existing run.
     root_id:
@@ -20,11 +26,11 @@ class SematicContext:
         The import path for the resolver being used.
     """
 
-    id: str
+    run_id: str
     root_id: str
     resolver_class_path: str
 
-    def resolver_class(self) -> Type[Any]:
+    def resolver_class(self) -> Type[Resolver]:
         module_name, resolver_name = self.resolver_class_path.rsplit(".", maxsplit=1)
         module = import_module(module_name)
         resolver_class = getattr(module, resolver_name, None)
@@ -49,17 +55,25 @@ def set_context(ctx: SematicContext):
     """
     global _current_context
 
-    # _current_context might not be None if a Sematic resolution is started
-    # from within a Sematic func. This is not a pattern we encourage, but
-    # shouldn't fail.
-    prior_context = _current_context
+    if _current_context is not None:
+        raise RuntimeError(
+            f"You have called .resolve() within a Sematic func. Usually people "
+            f"do this when they have a future object and want it to be resolved to "
+            f"an actual value in the middle of a Sematic func's body for usage "
+            f"downstream. If this is your use-case, consider wrapping the downstream "
+            f"logic in a new Sematic func and passing the unresolved future into it. "
+            f"Sematic will ensure that the future is resolved before it starts the "
+            f"new func. For more information, read {FUTURE_ALGEBRA_DOC_LINK}"
+        )
+    
     if not isinstance(ctx, SematicContext):
-        raise ValueError(f"Expecting a Sematic context, got: {ctx}")
+        raise ValueError(f"Expecting a `SematicContext`, got: {ctx}")
     _current_context = ctx
+
     try:
         yield
     finally:
-        _current_context = prior_context
+        _current_context = None
 
 
 def context() -> SematicContext:

--- a/sematic/future_context.py
+++ b/sematic/future_context.py
@@ -1,0 +1,88 @@
+# Standard Library
+from contextlib import contextmanager
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Optional, Type
+
+
+@dataclass(frozen=True)
+class SematicContext:
+    """Contextual information about the execution of the current Sematic function
+    Attributes
+    ----------
+    id:
+        The id of the future for the current execution. For cloud executions, this
+        is equivalent to the id for the existing run.
+    root_id:
+        The id of the root future for a resolution. For cloud executions, this is
+        equivalent to the id for the root run.
+    resolver_class_path:
+        The import path for the resolver being used.
+    """
+
+    id: str
+    root_id: str
+    resolver_class_path: str
+
+    def resolver_class(self) -> Type[Any]:
+        module_name, resolver_name = self.resolver_class_path.rsplit(".", maxsplit=1)
+        module = import_module(module_name)
+        resolver_class = getattr(module, resolver_name, None)
+        if resolver_class is None:
+            raise ImportError(f"No class named '{resolver_name}' in {module_name}")
+        return resolver_class
+
+
+_current_context: Optional[SematicContext] = None
+
+
+@contextmanager
+def set_context(ctx: SematicContext):
+    """Context manager to execute a Sematic function with a global context enabled.
+
+    This should only be called by Sematic itself, not by end-users.
+
+    Parameters
+    ----------
+    ctx:
+        The context that the function should be executed with
+    """
+    global _current_context
+
+    # _current_context might not be None if a Sematic resolution is started
+    # from within a Sematic func. This is not a pattern we encourage, but
+    # shouldn't fail.
+    prior_context = _current_context
+    if not isinstance(ctx, SematicContext):
+        raise ValueError(f"Expecting a Sematic context, got: {ctx}")
+    _current_context = ctx
+    try:
+        yield
+    finally:
+        _current_context = prior_context
+
+
+def context() -> SematicContext:
+    """Get the current run context, including the active run id and root run id.
+
+    This can be used if you wish to track information about a Sematic execution
+    in an external system, and store it by an id that can link you back to the
+    Sematic run. It should not be used to interact with the Sematic API directly.
+
+    Returns
+    -------
+    The active context, if a Sematic function is currently executing. Otherwise
+    it will raise an error.
+
+    Raises
+    ------
+    RuntimeError:
+        If this function is called outside the execution of a Sematic function.
+    """
+    global _current_context
+    if _current_context is None:
+        raise RuntimeError(
+            "context() must be called from within the execution of a Sematic function, "
+            "in the root process that function was invoked from."
+        )
+    return _current_context

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -37,6 +37,7 @@ sematic_py_lib(
     srcs = ["silent_resolver.py"],
     deps = [
         "//sematic:abstract_future",
+        "//sematic:future_context",
         "//sematic/resolvers:state_machine_resolver",
     ],
 )
@@ -97,6 +98,7 @@ sematic_py_lib(
         "//sematic:api_client",
         "//sematic:calculator",
         "//sematic:future",
+        "//sematic:future_context",
         "//sematic:log_reader",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -3,6 +3,7 @@ import logging
 
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState
+from sematic.future_context import SematicContext, set_context
 from sematic.resolvers.state_machine_resolver import StateMachineResolver
 from sematic.utils.exceptions import ResolutionError, format_exception_for_run
 
@@ -19,7 +20,14 @@ class SilentResolver(StateMachineResolver):
         self._set_future_state(future, FutureState.SCHEDULED)
         try:
             self._start_inline_execution(future.id)
-            value = future.calculator.calculate(**future.resolved_kwargs)
+            with set_context(
+                SematicContext(
+                    id=future.id,
+                    root_id=self._root_future.id,
+                    resolver_class_path=self.classpath(),
+                )
+            ):
+                value = future.calculator.calculate(**future.resolved_kwargs)
             self._update_future_with_value(future, value)
         except ResolutionError:
             # only we raise ResolutionError when determining a failure is unrecoverable

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -22,7 +22,7 @@ class SilentResolver(StateMachineResolver):
             self._start_inline_execution(future.id)
             with set_context(
                 SematicContext(
-                    id=future.id,
+                    run_id=future.id,
                     root_id=self._root_future.id,
                     resolver_class_path=self.classpath(),
                 )

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -384,3 +384,7 @@ class StateMachineResolver(Resolver, abc.ABC):
         future.nested_future = nested_future
         nested_future.parent_future = future
         self._enqueue_future(nested_future)
+
+    @classmethod
+    def classpath(cls) -> str:
+        return f"{cls.__module__}.{cls.__name__}"

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -79,9 +79,13 @@ pytest_test(
     srcs = ["test_worker.py"],
     deps = [
         "//sematic:abstract_future",
+        "//sematic:api_client",
         "//sematic:calculator",
+        "//sematic:future_context",
         "//sematic/api/tests:fixtures",
         "//sematic/db:queries",
+        "//sematic/db/models:edge",
+        "//sematic/db/models:factories",
         "//sematic/db/models:resolution",
         "//sematic/db/tests:fixtures",
         "//sematic/resolvers:cloud_resolver",

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -42,6 +42,7 @@ pytest_test(
     deps = [
         "//sematic:abstract_calculator",
         "//sematic:calculator",
+        "//sematic:future_context",
         "//sematic:retry_settings",
         "//sematic/resolvers:silent_resolver",
         "//sematic/utils:exceptions",

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -38,6 +38,11 @@ def direct_context_func() -> SematicContext:
     return context()
 
 
+@func
+def nested_resolve_func() -> int:
+    return add(1, 2).resolve()
+
+
 def test_silent_resolver():
     assert SilentResolver().resolve(pipeline(3, 5)) == 24
 
@@ -46,13 +51,18 @@ def test_silent_resolver_context():
     future = context_pipeline()
     result = SilentResolver().resolve(future)
     assert result.root_id == future.id
-    assert result.id != future.id
+    assert result.run_id != future.id
     assert result.resolver_class() is SilentResolver
 
     future = direct_context_func()
     result = SilentResolver().resolve(future)
     assert result.root_id == future.id
-    assert result.id == future.id
+    assert result.run_id == future.id
+
+
+def test_nested_resolve():
+    with pytest.raises(ResolutionError):
+        nested_resolve_func().resolve()
 
 
 _tried = 0

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -62,7 +62,7 @@ def test_silent_resolver_context():
 
 def test_nested_resolve():
     with pytest.raises(ResolutionError):
-        nested_resolve_func().resolve()
+        SilentResolver().resolve(nested_resolve_func())
 
 
 _tried = 0

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -5,6 +5,7 @@ import pytest
 from sematic.abstract_calculator import CalculatorError
 from sematic.abstract_future import FutureState
 from sematic.calculator import func
+from sematic.future_context import SematicContext, context
 from sematic.resolvers.silent_resolver import SilentResolver
 from sematic.retry_settings import RetrySettings
 from sematic.utils.exceptions import ResolutionError
@@ -27,8 +28,31 @@ def pipeline(a: float, b: float) -> float:
     return add(c, d)
 
 
+@func
+def context_pipeline() -> SematicContext:
+    return direct_context_func()
+
+
+@func
+def direct_context_func() -> SematicContext:
+    return context()
+
+
 def test_silent_resolver():
     assert SilentResolver().resolve(pipeline(3, 5)) == 24
+
+
+def test_silent_resolver_context():
+    future = context_pipeline()
+    result = SilentResolver().resolve(future)
+    assert result.root_id == future.id
+    assert result.id != future.id
+    assert result.resolver_class() is SilentResolver
+
+    future = direct_context_func()
+    result = SilentResolver().resolve(future)
+    assert result.root_id == future.id
+    assert result.id == future.id
 
 
 _tried = 0

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -1,10 +1,13 @@
 # Standard Library
+import datetime
+import uuid
 from unittest import mock
 
 # Third-party
 import pytest
 
 # Sematic
+from sematic import api_client
 from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import (  # noqa: F401
     mock_auth,
@@ -13,9 +16,17 @@ from sematic.api.tests.fixtures import (  # noqa: F401
     test_client,
 )
 from sematic.calculator import func
+from sematic.db.models.edge import Edge
+from sematic.db.models.factories import make_artifact, make_run_from_future
 from sematic.db.models.resolution import ResolutionStatus
-from sematic.db.queries import get_resolution, get_root_graph, save_resolution
+from sematic.db.queries import (
+    get_resolution,
+    get_root_graph,
+    save_graph,
+    save_resolution,
+)
 from sematic.db.tests.fixtures import test_db  # noqa: F401
+from sematic.future_context import SematicContext
 from sematic.resolvers.cloud_resolver import CloudResolver
 from sematic.resolvers.worker import main
 from sematic.tests.fixtures import (  # noqa: F401
@@ -41,6 +52,7 @@ _MOCK_STORAGE = MockStorage()
 @mock.patch(
     "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
 )
+@mock.patch("sematic.resolvers.silent_resolver.set_context")
 @mock.patch("sematic.api_client.schedule_resolution")
 @mock.patch("kubernetes.config.load_kube_config")
 @mock.patch("sematic.resolvers.cloud_resolver.S3Storage", return_value=_MOCK_STORAGE)
@@ -50,6 +62,7 @@ def test_main(
     mock_storage: mock.MagicMock,
     mock_load_kube_config: mock.MagicMock,
     mock_schedule_job: mock.MagicMock,
+    mock_set_context: mock.MagicMock,
     mock_get_image: mock.MagicMock,
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
@@ -76,6 +89,100 @@ def test_main(
     assert len(runs) == 2
     assert len(artifacts) == 3
     assert len(edges) == 6
+    mock_set_context.assert_any_call(
+        SematicContext(
+            run_id=future.id,
+            root_id=future.id,
+            resolver_class_path=CloudResolver.classpath(),
+        )
+    )
+
+
+@mock.patch(
+    "sematic.resolvers.cloud_resolver.get_image_uris", return_value=dict(default="foo")
+)
+@mock.patch("sematic.resolvers.worker.set_context")
+@mock.patch("sematic.api_client.schedule_resolution")
+@mock.patch("kubernetes.config.load_kube_config")
+@mock.patch("sematic.resolvers.cloud_resolver.S3Storage")
+@mock.patch("sematic.resolvers.worker.S3Storage")
+def test_main_func(
+    mock_worker_storage: mock.MagicMock,
+    mock_storage: mock.MagicMock,
+    mock_load_kube_config: mock.MagicMock,
+    mock_schedule_job: mock.MagicMock,
+    mock_set_context: mock.MagicMock,
+    mock_get_image: mock.MagicMock,
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_requests,  # noqa: F811
+    test_db,  # noqa: F811
+    test_storage,  # noqa: F811
+    valid_client_version,  # noqa: F811
+):
+    mock_storage.return_value = test_storage
+    mock_worker_storage.return_value = test_storage
+    future = add(1, 1)
+    artifact_1 = make_artifact(1, int, test_storage)
+    artifact_2 = make_artifact(1, int, test_storage)
+
+    edge_1 = Edge(
+        id=uuid.uuid4().hex,
+        created_at=datetime.datetime.utcnow(),
+        updated_at=datetime.datetime.utcnow(),
+        source_run_id=None,
+        destination_run_id=future.id,
+        destination_name="a",
+        artifact_id=artifact_1.id,
+        parent_id=None,
+    )
+    edge_2 = Edge(
+        id=uuid.uuid4().hex,
+        created_at=datetime.datetime.utcnow(),
+        updated_at=datetime.datetime.utcnow(),
+        source_run_id=None,
+        destination_run_id=future.id,
+        destination_name="b",
+        artifact_id=artifact_2.id,
+        parent_id=None,
+    )
+
+    out_edge = Edge(
+        id=uuid.uuid4().hex,
+        created_at=datetime.datetime.utcnow(),
+        updated_at=datetime.datetime.utcnow(),
+        source_run_id=future.id,
+        destination_run_id=None,
+        destination_name=None,
+        artifact_id=None,
+        parent_id=None,
+    )
+    run = make_run_from_future(future)
+    run.root_id = run.id
+    save_graph(
+        runs=[run], artifacts=[artifact_1, artifact_2], edges=[edge_1, edge_2, out_edge]
+    )
+
+    # on the worker
+    main(run_id=future.id, resolve=False)
+
+    runs, artifacts, _ = get_root_graph(future.id)
+    assert len(runs) == 1
+    output_artifact_id = [
+        artifact.id
+        for artifact in artifacts
+        if artifact.id not in (artifact_1.id, artifact_2.id)
+    ][0]
+    value = api_client.get_artifact_value_by_id(output_artifact_id, test_storage)
+    assert value == 2  # 1+1==2. Rest assured that math is intact!
+
+    mock_set_context.assert_called_once_with(
+        SematicContext(
+            run_id=future.id,
+            root_id=future.id,
+            resolver_class_path=CloudResolver.classpath(),
+        )
+    )
 
 
 @func

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -19,6 +19,7 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value, make_artifact
 from sematic.db.models.run import Run
 from sematic.future import Future
+from sematic.future_context import SematicContext, set_context
 from sematic.log_reader import log_prefix
 from sematic.resolvers.cloud_resolver import (
     CloudResolver,
@@ -159,7 +160,14 @@ def main(
 
         else:
             logger.info("Executing %s", func.__name__)
-            output = func.calculate(**kwargs)
+            with set_context(
+                SematicContext(
+                    id=run.id,
+                    root_id=run.root_id,
+                    resolver_class_path=CloudResolver.classpath(),
+                )
+            ):
+                output = func.calculate(**kwargs)
             _set_run_output(run, output, func.output_type, edges)
 
     except Exception as e:

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -162,7 +162,7 @@ def main(
             logger.info("Executing %s", func.__name__)
             with set_context(
                 SematicContext(
-                    id=run.id,
+                    run_id=run.id,
                     root_id=run.root_id,
                     resolver_class_path=CloudResolver.classpath(),
                 )

--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -66,7 +66,17 @@ def _safe_cast_dataclass(value: Any, type_: Any) -> Tuple[Any, Optional[str]]:
         if create_instance_from_scratch:
             cast_value[name] = cast_field
         else:
-            setattr(cast_value, name, cast_field)
+            try:
+                setattr(cast_value, name, cast_field)
+            except dataclasses.FrozenInstanceError:
+                if error is None:
+                    # value was fine anyway
+                    continue
+                else:
+                    return None, (
+                        f"The field '{name}' of {type_} was not a valid "
+                        f"instance of '{field.type}': {error}"
+                    )
 
     if create_instance_from_scratch:
         cast_value = type_(**cast_value)

--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -69,14 +69,9 @@ def _safe_cast_dataclass(value: Any, type_: Any) -> Tuple[Any, Optional[str]]:
             try:
                 setattr(cast_value, name, cast_field)
             except dataclasses.FrozenInstanceError:
-                if error is None:
-                    # value was fine anyway
-                    continue
-                else:
-                    return None, (
-                        f"The field '{name}' of {type_} was not a valid "
-                        f"instance of '{field.type}': {error}"
-                    )
+                # it's frozen, and the casts all passed, so we're fine
+                # to just leave the object as-is.
+                pass
 
     if create_instance_from_scratch:
         cast_value = type_(**cast_value)

--- a/sematic/types/types/tests/test_dataclass.py
+++ b/sematic/types/types/tests/test_dataclass.py
@@ -40,6 +40,11 @@ class E:
     a: float
 
 
+@dataclass
+class MyFrozenDataclass:
+    field: str
+
+
 @pytest.mark.parametrize(
     "from_type, to_type, expected_can_cast, expected_error",
     (
@@ -101,6 +106,13 @@ def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
             None,
             None,
             "Cannot cast C(a='abc') to <class 'sematic.types.types.tests.test_dataclass.A'>: Cannot cast 'abc' to <class 'int'>",  # noqa: E501
+        ),
+        (
+            MyFrozenDataclass("some value"),
+            MyFrozenDataclass,
+            MyFrozenDataclass,
+            MyFrozenDataclass("some value"),
+            None,
         ),
     ),
 )


### PR DESCRIPTION
#138

Introduces a new context object that can be used to obtain the ids of the active run/root run as well as the Resolver class. Example:

```python
import sematic

@sematic.func
def my_func() -> None:
    print("Root id is: {}".format(sematic.context().root_id))
    return None
```

This PR serves 3 purposes. The first two are related to the start of Spark work, the last is general.
1. In order to have behavior that differs based on which resolver is being used (ex: allocate local or remote spark cluster), we will need a context object like this
2. In order to allow the resolver logic to have a "hook" into how references to external resources (ex: a spark cluster) are registered, we will need such a context. Silent resolver can store references to these resources in memory, while the others store in a DB.
3. there are some legit use cases where It is useful to be able to get the id of the current run/root run (see #138)

Testing
--------
In addition to unit tests, also executed a cloud run in which I printed the context from within a function. Ensured that the logs showed the correct context. Run [here](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.bazel.pipeline.pipeline/743c03cd549c4dccaab1be55acc507ca). View source code and logs for `add` to see the result.