### PR TITLE
make coverage conditional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,10 @@ jobs:
       - install-ci-pip-deps
       - do-static-analysis
       - non-coverage-tests
-      - coverage-tests
+      - when:
+          condition: true
+          steps:
+            - coverage-tests
       - installation-tests
       - notify-completion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,40 +31,15 @@ commands:
           # For example sqlalchemy requires greenlet only on certain platforms
           name: Freeze requirements
           command: pip-compile --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
-  install-postgres:
-    description: Install PostgreSQL
+  do-static-analysis:
+    description: Do linting and other static analysis
     steps:
       - run:
-          name: Add PG 14 repository
-          command: |
-            sudo apt install wget gnupg
-            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          name: Linting
+          command: python3 -m flake8 --max-line-length=90
       - run:
-          name: Install PostgreSQL
-          command: sudo apt update && sudo apt install postgresql-14
-  setup-bazel:
-    description: |
-      Setup the Bazel build system used for building Android projects
-    steps:
-      - run:
-          name: Add Bazel Apt repository
-          command: |
-            sudo apt install curl gnupg
-            curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-            sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-            echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-      - run:
-          name: Install Bazel from Apt
-          command: sudo apt update && sudo apt install bazel
-  install-java:
-    description: Install JAVA JDK
-    steps:
-      - run:
-          command: |
-            sudo apt install default-jre default-jdk
-            export JAVA_HOME=/usr/lib/jvm/default-java
-
+          name: MyPy
+          command: mypy --version && mypy sematic
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -86,12 +61,7 @@ jobs:
     steps:
       - checkout
       - install-ci-pip-deps
-      - run:
-          name: Linting
-          command: python3 -m flake8 --max-line-length=90
-      - run:
-          name: MyPy
-          command: mypy --version && mypy sematic
+      - do-static-analysis
       - run:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ orbs:
   slack: circleci/slack@4.9.3
   codecov: codecov/codecov@3.2.3
 
+parameters:
+  run_coverage:
+    type: boolean
+    default: false
+
 commands:
   install-postgres:
     description: Install PostgreSQL
@@ -47,6 +52,8 @@ commands:
           command: |
             sudo apt install default-jre default-jdk
             export JAVA_HOME=/usr/lib/jvm/default-java
+
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -89,13 +96,16 @@ jobs:
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel test //sematic/... --test_output=all
       - run:
+          when: << pipeline.parameters.run_coverage >>
           name: Run Coverage Tests
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov
       - run:
+          when: << pipeline.parameters.run_coverage >>
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
       - codecov/upload
+          when: << pipeline.parameters.run_coverage >>
       - run:
           name: Build wheel
           command: make wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,13 @@ parameters:
     default: false
 
 commands:
+  install-ci-pip-deps:
+    description: Install CI pip deps
+    steps:
+      - python/install-packages:
+        pkg-manager: pip
+        app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
+        pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
   install-postgres:
     description: Install PostgreSQL
     steps:
@@ -72,14 +79,8 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
-      # - install-postgres
       - checkout
-      #- setup-bazel
-      #- install-java
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
-          pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+      - install-ci-pip-deps
       - run:
           # This is necessary because some packages have platform-dependent dependencies
           # For example sqlalchemy requires greenlet only on certain platforms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           when: << pipeline.parameters.run_coverage >>
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
-      - codecov/upload
+      - codecov/upload:
           when: << pipeline.parameters.run_coverage >>
       - run:
           name: Build wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,17 @@ commands:
       - run:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
+          when: on_fail
+      # try uploading up to 4 times in a row. Weirdly, Circle doesn't
+      # have a formal retry mechanism:
+      # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
       - codecov/upload
+      - codecov/upload:
+          when: on_fail
+      - codecov/upload:
+          when: on_fail
+      - codecov/upload:
+          when: on_fail
   installation-tests:
     description: Do a test of installing sematic via wheel
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,22 +56,22 @@ commands:
       - run:
           name: Set Up Coverage Tests
           # This assumes pytest is installed via the install-package step above
-          command: do_coverage () { bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov; }
+          command: echo "bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov" > ./do_coverage && chmod +x ./do_coverage
       - run:
           name: Run Coverage Tests
-          command: PYTHONUNBUFFERED=1 do_coverage
+          command: PYTHONUNBUFFERED=1 bash do_coverage
       - run:
           when: on_fail
           name: Retry Coverage Tests (1)
-          command: PYTHONUNBUFFERED=1 do_coverage
+          command: PYTHONUNBUFFERED=1 bash do_coverage
       - run:
           when: on_fail
           name: Retry Coverage Tests (2)
-          command: PYTHONUNBUFFERED=1 do_coverage
+          command: PYTHONUNBUFFERED=1 bash do_coverage
       - run:
           when: on_fail
           name: Retry Coverage Tests (3)
-          command: PYTHONUNBUFFERED=1 do_coverage
+          command: PYTHONUNBUFFERED=1 bash do_coverage
       - run:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,16 +58,7 @@ commands:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
           when: on_fail
-      # try uploading up to 4 times in a row. Weirdly, Circle doesn't
-      # have a formal retry mechanism:
-      # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
       - codecov/upload
-      - codecov/upload:
-          when: on_fail
-      - codecov/upload:
-          when: on_fail
-      - codecov/upload:
-          when: on_fail
   installation-tests:
     description: Do a test of installing sematic via wheel
     steps:
@@ -97,7 +88,16 @@ jobs:
       - when:
           condition: << pipeline.parameters.run_coverage >>
           steps:
+            # try doing coverage up to 4 times in a row. Weirdly, Circle doesn't
+            # have a formal retry mechanism:
+            # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
             - coverage-tests
+            - coverage-tests:
+                when: on_fail
+            - coverage-tests:
+                when: on_fail
+            - coverage-tests:
+                when: on_fail
       - installation-tests
       - notify-completion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,28 @@ commands:
   coverage-tests:
     description: Do tests with coverage and upload coverage results
     steps:
+      # try running coverage up to 4 times in a row. Weirdly, Circle doesn't
+      # have a formal retry mechanism:
+      # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
+      - run:
+          name: Set Up Coverage Tests
+          # This assumes pytest is installed via the install-package step above
+          command: do_coverage () { bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov; }
       - run:
           name: Run Coverage Tests
-          # This assumes pytest is installed via the install-package step above
-          command: PYTHONUNBUFFERED=1 bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov
+          command: PYTHONUNBUFFERED=1 do_coverage
+      - run:
+          when: on_fail
+          name: Retry Coverage Tests (1)
+          command: PYTHONUNBUFFERED=1 do_coverage
+      - run:
+          when: on_fail
+          name: Retry Coverage Tests (2)
+          command: PYTHONUNBUFFERED=1 do_coverage
+      - run:
+          when: on_fail
+          name: Retry Coverage Tests (3)
+          command: PYTHONUNBUFFERED=1 do_coverage
       - run:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
@@ -88,16 +106,7 @@ jobs:
       - when:
           condition: << pipeline.parameters.run_coverage >>
           steps:
-            # try doing coverage up to 4 times in a row. Weirdly, Circle doesn't
-            # have a formal retry mechanism:
-            # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
             - coverage-tests
-            - coverage-tests:
-                when: on_fail
-            - coverage-tests:
-                when: on_fail
-            - coverage-tests:
-                when: on_fail
       - installation-tests
       - notify-completion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - do-static-analysis
       - non-coverage-tests
       - when:
-          condition: true
+          condition: << pipeline.parameters.run_coverage >>
           steps:
             - coverage-tests
       - installation-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,32 +40,16 @@ commands:
       - run:
           name: MyPy
           command: mypy --version && mypy sematic
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
-jobs:
-  build-and-test: # This is the name of the job, feel free to change it to better match what you're trying to do!
-    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
-    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
-    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
-    # Change the version below to your required version of python
-    docker:
-      - image: sematicai/sematic-ci:latest
-    #  - image: cimg/python:3.9.10
-    # Checkout the code as the first step. This is a dedicated CircleCI step.
-    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
-    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
-    # Then run your tests!
-    # CircleCI will report the results back to your VCS provider.
+  non-coverage-tests:
+    description: Do tests without tracking code coverage
     steps:
-      - checkout
-      - install-ci-pip-deps
-      - do-static-analysis
       - run:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel test //sematic/... --test_output=all
+  coverage-tests:
+    description: Do tests with coverage and upload coverage results
+    steps:
       - run:
           name: Run Coverage Tests
           # This assumes pytest is installed via the install-package step above
@@ -74,6 +58,18 @@ jobs:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
       - codecov/upload
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build-and-test:
+    docker:
+      - image: sematicai/sematic-ci:latest
+    steps:
+      - checkout
+      - install-ci-pip-deps
+      - do-static-analysis
+      - non-coverage-tests
+      - coverage-tests
       - run:
           name: Build wheel
           command: make wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,21 @@ commands:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
       - codecov/upload
+  installation-tests:
+    description: Do a test of installing sematic via wheel
+    steps:
+      - run:
+          name: Build wheel
+          command: make wheel
+      - run:
+          name: Test pip install
+          command: bazel run //sematic/tests/integration:test_pip_install
+  notify-completion:
+    description: Send a notification to Slack about job completion
+    steps:
+      - slack/notify:
+          channel: C03CPMXA1QU
+          event: always
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -70,15 +85,8 @@ jobs:
       - do-static-analysis
       - non-coverage-tests
       - coverage-tests
-      - run:
-          name: Build wheel
-          command: make wheel
-      - run:
-          name: Test pip install
-          command: bazel run //sematic/tests/integration:test_pip_install
-      - slack/notify:
-          channel: C03CPMXA1QU
-          event: always
+      - installation-tests
+      - notify-completion
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ commands:
     description: Install CI pip deps
     steps:
       - python/install-packages:
-        pkg-manager: pip
-        app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
-        pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+          pkg-manager: pip
+          app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
+          pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
   install-postgres:
     description: Install PostgreSQL
     steps:
@@ -97,16 +97,13 @@ jobs:
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel test //sematic/... --test_output=all
       - run:
-          when: << pipeline.parameters.run_coverage >>
           name: Run Coverage Tests
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov
       - run:
-          when: << pipeline.parameters.run_coverage >>
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat
-      - codecov/upload:
-          when: << pipeline.parameters.run_coverage >>
+      - codecov/upload
       - run:
           name: Build wheel
           command: make wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ commands:
           pkg-manager: pip
           app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
           pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+      - run:
+          # This is necessary because some packages have platform-dependent dependencies
+          # For example sqlalchemy requires greenlet only on certain platforms
+          name: Freeze requirements
+          command: pip-compile --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
   install-postgres:
     description: Install PostgreSQL
     steps:
@@ -81,11 +86,6 @@ jobs:
     steps:
       - checkout
       - install-ci-pip-deps
-      - run:
-          # This is necessary because some packages have platform-dependent dependencies
-          # For example sqlalchemy requires greenlet only on certain platforms
-          name: Freeze requirements
-          command: pip-compile --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
       - run:
           name: Linting
           command: python3 -m flake8 --max-line-length=90


### PR DESCRIPTION
I did a bunch of cleanup on our Circle CI configuration, but the main motivation was to:
- remove coverage from happening on every PR commit
- enable executing a full build with coverage every night
- add retry to the coverage upload, which is flaky

In addition to these, I also:
- moved a bunch of stuff from steps directly in the job to being commands (which are more re-usable, and makes the overall steps in the job more clear)
- removed some comments and code that look to have been left over from very early attempts at CI setup

Triggering on a schedule is configured only via UI, and not via config file. I already set up [a trigger](https://app.circleci.com/settings/project/github/sematic-ai/sematic/triggers?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fsematic-ai%2Fsematic&triggerSource=&scheduledTriggerId=e195b9eb-6b69-40bc-8a78-744d203306d9&success=true), we can iterate on that separately from this PR though given that it is UI-config only.

Testing
--------
- [Execution of CI](https://app.circleci.com/pipelines/github/sematic-ai/sematic/1368/workflows/0f7b1dd6-f08b-4da3-aba6-2cd5554b50a1) on the branch using the default builds that get triggered by commit pushes. Note that it only took 9min 50s, which Circle tells me is down 63% from our prior runtime
- [Manual trigger setting run_coverage=true](https://app.circleci.com/pipelines/github/sematic-ai/sematic/1378/workflows/d718b100-ae48-4a76-899d-f63b67f14336/jobs/1356). Note that coverage tests get executed