### PR TITLE
[bugfix] Inline future status were not being updated by `CloudResolver` prior to executing

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -201,7 +201,11 @@ class CloudResolver(LocalResolver):
     def _update_run_and_future_pre_scheduling(self, run: Run, future: AbstractFuture):
         # For the cloud resolver, the server will update the relevant
         # run fields when it gets scheduled by the server.
-        pass
+        # Inline futures still need the updates.
+        if not future.props.inline:
+            return
+
+        super()._update_run_and_future_pre_scheduling(run, future)
 
     def _detach_resolution(self, future: AbstractFuture) -> str:
         run = self._populate_run_and_artifacts(future)


### PR DESCRIPTION
With `CloudResolver`, the server is responsible for starting k8s jobs, and also updating the run status to `SCHEDULED`.

Inline runs are not scheduled by the server, therefore the usual logic needs to be applied.

This bug lead to inline runs remaining in the `CREATED` state until completion. This would have been caught by #107.