### PR TITLE
[bugfix] Cache version check

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -294,6 +294,8 @@ def _validate_server_compatibility(
         delay=seconds_between_tries,
     )(_validate_server_compatibility_no_catch)()
 
+    _validated_client_version = True
+
 
 def _validate_server_compatibility_no_catch() -> None:
     base_url = get_config().api_url.replace("/api/v1", "")

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -133,6 +133,9 @@ def test_validate_server_compatibility_new_server_still_supports(mock_requests):
         ),
     )
     _validate_server_compatibility(tries=5, seconds_between_tries=0, use_cached=False)
+    _validate_server_compatibility(tries=5, seconds_between_tries=0, use_cached=True)
+
+    mock_requests.get.assert_called_once()
 
 
 @mock.patch("sematic.api_client.requests")


### PR DESCRIPTION
We have a mechanism to validate compatibility of version between client and server. The check is supposed to be done once per interpreter session and then be cached for subsequent calls. It is not cached.
This leads to every single API query being preceded by a version check.

This PR fixes this.