### PR TITLE
[bugfix] Missing broadcasts upon server-side run save

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ with nothing else on the line.
       release, if you try to "rerun from here" using a pipeline that has `Union` values in
       it that were produced prior to this version of Sematic, the rerun will likely fail
       with a serialization issue.
+    * [bugfix] Missing broadcasts upon server-side run save
 * [0.20.1](https://pypi.org/project/sematic/0.20.1/)
     * [bugfix] Add support for subclasses of ABCMeta
 * [0.20.0](https://pypi.org/project/sematic/0.20.0/)

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -200,7 +200,13 @@ def test_schedule_run(
         )
         persisted_resolution.status = ResolutionStatus.RUNNING
         save_resolution(persisted_resolution)
-        response = test_client.post(f"/api/v1/runs/{persisted_run.id}/schedule")
+
+        with mock.patch(
+            "sematic.api.endpoints.runs.broadcast_graph_update"
+        ) as mock_broadcast_graph_update:
+            response = test_client.post(f"/api/v1/runs/{persisted_run.id}/schedule")
+
+            mock_broadcast_graph_update.assert_called_once()
 
         assert response.status_code == 200
 
@@ -300,9 +306,14 @@ def test_update_run_disappeared(
         job.has_infra_failure = True
         mock_k8s.refresh_job.side_effect = lambda j: job
 
-        response = test_client.post(
-            "/api/v1/runs/future_states", json={"run_ids": [persisted_run.id]}
-        )
+        with mock.patch(
+            "sematic.api.endpoints.runs.broadcast_graph_update"
+        ) as mock_broadcast_graph_update:
+            response = test_client.post(
+                "/api/v1/runs/future_states", json={"run_ids": [persisted_run.id]}
+            )
+            mock_broadcast_graph_update.assert_called_once()
+
         assert response.status_code == 200
         payload = response.json
         assert payload == {


### PR DESCRIPTION
Every time the server saves a run, it needs to broadcast the fact that the graph was updated. These two were missing leading to the DAG not refreshing in the UI.

Ideally we would have a centralized way of doing this (so that any call to `save_run` automatically broadcasts the update), but I don't want to add a dependency to socketio in the `queries` module as it would mix concerns.

Maybe we need an additional intermediate layer that takes care of persisting objects (calling `queries` functions) and broadcasting to socketio too.