### PR TITLE
Make mnist work

### DIFF
--- a/sematic/examples/mnist/pytorch/BUILD
+++ b/sematic/examples/mnist/pytorch/BUILD
@@ -32,6 +32,7 @@ py_library(
 sematic_pipeline(
     name = "mnist_train",
     dev = True,
+    base = "@sematic-worker-cuda//image",
     registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
     repository = "sematic-dev",
     deps = [
@@ -59,6 +60,7 @@ py_library(
 sematic_pipeline(
     name = "mnist_learning_rates",
     dev = True,
+    base = "@sematic-worker-cuda//image",
     registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
     repository = "sematic-dev",
     deps = [

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -55,7 +55,7 @@ class PipelineConfig:
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesResourceRequirements(
         node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
-        requests={"cpu": "2", "memory": "2Gi"},
+        requests={"cpu": "2", "memory": "4Gi"},
     )
 )
 


### PR DESCRIPTION
The mnist example with GPUs doesn't work "out of the box" on any of Sematic's infra. This PR makes it so that it at least works with some old infra.

Testing
-------
Using the old infra:
- `bazel run //sematic/examples/mnist/pytorch:mnist_train -- --cuda` [run](https://dev.sematic.cloud/pipelines/sematic.examples.mnist.pytorch.pipeline.pipeline/a9f3e45b6b3049c78c7fddcf956c5646)
- `bazel run //sematic/examples/mnist/pytorch:mnist_learning_rates -- --cuda` [run](https://dev.sematic.cloud/pipelines/sematic.examples.mnist.pytorch.pipeline.scan_learning_rate/642e9ebc79b04ee1ae32703c4cd36746)