### PR TITLE
Implements the pull down to trigger logs fetch function

### DIFF
--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -21,7 +21,7 @@ export default function LogPanel(props: { run: Run }) {
       filterString={filterString} />
   );
   const logErrorView = (
-    <Alert severity="error">
+    <Alert severity="error" sx={{ my: 5 }}>
       The server returned an error when asked for logs for this run.
     </Alert>
   );

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -34,7 +34,7 @@ export function useHttpClient(): HttpClient {
 
         const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
 
-        devLogger("fetch() ", method, url, reqBody);
+        devLogger("HttpClient.fetch ", method, url, reqBody);
 
         const abortController = new AbortController();
         abortControllerRef.current = (abortController);

--- a/sematic/ui/src/hooks/scrollingHooks.ts
+++ b/sematic/ui/src/hooks/scrollingHooks.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLogger } from "../utils";
+import { useSetTimeout } from "./setTimeoutHooks";
+
+const SCROLL_EVENTS = ['mousewheel', 'DOMMouseScroll', 'wheel', 'MozMousePixelScroll'];
+const SCROLL_DOWN_CONTINUATION = 800;
+/**
+ * A hook tracks that whether `refElement` has scrolled down to the bottom,
+ * and then user has kept scrolling down for SCROLL_DOWN_CONTINUATION consecutive
+ * milliseconds. If so, `callback` will be triggered.
+ * 
+ * @param refElement The scrolling container to monitor. Its height should be 
+ *        taller than its content's height. (or there will be no scrolling)
+ * @param callback The callback to call.
+ * @returns 
+ */
+export function usePulldownTrigger(
+    refElement: React.MutableRefObject<HTMLElement | undefined>,
+    callback: () => Promise<void>
+) {
+    const { devLogger } = useLogger();
+    const hasElementScrolledToBottom = useCallback(() => {
+        if (!refElement.current) {
+            return;
+        }
+        const {scrollTop, clientHeight, scrollHeight } = refElement.current;
+
+        return scrollHeight - scrollTop - clientHeight < 10;
+    }, [refElement]);
+
+    const [pullDownTriggerEnabled, setPullDownTriggerEnabled] = useState(false);
+    const [markPulldownTriggerEnabled, cancelPulldownTriggerEnabled] = useSetTimeout(useCallback(() => {
+        // Mark the `enabled` state only when the scrolling has completely ceased.
+        // (in other words, there is not another follow-up scroll event to cancel this marking.)
+        setPullDownTriggerEnabled(true);
+    }, [setPullDownTriggerEnabled]), 50);
+
+    // This timeout function cancels the above timeout function
+    const [startDroppingPulldownTrigger, cancelDroppingPulldownTrigger] = useSetTimeout(() => {
+        cancelPulldownTriggerCall();
+        setPulldownProgress(0);
+    }, SCROLL_DOWN_CONTINUATION *.3);
+
+    // This is the timeout function who eventually trigger the `callback`
+    const [startPullDownTriggerCall, 
+        cancelPulldownTriggerCall, 
+        isPullDownTriggerCallInitiated
+    ] = useSetTimeout(useCallback(async () => {
+        setPulldownProgress(100);
+        devLogger('Pulldown triggered');
+        cancelDroppingPulldownTrigger();
+        pulldownCallbackInprogress.current = true;
+
+        await callback();
+        devLogger('Pulled down callback completed');
+
+        setPulldownProgress(0);
+        pulldownCallbackInprogress.current = false;
+    }, [callback, cancelDroppingPulldownTrigger, devLogger]), SCROLL_DOWN_CONTINUATION);
+
+    
+    const pullDownTriggerStarttime = useRef<number>(0);
+    const pulldownCallbackInprogress = useRef<boolean>(false);
+
+    const [pullDownProgress, setPulldownProgress] = useState<number>(0);
+
+    const onScroll = useCallback((event: Event) => {
+        if (pulldownCallbackInprogress.current) {
+            return;
+        }
+        event.stopPropagation();
+
+        // Phase 1: detect whether the scrolling has reached to the bottom
+        const hasReachedBottom = hasElementScrolledToBottom();
+        cancelPulldownTriggerEnabled();
+
+        if (hasReachedBottom) {
+            if (!pullDownTriggerEnabled) {
+                // mark pulldown trigger enabled in a delayed way.
+                markPulldownTriggerEnabled();
+            }
+        } else {
+            setPullDownTriggerEnabled(false);
+        }
+
+        if (!pullDownTriggerEnabled) {
+            return false;
+        }
+
+        // Phase 2: detect whether there is a continous scrolling down for 
+        // SCROLL_DOWN_CONTINUATION milliseconds. If it has, then `callback`
+        // will be triggered.
+        const { deltaY } = event as WheelEvent;
+        if (deltaY >= 0) { // deltaY >= 0 means it is scrolling down
+            // initiate pulldown trigger if not yet
+            if (!isPullDownTriggerCallInitiated()) {
+                setPulldownProgress(0);
+                startPullDownTriggerCall();
+                pullDownTriggerStarttime.current = performance.now();
+            }
+            // cancel previous attempt of cancelling pulldown trigger, so
+            // the cancellation of pulldownTrigger is delayed.
+            cancelDroppingPulldownTrigger();
+            
+            setPulldownProgress(
+                (performance.now() - pullDownTriggerStarttime.current) / SCROLL_DOWN_CONTINUATION * 100
+            );
+
+            // prepare to cancel pulldown trigger, so if there is not a consecutive
+            // scroll down event soon, the pull down trigger will be cancelled.
+            startDroppingPulldownTrigger();
+        } else {
+            // If it is not scrolling down, immediately cancel the current pull down detection
+            cancelPulldownTriggerCall();
+            setPulldownProgress(0);
+        }
+    }, [hasElementScrolledToBottom, markPulldownTriggerEnabled,
+        isPullDownTriggerCallInitiated, cancelPulldownTriggerCall, startPullDownTriggerCall, 
+        startDroppingPulldownTrigger, cancelDroppingPulldownTrigger, cancelPulldownTriggerEnabled,
+        pullDownTriggerEnabled, setPullDownTriggerEnabled]);
+    
+    const attachedDomElement = useRef<HTMLElement | undefined>(undefined);
+
+    useEffect(() => {
+        attachedDomElement.current = refElement.current;
+
+        SCROLL_EVENTS.forEach(eventName => {
+            attachedDomElement.current?.addEventListener(eventName, onScroll);
+        });
+
+        return () => {
+            SCROLL_EVENTS.forEach(eventName => {
+                attachedDomElement.current?.removeEventListener(eventName, onScroll);
+            });
+        };
+    }, [refElement, onScroll, attachedDomElement]);
+
+    return {pullDownProgress, pullDownTriggerEnabled};
+}

--- a/sematic/ui/src/hooks/setTimeoutHooks.ts
+++ b/sematic/ui/src/hooks/setTimeoutHooks.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * A utility to drive the function controlled by setTimeout.
+ * Does not trigger re-render.
+ * 
+ * @param callback Function to call.
+ * @param timeout how soon to call the function.
+ */
+export function useSetTimeout<T extends (...args: any[]) => any>(callback: T, timeout: number, label = 0): [
+    (...args: Parameters<T>) => void,
+    () => void,
+    () => boolean
+] {
+    const handle = useRef<number | undefined>(undefined);
+    const isPending = useRef<boolean>(false);
+
+    const call = useCallback((...args: Parameters<T>) => {
+        isPending.current = true;
+        handle.current = window.setTimeout(async () => {
+            const result = await callback(...args);
+            isPending.current = false;
+            return result;
+        }, timeout);
+    }, [callback, handle, timeout, isPending]);
+
+    const cancel = useCallback(() => {
+        !!handle.current && clearTimeout(handle.current);
+        handle.current = undefined;
+        isPending.current = false;
+    }, [handle, isPending]);
+
+    const isPendingFn = useCallback(() => isPending.current, [isPending]);
+
+    return [call, cancel, isPendingFn];
+}


### PR DESCRIPTION
Implements a `usePulldownTrigger`, which monitors whether a scroller container has scrolled to the bottom. If there are consecutive scrolling down events occur after that, a callback function will be triggered. This callback function fetches the next page of logs.

Here is a screencast of the work of this PR:

![capture1](https://user-images.githubusercontent.com/1046489/207223571-dcd670f1-a364-4295-9b66-ba035a750100.gif)


This is what happens in case of an server-side error:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/1046489/207220004-cb83b200-7748-4fe2-961e-8cef40cdc9a8.png">
