### PR TITLE
Fix log continuation bug

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,7 @@ with nothing else on the line.
       with a serialization issue.
     * [bugfix] Missing broadcasts upon server-side run save
     * [bugfix] Cache version check
+    * [bugfix] Fix a bug with loading logs with in-progress runs when you have reached the end
 * [0.20.1](https://pypi.org/project/sematic/0.20.1/)
     * [bugfix] Add support for subclasses of ABCMeta
 * [0.20.0](https://pypi.org/project/sematic/0.20.0/)

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -643,11 +643,10 @@ def get_log_lines_from_line_stream(
             # up!
             has_more = still_running
     missing_reason = None if len(lines) > 0 else "No matching log lines."
-    return LogLineResult(
-        more_before=more_before,
-        more_after=has_more,
-        lines=lines,
-        continuation_cursor=Cursor(
+    if not has_more:
+        cursor_token = None
+    elif found_cursor:
+        cursor_token = Cursor(
             source_log_key=source_file,
             # +1: next time we want to start AFTER where we last read
             source_file_line_index=source_file_line_index + 1,
@@ -655,7 +654,19 @@ def get_log_lines_from_line_stream(
             run_id=run_id,
             traversal_had_lines=more_before or len(lines) > 0,
         ).to_token()
-        if has_more
-        else None,
+    else:
+        # didn't find anything new, just use the existing cursor values
+        cursor_token = Cursor(
+            source_log_key=cursor_source_file,
+            source_file_line_index=cursor_line_index,
+            filter_strings=filter_strings,
+            run_id=run_id,
+            traversal_had_lines=cursor_had_more_before,
+        ).to_token()
+    return LogLineResult(
+        more_before=more_before,
+        more_after=has_more,
+        lines=lines,
+        continuation_cursor=cursor_token,
         log_unavailable_reason=missing_reason,
     )

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -643,7 +643,7 @@ def get_log_lines_from_line_stream(
             # up!
             has_more = still_running
     missing_reason = None if len(lines) > 0 else "No matching log lines."
-    
+
     if not has_more:
         cursor_token = None
     elif found_cursor:
@@ -664,7 +664,7 @@ def get_log_lines_from_line_stream(
             run_id=run_id,
             traversal_had_lines=cursor_had_more_before,
         ).to_token()
-    
+
     return LogLineResult(
         more_before=more_before,
         more_after=has_more,

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -643,6 +643,7 @@ def get_log_lines_from_line_stream(
             # up!
             has_more = still_running
     missing_reason = None if len(lines) > 0 else "No matching log lines."
+    
     if not has_more:
         cursor_token = None
     elif found_cursor:
@@ -663,6 +664,7 @@ def get_log_lines_from_line_stream(
             run_id=run_id,
             traversal_had_lines=cursor_had_more_before,
         ).to_token()
+    
     return LogLineResult(
         more_before=more_before,
         more_after=has_more,

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -627,7 +627,6 @@ def test_cancel_non_terminal_futures(
     assert middle_func_callbacks == [
         "_future_did_schedule",
         "_future_did_terminate",
-
         # final resolved here is just because of the weird way in which
         # we cancel from within a func body. We should technically
         # disallow this kind of transition, see:
@@ -654,7 +653,6 @@ def test_cancel_non_terminal_futures(
     assert middle_func_states == [
         FutureState.SCHEDULED,
         FutureState.CANCELED,
-
         # see comment in callback assetions above about why this is here
         FutureState.RESOLVED,
     ]

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 from unittest import mock
 
 # Third-party
@@ -65,7 +65,7 @@ def fake_streamer(to_stream: Iterable[LogLine]) -> Iterable[LogLine]:
         yield line
 
 
-def test_get_log_lines_from_line_stream_does_streaming():
+def tZest_get_log_lines_from_line_stream_does_streaming():
     _streamed_lines.clear()
     max_lines = 200
     result = get_log_lines_from_line_stream(
@@ -113,7 +113,7 @@ def test_get_log_lines_from_line_stream_does_streaming():
     )
 
 
-def test_get_log_lines_from_line_stream_more_after():
+def tZest_get_log_lines_from_line_stream_more_after():
     max_lines = 200
     kwargs = dict(
         cursor_source_file=None,
@@ -145,7 +145,7 @@ def test_get_log_lines_from_line_stream_more_after():
     assert not result.more_after
 
 
-def test_get_log_lines_from_line_stream_filter():
+def tZest_get_log_lines_from_line_stream_filter():
     max_lines = 10
     result = get_log_lines_from_line_stream(
         line_stream=fake_streamer(infinite_logs()),
@@ -219,8 +219,7 @@ def prepare_logs_v1(run_id, text_lines, mock_storage, job_type):
     return prefix
 
 
-def prepare_logs_v2(run_id, text_lines, mock_storage, job_type):
-    break_at_line = 52
+def prepare_logs_v2(run_id, text_lines, mock_storage, job_type, break_at_line=52, emulate_pending_more_lines=False):
     lines_part_1 = text_lines[:break_at_line]
     lines_part_2 = text_lines[break_at_line:]
 
@@ -229,6 +228,9 @@ def prepare_logs_v2(run_id, text_lines, mock_storage, job_type):
     key_part_1 = f"{prefix}12345.log"
     mock_storage.set(key_part_1, log_file_contents_part_1)
 
+    if emulate_pending_more_lines:
+        # act as if the second file hasn't been produced yet
+        return prefix
     log_file_contents_part_2 = bytes("\n".join(lines_part_2), encoding="utf8")
     prefix = log_prefix(run_id, job_type)
     key_part_2 = f"{prefix}12346.log"
@@ -243,7 +245,7 @@ def prepare_logs_v2(run_id, text_lines, mock_storage, job_type):
         prepare_logs_v2,
     ),
 )
-def test_load_non_inline_logs(
+def tZest_load_non_inline_logs(
     test_db, mock_storage: MockStorage, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -326,7 +328,7 @@ def test_load_non_inline_logs(
     )
 
 
-def test_line_stream_from_log_directory(
+def tZest_line_stream_from_log_directory(
     mock_storage: MockStorage, test_db  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -365,7 +367,7 @@ def test_line_stream_from_log_directory(
         prepare_logs_v2,
     ),
 )
-def test_load_inline_logs(
+def tZest_load_inline_logs(
     mock_storage: MockStorage, test_db, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -472,7 +474,7 @@ def test_load_inline_logs(
         prepare_logs_v2,
     ),
 )
-def test_load_log_lines(
+def tZest_load_log_lines(
     mock_storage: MockStorage, test_db, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.CREATED)
@@ -578,3 +580,114 @@ def test_load_log_lines(
         filter_strings=["2", "4"],
     )
     assert result.lines == ["Line 42"]
+
+
+def test_continue_from_end_with_no_new_logs(
+    test_db, mock_storage: MockStorage  # noqa: F811
+):
+    run = make_run(future_state=FutureState.SCHEDULED)
+    save_run(run)
+
+    max_lines = 50
+    break_at_line = 52
+    total_lines = 100
+    text_lines = [line.line for line in finite_logs(total_lines)]
+
+    # Emulate a scenario where:
+    # - 50 lines requested, 52 lines produced
+    # - return lines 0-50
+    # - 50 more lines requested
+    # - return lines 50-52
+    # - lines 52-100 produced
+    # - 50 more lines requested
+    # - lines 52-100 returned
+
+    prepare_logs_v2(run.id, text_lines, mock_storage, JobType.worker, break_at_line=break_at_line, emulate_pending_more_lines=True)
+
+    # 50 lines requested, 50 returned
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=True,
+        cursor_file=None,
+        cursor_line_index=-1,
+        cursor_had_more_before=False,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.continuation_cursor is not None
+    cursor = Cursor.from_token(result.continuation_cursor)
+    assert cursor.traversal_had_lines
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=text_lines[:max_lines],
+        log_unavailable_reason=None,
+    )
+
+    # 50 more lines requested, only 2 more available
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=True,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        cursor_had_more_before=cursor.traversal_had_lines,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.continuation_cursor is not None
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=text_lines[max_lines : break_at_line],  # noqa: E203
+        log_unavailable_reason=None,
+    )
+
+    # 50 more lines requested, no more available
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=True,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        cursor_had_more_before=cursor.traversal_had_lines,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.continuation_cursor is not None
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=[],  # noqa: E203
+        log_unavailable_reason="No matching log lines.",
+    )
+
+    # upload more logs
+    prepare_logs_v2(run.id, text_lines, mock_storage, JobType.worker, break_at_line=break_at_line, emulate_pending_more_lines=False)
+
+    # 50 more lines requested, 48 more available
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=True,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        cursor_had_more_before=cursor.traversal_had_lines,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.continuation_cursor is not None
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=text_lines[break_at_line: total_lines],  # noqa: E203
+        log_unavailable_reason=None,
+    )

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -219,7 +219,14 @@ def prepare_logs_v1(run_id, text_lines, mock_storage, job_type):
     return prefix
 
 
-def prepare_logs_v2(run_id, text_lines, mock_storage, job_type, break_at_line=52, emulate_pending_more_lines=False):
+def prepare_logs_v2(
+    run_id,
+    text_lines,
+    mock_storage,
+    job_type,
+    break_at_line=52,
+    emulate_pending_more_lines=False,
+):
     lines_part_1 = text_lines[:break_at_line]
     lines_part_2 = text_lines[break_at_line:]
 
@@ -602,7 +609,14 @@ def test_continue_from_end_with_no_new_logs(
     # - 50 more lines requested
     # - lines 52-100 returned
 
-    prepare_logs_v2(run.id, text_lines, mock_storage, JobType.worker, break_at_line=break_at_line, emulate_pending_more_lines=True)
+    prepare_logs_v2(
+        run.id,
+        text_lines,
+        mock_storage,
+        JobType.worker,
+        break_at_line=break_at_line,
+        emulate_pending_more_lines=True,
+    )
 
     # 50 lines requested, 50 returned
     result = _load_non_inline_logs(
@@ -643,7 +657,7 @@ def test_continue_from_end_with_no_new_logs(
         continuation_cursor=None,
         more_before=True,
         more_after=True,
-        lines=text_lines[max_lines : break_at_line],  # noqa: E203
+        lines=text_lines[max_lines:break_at_line],  # noqa: E203
         log_unavailable_reason=None,
     )
 
@@ -669,7 +683,14 @@ def test_continue_from_end_with_no_new_logs(
     )
 
     # upload more logs
-    prepare_logs_v2(run.id, text_lines, mock_storage, JobType.worker, break_at_line=break_at_line, emulate_pending_more_lines=False)
+    prepare_logs_v2(
+        run.id,
+        text_lines,
+        mock_storage,
+        JobType.worker,
+        break_at_line=break_at_line,
+        emulate_pending_more_lines=False,
+    )
 
     # 50 more lines requested, 48 more available
     result = _load_non_inline_logs(
@@ -688,6 +709,6 @@ def test_continue_from_end_with_no_new_logs(
         continuation_cursor=None,
         more_before=True,
         more_after=True,
-        lines=text_lines[break_at_line: total_lines],  # noqa: E203
+        lines=text_lines[break_at_line:total_lines],  # noqa: E203
         log_unavailable_reason=None,
     )

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 from unittest import mock
 
 # Third-party
@@ -65,7 +65,7 @@ def fake_streamer(to_stream: Iterable[LogLine]) -> Iterable[LogLine]:
         yield line
 
 
-def tZest_get_log_lines_from_line_stream_does_streaming():
+def test_get_log_lines_from_line_stream_does_streaming():
     _streamed_lines.clear()
     max_lines = 200
     result = get_log_lines_from_line_stream(
@@ -113,7 +113,7 @@ def tZest_get_log_lines_from_line_stream_does_streaming():
     )
 
 
-def tZest_get_log_lines_from_line_stream_more_after():
+def test_get_log_lines_from_line_stream_more_after():
     max_lines = 200
     kwargs = dict(
         cursor_source_file=None,
@@ -145,7 +145,7 @@ def tZest_get_log_lines_from_line_stream_more_after():
     assert not result.more_after
 
 
-def tZest_get_log_lines_from_line_stream_filter():
+def test_get_log_lines_from_line_stream_filter():
     max_lines = 10
     result = get_log_lines_from_line_stream(
         line_stream=fake_streamer(infinite_logs()),
@@ -252,7 +252,7 @@ def prepare_logs_v2(
         prepare_logs_v2,
     ),
 )
-def tZest_load_non_inline_logs(
+def test_load_non_inline_logs(
     test_db, mock_storage: MockStorage, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -335,7 +335,7 @@ def tZest_load_non_inline_logs(
     )
 
 
-def tZest_line_stream_from_log_directory(
+def test_line_stream_from_log_directory(
     mock_storage: MockStorage, test_db  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -374,7 +374,7 @@ def tZest_line_stream_from_log_directory(
         prepare_logs_v2,
     ),
 )
-def tZest_load_inline_logs(
+def test_load_inline_logs(
     mock_storage: MockStorage, test_db, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
@@ -481,7 +481,7 @@ def tZest_load_inline_logs(
         prepare_logs_v2,
     ),
 )
-def tZest_load_log_lines(
+def test_load_log_lines(
     mock_storage: MockStorage, test_db, log_preparation_function  # noqa: F811
 ):
     run = make_run(future_state=FutureState.CREATED)


### PR DESCRIPTION
Fixes a bug where you could get the following behavior:

- run is in progress, you scroll to the end
- you request more logs
- you get back more logs from the beginning

The issue was this:
- the code for constructing the cursor to be returned uses the place where it stopped searching
- if you requested more lines and there were 0 more available, there was no information available about where the code had stopped searching

The fix was to have the code return the same cursor position as it was supposed to start from if it didn't find any log lines (but might still find more later because the run is still running).

Testing
--------
- Added a unit test to emulate this case. Confirmed the test fails with the old code, and passes with the new.
- Tested using `bazel run //sematic/examples/testing_pipeline:__main__ -- --sleep 1000 --cloud --detach` and following the logs on the `do_sleep` func. Used the UI from [this branch](https://github.com/sematic-ai/sematic/pull/391) to confirm that when I asked for more logs after it had reached the end of the available, it gave me the correct next logs.