### PR TITLE
Add back worker url override

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
+  SEMATIC_WORKER_API_ADDRESS: "http://{{ include "sematic-server.fullname" . }}"

--- a/sematic/scheduling/BUILD
+++ b/sematic/scheduling/BUILD
@@ -24,6 +24,7 @@ sematic_py_lib(
     deps = [
         "//sematic:container_images",
         "//sematic/config:config",
+        "//sematic/config:user_settings",
         "//sematic/config:server_settings",
         "//sematic/scheduling:external_job",
         "//sematic/resolvers:resource_requirements",

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -15,6 +15,7 @@ from urllib3.exceptions import ConnectionError
 # Sematic
 from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR, ON_WORKER_ENV_VAR
 from sematic.config.server_settings import ServerSettingsVar, get_server_setting
+from sematic.config.user_settings import UserSettingsVar
 from sematic.container_images import CONTAINER_IMAGE_ENV_VAR
 from sematic.resolvers.resource_requirements import (
     KUBERNETES_SECRET_NAME,
@@ -542,10 +543,21 @@ def _schedule_kubernetes_job(
     environment_vars: Dict[str, str],
     namespace: str,
     service_account: str = DEFAULT_WORKER_SERVICE_ACCOUNT,
+    api_address_override: Optional[str] = None,
     resource_requirements: Optional[ResourceRequirements] = None,
     args: Optional[List[str]] = None,
 ):
     load_kube_config()
+
+    # clone so we can modify without changing the original
+    environment_vars = dict(environment_vars)
+
+    if api_address_override is not None:
+        logger.warning(f"\n\n\nBLUEBERRY: '{api_address_override}'")
+        environment_vars[
+            UserSettingsVar.SEMATIC_API_ADDRESS.value
+        ] = api_address_override
+
     args = args if args is not None else []
     node_selector = {}
     resource_requests = {}
@@ -668,6 +680,9 @@ def schedule_resolution_job(
     service_account = get_server_setting(
         ServerSettingsVar.SEMATIC_WORKER_KUBERNETES_SA, DEFAULT_WORKER_SERVICE_ACCOUNT
     )
+    api_address_override = get_server_setting(
+        ServerSettingsVar.SEMATIC_WORKER_API_ADDRESS, None
+    )
 
     external_job = KubernetesExternalJob.new(
         try_number=0,
@@ -692,6 +707,7 @@ def schedule_resolution_job(
         environment_vars=user_settings,
         namespace=namespace,
         service_account=service_account,
+        api_address_override=api_address_override,
         resource_requirements=RESOLUTION_RESOURCE_REQUIREMENTS,
         args=args,
     )
@@ -711,6 +727,10 @@ def schedule_run_job(
     service_account = get_server_setting(
         ServerSettingsVar.SEMATIC_WORKER_KUBERNETES_SA, DEFAULT_WORKER_SERVICE_ACCOUNT
     )
+    api_address_override = get_server_setting(
+        ServerSettingsVar.SEMATIC_WORKER_API_ADDRESS, None
+    )
+
     external_job = KubernetesExternalJob.new(
         try_number, run_id, namespace, JobType.worker
     )
@@ -725,6 +745,7 @@ def schedule_run_job(
         environment_vars=user_settings,
         namespace=namespace,
         service_account=service_account,
+        api_address_override=api_address_override,
         resource_requirements=resource_requirements,
         args=args,
     )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -553,7 +553,6 @@ def _schedule_kubernetes_job(
     environment_vars = dict(environment_vars)
 
     if api_address_override is not None:
-        logger.warning(f"\n\n\nBLUEBERRY: '{api_address_override}'")
         environment_vars[
             UserSettingsVar.SEMATIC_API_ADDRESS.value
         ] = api_address_override


### PR DESCRIPTION
There was a feature that would allow you to configure the workers to use a different URL to talk to the server than the end-users did. This is useful if your networking setup is such that user machines will hit some sort of proxy that can't be used in-cluster.

The old setting was left in as a server setting, and the docs still reference it. It just wasn't hooked up to anything. So this PR just goes the last mile to hook it back up--this time functioning fully server-side rather than relying on the configuration to be set by the users. Luckily, in-cluster, you can just use the k8s built-in DNS to refer to the API via its k8s service name. This means that for helm deployments, we can set this config automatically.

Testing
-------
Deployed this code to dev1 using the helm chart. Then for my client code, modified the API client to print out the URLs it constructed. Executed the testing pipeline, confirmed the URLs were using the k8s service name, and successfully. See [run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/90d5147363e24910bb85a24aa7e5641c) and its logs.