### PR TITLE
Makes RunID links more explicit visually

### DIFF
--- a/sematic/ui/src/components/Notes.tsx
+++ b/sematic/ui/src/components/Notes.tsx
@@ -1,7 +1,6 @@
-import { Box, ButtonBase, Typography, useTheme } from "@mui/material";
-import { useCallback } from "react";
-import { useParams } from "react-router-dom";
-import { usePipelineNavigation } from "../hooks/pipelineHooks";
+import { Box, Typography, useTheme } from "@mui/material";
+import { Link, useParams } from "react-router-dom";
+import { getPipelineUrlPattern } from "../hooks/pipelineHooks";
 import { Note, User } from "../Models";
 import { CopyButton } from "./CopyButton";
 import TimeAgo from "./TimeAgo";
@@ -74,23 +73,13 @@ function RunId(props: {
 
   const { calculatorPath } = useParams();
 
-  const navigate = usePipelineNavigation(calculatorPath!);
-
-  const onClick = useCallback(() => {
-    navigate(runId);
-  }, [navigate, runId]);
-
   return (
     <>
-      <ButtonBase onClick={onClick} disabled={false}>
-        <code
-          style={{
-            fontSize: 12,
-          }}
-        >
+      <Link to={getPipelineUrlPattern(calculatorPath!, runId)} style={
+        {fontSize: '12px'}
+      }>
           {trim ? runId.substring(0, 6) : runId}
-        </code>
-      </ButtonBase>
+      </Link>
       <CopyButton text={runId} message="Copied run ID" />
     </>
   );

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -54,6 +54,10 @@ export function useFetchRuns(runFilters: Filter | undefined = undefined,
     return {isLoaded, isLoading, error, runs: runs?.content, reloadRuns};
 }
 
+export function getPipelineUrlPattern(pipelinePath: string, requestedRootId: string) {
+    return `/pipelines/${pipelinePath}/${requestedRootId}`;
+}
+
 export function usePipelineNavigation(pipelinePath: string) {
     const navigate = useNavigate();
     const { rootId } = useParams();
@@ -63,7 +67,7 @@ export function usePipelineNavigation(pipelinePath: string) {
             return
         }
 
-        navigate(`/pipelines/${pipelinePath}/${requestedRootId}`, {
+        navigate(getPipelineUrlPattern(pipelinePath, requestedRootId), {
             replace
         });
     }, [pipelinePath, rootId, navigate]);


### PR DESCRIPTION
Currently, the links on the notes are not evident enough to be seen as a link. 

This change makes the links more evident.

From 
<img width="312" alt="image" src="https://user-images.githubusercontent.com/1046489/207132004-daec1235-f670-4c7d-bdae-49293a820c99.png">

To:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/1046489/207131932-28569029-e49c-4e0c-9184-d3135f1fe5ef.png">


It used to display as plain text instead of the link because we implemented it that way. Now when we use `<link>,` it will behave more naturally like an HTML native link. We gain the benefit of showing visited states of the link. 
