### PR TITLE
Future cache key module

### DIFF
--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -171,6 +171,12 @@ class AbstractFuture(abc.ABC):
             f"nested_id={nested_id}, value={self.value})"
         )
 
+    def is_root_future(self):
+        """
+        Returns whether this is the root Future of a pipeline Resolution.
+        """
+        return self.parent_future is None
+
 
 def make_future_id() -> str:
     return uuid.uuid4().hex

--- a/sematic/caching/BUILD
+++ b/sematic/caching/BUILD
@@ -18,3 +18,13 @@ sematic_py_lib(
         "//sematic/types:serialization",
     ],
 )
+
+sematic_py_lib(
+    name = "git",
+    srcs = ["git.py"],
+    pip_deps = [],
+    deps = [
+        "//sematic:abstract_future",
+        "//sematic/utils:git",
+    ],
+)

--- a/sematic/caching/BUILD
+++ b/sematic/caching/BUILD
@@ -1,0 +1,20 @@
+sematic_py_lib(
+    name = "init",
+    srcs = ["__init__.py"],
+    pip_deps = [],
+    deps = [
+        ":caching",
+        "//sematic:abstract_future",
+        "//sematic/types:serialization",
+    ],
+)
+
+sematic_py_lib(
+    name = "caching",
+    srcs = ["caching.py"],
+    pip_deps = [],
+    deps = [
+        "//sematic:abstract_future",
+        "//sematic/types:serialization",
+    ],
+)

--- a/sematic/caching/BUILD
+++ b/sematic/caching/BUILD
@@ -6,6 +6,7 @@ sematic_py_lib(
         ":caching",
         "//sematic:abstract_future",
         "//sematic/types:serialization",
+        "//sematic/utils:hashing",
     ],
 )
 
@@ -16,6 +17,7 @@ sematic_py_lib(
     deps = [
         "//sematic:abstract_future",
         "//sematic/types:serialization",
+        "//sematic/utils:hashing",
     ],
 )
 

--- a/sematic/caching/__init__.py
+++ b/sematic/caching/__init__.py
@@ -1,0 +1,6 @@
+# Sematic
+from sematic.caching.caching import (  # noqa: F401
+    CacheNamespace,
+    CacheNamespaceCallable,
+    get_future_cache_key,
+)

--- a/sematic/caching/__init__.py
+++ b/sematic/caching/__init__.py
@@ -3,4 +3,5 @@ from sematic.caching.caching import (  # noqa: F401
     CacheNamespace,
     CacheNamespaceCallable,
     get_future_cache_key,
+    resolve_cache_namespace,
 )

--- a/sematic/caching/caching.py
+++ b/sematic/caching/caching.py
@@ -1,0 +1,106 @@
+# Standard Library
+import hashlib
+import json
+import logging
+from typing import Any, Callable, Optional, Union
+
+# Sematic
+from sematic.abstract_future import AbstractFuture
+from sematic.types.serialization import value_to_json_encodable
+
+CacheNamespaceCallable = Callable[[AbstractFuture], str]
+CacheNamespace = Optional[Union[str, CacheNamespaceCallable]]
+
+logger = logging.getLogger(__name__)
+
+
+def get_future_cache_key(
+    cache_namespace: CacheNamespace, future: AbstractFuture
+) -> str:
+    """
+    Generates a cache key that can be used to uniquely identify the output value of a
+    deterministic function.
+
+    Parameters
+    ----------
+    cache_namespace: CacheNamespace
+        A string or a `Callable` which returns a string, which is used as the cache key
+        namespace.
+    future: AbstractFuture
+        The future for which to calculate the cache key.
+
+    Returns
+    -------
+    A cache key string that can be used to uniquely identify the output value of a
+    deterministic function.
+    """
+    # this may raise, so do it early
+    cache_namespace = _resolve_namespace(cache_namespace=cache_namespace, future=future)
+
+    func_fqpn = future.calculator.get_func_fqpn()  # type: ignore # noqa: ignore
+    output_type_repr = repr(future.calculator.output_type)
+    input_args_hash = _get_input_args_hash(future)
+
+    hash_base = f"{cache_namespace}|{func_fqpn}|{output_type_repr}|{input_args_hash}"
+    cache_key = _hash(hash_base)
+
+    logger.debug("Generated cache key `%s` from base: %s", cache_key, hash_base)
+    return cache_key
+
+
+def _get_input_args_hash(future: AbstractFuture) -> str:
+    # 1. we want to avoid constructing a large string containing all the serialized values
+    # and then hashing that, because its memory footprint is potentially very large, and
+    # because we would be duplicating memory usage between the individual value
+    # representations and the concatenated result
+    # 2. the consequence of applying the hash function multiple times is acceptable
+    # 3. we also push the application of the hash to each respective serialized value in
+    # order to avoid keeping references to the resulting strings, so that they can be
+    # deallocated quickly
+    # TODO #403: do these things in a sustainable and efficient way
+    serialized_input_arg_tuples = []
+    for name, value in future.kwargs.items():
+        json_value = value_to_json_encodable(value, future.calculator.input_types[name])
+        hashed_value = _hash(json.dumps(json_value, sort_keys=True))
+        serialized_input_arg_tuples.append((name, hashed_value))
+
+    # we rely on the registered value serializers to provide
+    # respective recursive deterministic sorted representations
+    return _hash(str(sorted(serialized_input_arg_tuples)))
+
+
+def _resolve_namespace(cache_namespace: CacheNamespace, future: AbstractFuture) -> str:
+    """
+    Returns a string cache namespace from a `CacheNamespace`, executing the `Callable`
+    instances of this type, if it is the case.
+    """
+    if cache_namespace is None:
+        raise ValueError("`cache_namespace` cannot be None!")
+
+    if isinstance(cache_namespace, str):
+        return str(cache_namespace)
+
+    logger.debug("Calling cache_namespace %s", cache_namespace)
+
+    # TODO: ponder async execution with a timeout
+    namespace = str(cache_namespace(future))
+
+    logger.debug(
+        "Finished calling cache_namespace %s with result: %s",
+        cache_namespace,
+        namespace,
+    )
+
+    return namespace
+
+
+def _hash(value: Any) -> str:
+    """
+    Utility method for performing the actual hashing of a value.
+    """
+    # we don't need a cryptographic hash, but we do need a fast hash
+    # unfortunately the builtin hash is initialized with a random salt seed on program
+    # initialization, and this cannot be reset,
+    # so we use sha1 for now
+    # https://automationrhapsody.com/md5-sha-1-sha-256-sha-512-speed-performance/
+    return hashlib.sha1(str(value).encode("utf-8")).hexdigest()

--- a/sematic/caching/caching.py
+++ b/sematic/caching/caching.py
@@ -41,12 +41,23 @@ def resolve_cache_namespace(
     Returns
     -------
     A string of maximum length 50.
+
+    Raises
+    ------
+    ValueError:
+        If `cache_namespace` is `None` or if `cache_namespace` is a `Callable` and
+        `root_future` is not an actual root `Future`.
     """
     if cache_namespace is None:
         raise ValueError("`cache_namespace` cannot be None!")
 
     if isinstance(cache_namespace, str):
         return _truncate_namespace(cache_namespace)
+
+    if root_future is None:
+        raise ValueError("`root_future` cannot be None!")
+    if not root_future.is_root_future():
+        raise ValueError("`root_future` must be a Resolution root Future!")
 
     logger.debug("Calling cache_namespace %s", cache_namespace)
 
@@ -66,6 +77,11 @@ def get_future_cache_key(cache_namespace: str, future: AbstractFuture) -> str:
     """
     Generates a cache key that can be used to uniquely identify the output value of a
     deterministic function.
+
+    The cache key is under the form "<SHA1>_<cache_namespace>". The first part is a hash
+    over the `Future` func fully qualified path name, its output type, and its effective
+    input arguments names, types, and values. Consequently, modifying any of these between
+    calls to the func will modify the resulting cache key, and result in a miss.
 
     Parameters
     ----------

--- a/sematic/caching/caching.py
+++ b/sematic/caching/caching.py
@@ -1,4 +1,5 @@
 # Standard Library
+import json
 import logging
 from typing import Callable, Optional, Union
 
@@ -123,7 +124,7 @@ def _get_input_args_hash(future: AbstractFuture) -> str:
     # order to avoid keeping references to the resulting strings, so that they can be
     # deallocated quickly
     # TODO #403: do these things in a sustainable and efficient way
-    serialized_input_arg_tuples = []
+    input_arg_hashes = {}
     for name, value in future.kwargs.items():
 
         type_ = future.calculator.input_types[name]
@@ -134,8 +135,10 @@ def _get_input_args_hash(future: AbstractFuture) -> str:
         hashed_value = get_value_and_type_sha1_digest(
             value_serialization, type_serialization, json_summary
         )
-        serialized_input_arg_tuples.append((name, hashed_value))
+        input_arg_hashes[name] = hashed_value
 
     # we rely on the registered value serializers to provide
     # respective recursive deterministic sorted representations
-    return get_str_sha1_digest(str(sorted(serialized_input_arg_tuples)))
+    input_arg_hashes_dump = json.dumps(input_arg_hashes, sort_keys=True, default=str)
+
+    return get_str_sha1_digest(input_arg_hashes_dump)

--- a/sematic/caching/caching.py
+++ b/sematic/caching/caching.py
@@ -1,12 +1,17 @@
 # Standard Library
-import hashlib
-import json
 import logging
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional, Union
 
 # Sematic
 from sematic.abstract_future import AbstractFuture
-from sematic.types.serialization import value_to_json_encodable
+from sematic.types.serialization import (
+    get_json_encodable_summary,
+    type_to_json_encodable,
+    value_to_json_encodable,
+)
+from sematic.utils.hashing import get_str_sha1_digest, get_value_and_type_sha1_digest
+
+CACHE_NAMESPACE_MAX_LENGTH = 50
 
 CacheNamespaceCallable = Callable[[AbstractFuture], str]
 CacheNamespace = Optional[Union[str, CacheNamespaceCallable]]
@@ -14,38 +19,98 @@ CacheNamespace = Optional[Union[str, CacheNamespaceCallable]]
 logger = logging.getLogger(__name__)
 
 
-def get_future_cache_key(
-    cache_namespace: CacheNamespace, future: AbstractFuture
+def resolve_cache_namespace(
+    cache_namespace: CacheNamespace, root_future: AbstractFuture
 ) -> str:
     """
-    Generates a cache key that can be used to uniquely identify the output value of a
-    deterministic function.
+    Returns a string cache namespace from a `CacheNamespace`, executing the `Callable`
+    instances of this type, if it is the case.
+
+    The string representation is truncated to 50 characters, in order to be a
+    human-readable part of the final cache key for each `Future` execution.
 
     Parameters
     ----------
     cache_namespace: CacheNamespace
         A string or a `Callable` which returns a string, which is used as the cache key
         namespace.
+    root_future: AbstractFuture
+        The root Future of the pipeline for which to look up the code git commit status.
+
+    Returns
+    -------
+    A string of maximum length 50.
+    """
+    if cache_namespace is None:
+        raise ValueError("`cache_namespace` cannot be None!")
+
+    if isinstance(cache_namespace, str):
+        return _truncate_namespace(cache_namespace)
+
+    logger.debug("Calling cache_namespace %s", cache_namespace)
+
+    # TODO: ponder async execution with a timeout
+    namespace = str(cache_namespace(root_future))
+
+    logger.debug(
+        "Finished calling cache_namespace %s with result: %s",
+        cache_namespace,
+        namespace,
+    )
+
+    return _truncate_namespace(namespace)
+
+
+def get_future_cache_key(cache_namespace: str, future: AbstractFuture) -> str:
+    """
+    Generates a cache key that can be used to uniquely identify the output value of a
+    deterministic function.
+
+    Parameters
+    ----------
+    cache_namespace: str
+        A string which is used as the cache key namespace.
     future: AbstractFuture
         The future for which to calculate the cache key.
 
     Returns
     -------
     A cache key string that can be used to uniquely identify the output value of a
-    deterministic function.
+    deterministic function. It is under the form "<SHA1>_<cache_namespace>".
     """
-    # this may raise, so do it early
-    cache_namespace = _resolve_namespace(cache_namespace=cache_namespace, future=future)
+    # even if the type hint does not include Optional,
+    # this code is critical and must be properly sanitized
+    if cache_namespace is None:
+        raise ValueError("`cache_namespace` cannot be None!")
 
-    func_fqpn = future.calculator.get_func_fqpn()  # type: ignore # noqa: ignore
+    func_fqpn = future.calculator.get_func_fqpn()  # type: ignore
     output_type_repr = repr(future.calculator.output_type)
     input_args_hash = _get_input_args_hash(future)
 
-    hash_base = f"{cache_namespace}|{func_fqpn}|{output_type_repr}|{input_args_hash}"
-    cache_key = _hash(hash_base)
+    hash_base = f"{func_fqpn}|{output_type_repr}|{input_args_hash}"
+    hashed_base = get_str_sha1_digest(hash_base)
+    cache_key = f"{hashed_base}_{cache_namespace}"
 
     logger.debug("Generated cache key `%s` from base: %s", cache_key, hash_base)
     return cache_key
+
+
+def _truncate_namespace(
+    namespace: str, max_length: int = CACHE_NAMESPACE_MAX_LENGTH
+) -> str:
+    """
+    Ensures that the namespace is right-truncated to the specified length, and logs a
+    warning message if it was actually modified.
+    """
+    if len(namespace) <= max_length:
+        return namespace
+
+    namespace = namespace[:max_length]
+    logger.warning(
+        "Truncated the cache namespace to %s characters: %s", max_length, namespace
+    )
+
+    return namespace
 
 
 def _get_input_args_hash(future: AbstractFuture) -> str:
@@ -60,47 +125,17 @@ def _get_input_args_hash(future: AbstractFuture) -> str:
     # TODO #403: do these things in a sustainable and efficient way
     serialized_input_arg_tuples = []
     for name, value in future.kwargs.items():
-        json_value = value_to_json_encodable(value, future.calculator.input_types[name])
-        hashed_value = _hash(json.dumps(json_value, sort_keys=True))
+
+        type_ = future.calculator.input_types[name]
+        type_serialization = type_to_json_encodable(type_)
+        value_serialization = value_to_json_encodable(value, type_)
+        json_summary = get_json_encodable_summary(value, type_)
+
+        hashed_value = get_value_and_type_sha1_digest(
+            value_serialization, type_serialization, json_summary
+        )
         serialized_input_arg_tuples.append((name, hashed_value))
 
     # we rely on the registered value serializers to provide
     # respective recursive deterministic sorted representations
-    return _hash(str(sorted(serialized_input_arg_tuples)))
-
-
-def _resolve_namespace(cache_namespace: CacheNamespace, future: AbstractFuture) -> str:
-    """
-    Returns a string cache namespace from a `CacheNamespace`, executing the `Callable`
-    instances of this type, if it is the case.
-    """
-    if cache_namespace is None:
-        raise ValueError("`cache_namespace` cannot be None!")
-
-    if isinstance(cache_namespace, str):
-        return str(cache_namespace)
-
-    logger.debug("Calling cache_namespace %s", cache_namespace)
-
-    # TODO: ponder async execution with a timeout
-    namespace = str(cache_namespace(future))
-
-    logger.debug(
-        "Finished calling cache_namespace %s with result: %s",
-        cache_namespace,
-        namespace,
-    )
-
-    return namespace
-
-
-def _hash(value: Any) -> str:
-    """
-    Utility method for performing the actual hashing of a value.
-    """
-    # we don't need a cryptographic hash, but we do need a fast hash
-    # unfortunately the builtin hash is initialized with a random salt seed on program
-    # initialization, and this cannot be reset,
-    # so we use sha1 for now
-    # https://automationrhapsody.com/md5-sha-1-sha-256-sha-512-speed-performance/
-    return hashlib.sha1(str(value).encode("utf-8")).hexdigest()
+    return get_str_sha1_digest(str(sorted(serialized_input_arg_tuples)))

--- a/sematic/caching/git.py
+++ b/sematic/caching/git.py
@@ -3,10 +3,14 @@ from sematic.abstract_future import AbstractFuture
 from sematic.utils.git import get_git_info
 
 
-def get_git_sha_caching_namespace(future: AbstractFuture) -> str:
+def get_git_sha_caching_namespace(root_future: AbstractFuture) -> str:
     """
-    Returns a caching namespace based on the specified Future func's source code git
-    commit SHA.
+    Returns a caching namespace based on the specified pipeline root Future func's source
+    code git commit SHA.
+
+    Must only be used when launching the Resolution from a development environment that is
+    versioned by git! Otherwise, this will raise an exception, and the cache will not be
+    used!
 
     When using this caching namespace, switching to another commit or locally editing the
     code would result in cache invalidation.
@@ -17,18 +21,22 @@ def get_git_sha_caching_namespace(future: AbstractFuture) -> str:
 
     Parameters
     ----------
-    future: AbstractFuture
-        The Future for which to look up the code git commit status.
+    root_future: AbstractFuture
+        The root Future of the pipeline for which to look up the code git commit status.
 
     Returns
     -------
-    A caching namespace which contains the git commit SHA and the dirty code value, or a
-    message saying the git info could not be sourced, in case this is not executed from a
-    development environment.
+    A caching namespace which contains the git commit SHA and the dirty code value.
+
+    Raises
+    ------
+    ValueError
+        If the git information could not be found.
     """
-    git_info = get_git_info(future.calculator.func)  # type: ignore
+    git_info = get_git_info(root_future.calculator.func)  # type: ignore
 
     if git_info is None:
-        return "no git commit info"
+        func_fqpn = root_future.calculator.get_func_fqpn()  # type: ignore
+        raise ValueError(f"Could not get git information for {func_fqpn}")
 
     return f"{git_info.commit}+{git_info.dirty}"

--- a/sematic/caching/git.py
+++ b/sematic/caching/git.py
@@ -3,14 +3,14 @@ from sematic.abstract_future import AbstractFuture
 from sematic.utils.git import get_git_info
 
 
-def get_git_sha_caching_namespace(root_future: AbstractFuture) -> str:
+def get_git_sha_caching_namespace(future: AbstractFuture) -> str:
     """
-    Returns a caching namespace based on the specified pipeline root Future func's source
-    code git commit SHA.
+    Returns a caching namespace based on the specified `Future` func's source code git
+    commit SHA.
 
-    Must only be used when launching the Resolution from a development environment that is
-    versioned by git! Otherwise, this will raise an exception, and the cache will not be
-    used!
+    Must only be used when launching the `Resolution` from a development environment that
+    is versioned by git! Otherwise, this will raise an exception, and the cache will not
+    be used!
 
     When using this caching namespace, switching to another commit or locally editing the
     code would result in cache invalidation.
@@ -21,8 +21,8 @@ def get_git_sha_caching_namespace(root_future: AbstractFuture) -> str:
 
     Parameters
     ----------
-    root_future: AbstractFuture
-        The root Future of the pipeline for which to look up the code git commit status.
+    future: AbstractFuture
+        The `Future` func for which to look up the code git commit status.
 
     Returns
     -------
@@ -33,10 +33,10 @@ def get_git_sha_caching_namespace(root_future: AbstractFuture) -> str:
     ValueError
         If the git information could not be found.
     """
-    git_info = get_git_info(root_future.calculator.func)  # type: ignore
+    git_info = get_git_info(future.calculator.func)  # type: ignore
 
     if git_info is None:
-        func_fqpn = root_future.calculator.get_func_fqpn()  # type: ignore
+        func_fqpn = future.calculator.get_func_fqpn()  # type: ignore
         raise ValueError(f"Could not get git information for {func_fqpn}")
 
     return f"{git_info.commit}+{git_info.dirty}"

--- a/sematic/caching/git.py
+++ b/sematic/caching/git.py
@@ -1,0 +1,34 @@
+# Sematic
+from sematic.abstract_future import AbstractFuture
+from sematic.utils.git import get_git_info
+
+
+def get_git_sha_caching_namespace(future: AbstractFuture) -> str:
+    """
+    Returns a caching namespace based on the specified Future func's source code git
+    commit SHA.
+
+    When using this caching namespace, switching to another commit or locally editing the
+    code would result in cache invalidation.
+
+    Successive code edits will not invalidate the cache, as the dirty code status is only
+    compared against the clean commit, and the actual contents of the code edits is not
+    considered.
+
+    Parameters
+    ----------
+    future: AbstractFuture
+        The Future for which to look up the code git commit status.
+
+    Returns
+    -------
+    A caching namespace which contains the git commit SHA and the dirty code value, or a
+    message saying the git info could not be sourced, in case this is not executed from a
+    development environment.
+    """
+    git_info = get_git_info(future.calculator.func)  # type: ignore
+
+    if git_info is None:
+        return "no git commit info"
+
+    return f"{git_info.commit}+{git_info.dirty}"

--- a/sematic/caching/tests/BUILD
+++ b/sematic/caching/tests/BUILD
@@ -1,0 +1,11 @@
+pytest_test(
+    name = "test_caching",
+    srcs = ["test_caching.py"],
+    pip_deps = [],
+    deps = [
+        "//sematic:abstract_future",
+        "//sematic:init",
+        "//sematic/caching:caching",
+        "//sematic/types:serialization",
+    ],
+)

--- a/sematic/caching/tests/test_caching.py
+++ b/sematic/caching/tests/test_caching.py
@@ -1,5 +1,6 @@
 # Standard Library
 from typing import Dict
+from unittest import mock
 
 # Third-party
 import pytest
@@ -27,6 +28,14 @@ def my_other_pipeline(a: int) -> int:
     return a
 
 
+def my_namespace(_: AbstractFuture) -> str:
+    return "my_namespace"
+
+
+def my_other_namespace(_: AbstractFuture) -> str:
+    return "my_other_namespace"
+
+
 def test_none_namespace():
     with pytest.raises(ValueError, match="cannot be None"):
         get_future_cache_key(None, my_pipeline(1, {"test_key": 2}))
@@ -46,14 +55,8 @@ def test_resolve_namespace_str_happy_path():
 
 
 def test_resolve_namespace_callable_happy_path():
-    def my_namespace(_: AbstractFuture) -> str:
-        return "my_namespace"
-
     actual = resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
     assert actual == "my_namespace"
-
-    def my_other_namespace(_: AbstractFuture) -> str:
-        return "my_other_namespace"
 
     actual = resolve_cache_namespace(
         my_other_namespace, my_pipeline(1, {"test_key": 2})
@@ -70,10 +73,12 @@ def test_resolve_namespace_str_truncated():
 
 
 def test_resolve_namespace_callable_truncated():
-    def my_namespace(_: AbstractFuture) -> str:
+    def my_custom_namespace(_: AbstractFuture) -> str:
         return "01234567890123456789012345678901234567890123456789extra"
 
-    actual = resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
+    actual = resolve_cache_namespace(
+        my_custom_namespace, my_pipeline(1, {"test_key": 2})
+    )
     assert actual == "01234567890123456789012345678901234567890123456789"
 
 
@@ -98,17 +103,33 @@ def test_custom_resolve_namespace():
     assert actual == "my_other_namespace"
 
 
+def test_invalid_args_resolve_namespace():
+    with pytest.raises(ValueError, match="cannot be None"):
+        resolve_cache_namespace(None, my_pipeline(1, {"test_key": 2}))
+
+    actual = resolve_cache_namespace("my_namespace", None)
+    assert actual == "my_namespace"
+
+    with pytest.raises(ValueError, match="cannot be None"):
+        resolve_cache_namespace(my_namespace, None)
+
+    nested_future = mock.MagicMock()
+    nested_future.is_root_future.return_value = False
+    with pytest.raises(ValueError, match="must be a Resolution root Future"):
+        resolve_cache_namespace(my_namespace, nested_future)
+
+
 def test_malformed_resolve_namespace():
-    def my_namespace() -> str:
+    def my_malformed_namespace() -> str:
         return "my_namespace"
 
     with pytest.raises(TypeError, match="takes 0 positional arguments but 1 was given"):
-        resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
+        resolve_cache_namespace(my_malformed_namespace, my_pipeline(1, {"test_key": 2}))
 
 
 def test_resolve_namespace_error_raised():
-    def my_namespace(_: AbstractFuture) -> str:
+    def my_error_namespace(_: AbstractFuture) -> str:
         raise ValueError("test error")
 
     with pytest.raises(ValueError, match="test error"):
-        resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
+        resolve_cache_namespace(my_error_namespace, my_pipeline(1, {"test_key": 2}))

--- a/sematic/caching/tests/test_caching.py
+++ b/sematic/caching/tests/test_caching.py
@@ -7,15 +7,12 @@ import pytest
 # Sematic
 from sematic import func
 from sematic.abstract_future import AbstractFuture
-from sematic.caching.caching import _hash, get_future_cache_key
+from sematic.caching.caching import get_future_cache_key, resolve_cache_namespace
 
 # these values were calculated by hand on paper to validate the algorithm
 # (they were all correct on the first try)
-HASH_1 = "356a192b7913b04c54574d18c28d46e6395428ab"
-HASH_A = "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8"
-MY_NAMESPACE_CACHE_KEY = "512706a76ddb96c9992c690a14a44a0ff733462f"
-MY_OTHER_NAMESPACE_CACHE_KEY = "b7de1f83e736134df188d99683f450a45c611e19"
-MY_CUSTOM_OTHER_NAMESPACE_CACHE_KEY = "de9cc62d0da2c5822048959687e7eacd72c287a0"
+MY_CACHE_KEY = "3056b3ba8b7aea0c5821168fdc5b6ddde7bb9b14_my_namespace"
+MY_OTHER_CACHE_KEY = "3056b3ba8b7aea0c5821168fdc5b6ddde7bb9b14_my_other_namespace"
 
 
 @func
@@ -30,39 +27,57 @@ def my_other_pipeline(a: int) -> int:
     return a
 
 
-def test_hash():
-    assert _hash(1) == HASH_1
-    assert _hash("a") == HASH_A
-
-
 def test_none_namespace():
     with pytest.raises(ValueError, match="cannot be None"):
         get_future_cache_key(None, my_pipeline(1, {"test_key": 2}))
 
 
-def test_str_namespace_happy_path():
+def test_namespace_str_happy_path():
     actual = get_future_cache_key("my_namespace", my_pipeline(1, {"test_key": 2}))
-    assert actual == MY_NAMESPACE_CACHE_KEY
+    assert actual == MY_CACHE_KEY
 
     actual = get_future_cache_key("my_other_namespace", my_pipeline(1, {"test_key": 2}))
-    assert actual == MY_OTHER_NAMESPACE_CACHE_KEY
+    assert actual == MY_OTHER_CACHE_KEY
 
 
-def test_callable_namespace_happy_path():
+def test_resolve_namespace_str_happy_path():
+    actual = resolve_cache_namespace("my_namespace", my_pipeline(1, {"test_key": 2}))
+    assert actual == "my_namespace"
+
+
+def test_resolve_namespace_callable_happy_path():
     def my_namespace(_: AbstractFuture) -> str:
         return "my_namespace"
 
-    actual = get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))
-    assert actual == MY_NAMESPACE_CACHE_KEY
+    actual = resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
+    assert actual == "my_namespace"
 
     def my_other_namespace(_: AbstractFuture) -> str:
         return "my_other_namespace"
 
-    actual = get_future_cache_key(my_other_namespace, my_pipeline(1, {"test_key": 2}))
-    assert actual == MY_OTHER_NAMESPACE_CACHE_KEY
+    actual = resolve_cache_namespace(
+        my_other_namespace, my_pipeline(1, {"test_key": 2})
+    )
+    assert actual == "my_other_namespace"
 
 
-def test_custom_callable_namespace():
+def test_resolve_namespace_str_truncated():
+    actual = resolve_cache_namespace(
+        "01234567890123456789012345678901234567890123456789extra",
+        my_pipeline(1, {"test_key": 2}),
+    )
+    assert actual == "01234567890123456789012345678901234567890123456789"
+
+
+def test_resolve_namespace_callable_truncated():
+    def my_namespace(_: AbstractFuture) -> str:
+        return "01234567890123456789012345678901234567890123456789extra"
+
+    actual = resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
+    assert actual == "01234567890123456789012345678901234567890123456789"
+
+
+def test_custom_resolve_namespace():
     def my_custom_namespace(future: AbstractFuture) -> str:
         fqpn = future.calculator.get_func_fqpn()  # type: ignore # noqa: ignore
 
@@ -74,24 +89,26 @@ def test_custom_callable_namespace():
 
         return "whatever"
 
-    actual = get_future_cache_key(my_custom_namespace, my_pipeline(1, {"test_key": 2}))
-    assert actual == MY_NAMESPACE_CACHE_KEY
+    actual = resolve_cache_namespace(
+        my_custom_namespace, my_pipeline(1, {"test_key": 2})
+    )
+    assert actual == "my_namespace"
 
-    actual = get_future_cache_key(my_custom_namespace, my_other_pipeline(1))
-    assert actual == MY_CUSTOM_OTHER_NAMESPACE_CACHE_KEY
+    actual = resolve_cache_namespace(my_custom_namespace, my_other_pipeline(1))
+    assert actual == "my_other_namespace"
 
 
-def test_malformed_callable_namespace():
+def test_malformed_resolve_namespace():
     def my_namespace() -> str:
         return "my_namespace"
 
     with pytest.raises(TypeError, match="takes 0 positional arguments but 1 was given"):
-        get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))
+        resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))
 
 
-def test_callable_namespace_failure_handled():
+def test_resolve_namespace_error_raised():
     def my_namespace(_: AbstractFuture) -> str:
         raise ValueError("test error")
 
     with pytest.raises(ValueError, match="test error"):
-        get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))
+        resolve_cache_namespace(my_namespace, my_pipeline(1, {"test_key": 2}))

--- a/sematic/caching/tests/test_caching.py
+++ b/sematic/caching/tests/test_caching.py
@@ -1,0 +1,97 @@
+# Standard Library
+from typing import Dict
+
+# Third-party
+import pytest
+
+# Sematic
+from sematic import func
+from sematic.abstract_future import AbstractFuture
+from sematic.caching.caching import _hash, get_future_cache_key
+
+# these values were calculated by hand on paper to validate the algorithm
+# (they were all correct on the first try)
+HASH_1 = "356a192b7913b04c54574d18c28d46e6395428ab"
+HASH_A = "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8"
+MY_NAMESPACE_CACHE_KEY = "512706a76ddb96c9992c690a14a44a0ff733462f"
+MY_OTHER_NAMESPACE_CACHE_KEY = "b7de1f83e736134df188d99683f450a45c611e19"
+MY_CUSTOM_OTHER_NAMESPACE_CACHE_KEY = "de9cc62d0da2c5822048959687e7eacd72c287a0"
+
+
+@func
+def my_pipeline(a: int, b: Dict[str, int]) -> int:
+    # a dict arg must be included ^ to check that we correctly cover
+    # potential "TypeError: unhashable type" errors
+    return a + b["test_key"]
+
+
+@func
+def my_other_pipeline(a: int) -> int:
+    return a
+
+
+def test_hash():
+    assert _hash(1) == HASH_1
+    assert _hash("a") == HASH_A
+
+
+def test_none_namespace():
+    with pytest.raises(ValueError, match="cannot be None"):
+        get_future_cache_key(None, my_pipeline(1, {"test_key": 2}))
+
+
+def test_str_namespace_happy_path():
+    actual = get_future_cache_key("my_namespace", my_pipeline(1, {"test_key": 2}))
+    assert actual == MY_NAMESPACE_CACHE_KEY
+
+    actual = get_future_cache_key("my_other_namespace", my_pipeline(1, {"test_key": 2}))
+    assert actual == MY_OTHER_NAMESPACE_CACHE_KEY
+
+
+def test_callable_namespace_happy_path():
+    def my_namespace(_: AbstractFuture) -> str:
+        return "my_namespace"
+
+    actual = get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))
+    assert actual == MY_NAMESPACE_CACHE_KEY
+
+    def my_other_namespace(_: AbstractFuture) -> str:
+        return "my_other_namespace"
+
+    actual = get_future_cache_key(my_other_namespace, my_pipeline(1, {"test_key": 2}))
+    assert actual == MY_OTHER_NAMESPACE_CACHE_KEY
+
+
+def test_custom_callable_namespace():
+    def my_custom_namespace(future: AbstractFuture) -> str:
+        fqpn = future.calculator.get_func_fqpn()  # type: ignore # noqa: ignore
+
+        if fqpn == "sematic.caching.tests.test_caching.my_pipeline":
+            return "my_namespace"
+
+        if fqpn == "sematic.caching.tests.test_caching.my_other_pipeline":
+            return "my_other_namespace"
+
+        return "whatever"
+
+    actual = get_future_cache_key(my_custom_namespace, my_pipeline(1, {"test_key": 2}))
+    assert actual == MY_NAMESPACE_CACHE_KEY
+
+    actual = get_future_cache_key(my_custom_namespace, my_other_pipeline(1))
+    assert actual == MY_CUSTOM_OTHER_NAMESPACE_CACHE_KEY
+
+
+def test_malformed_callable_namespace():
+    def my_namespace() -> str:
+        return "my_namespace"
+
+    with pytest.raises(TypeError, match="takes 0 positional arguments but 1 was given"):
+        get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))
+
+
+def test_callable_namespace_failure_handled():
+    def my_namespace(_: AbstractFuture) -> str:
+        raise ValueError("test error")
+
+    with pytest.raises(ValueError, match="test error"):
+        get_future_cache_key(my_namespace, my_pipeline(1, {"test_key": 2}))

--- a/sematic/caching/tests/test_caching.py
+++ b/sematic/caching/tests/test_caching.py
@@ -11,8 +11,8 @@ from sematic.caching.caching import get_future_cache_key, resolve_cache_namespac
 
 # these values were calculated by hand on paper to validate the algorithm
 # (they were all correct on the first try)
-MY_CACHE_KEY = "3056b3ba8b7aea0c5821168fdc5b6ddde7bb9b14_my_namespace"
-MY_OTHER_CACHE_KEY = "3056b3ba8b7aea0c5821168fdc5b6ddde7bb9b14_my_other_namespace"
+MY_CACHE_KEY = "ec8eaec9ea3bd0315d5bd0839380ed2cab6bf526_my_namespace"
+MY_OTHER_CACHE_KEY = "ec8eaec9ea3bd0315d5bd0839380ed2cab6bf526_my_other_namespace"
 
 
 @func

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -99,6 +99,9 @@ class Calculator(AbstractCalculator):
             )
 
     def __repr__(self):
+        return self.get_func_fqpn()
+
+    def get_func_fqpn(self):
         return "{}.{}".format(self.__module__, self.__name__)
 
     def get_source(self) -> str:

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -102,6 +102,9 @@ class Calculator(AbstractCalculator):
         return self.get_func_fqpn()
 
     def get_func_fqpn(self):
+        """
+        Returns the fully qualified path name of the func.
+        """
         return "{}.{}".format(self.__module__, self.__name__)
 
     def get_source(self) -> str:

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -31,6 +31,8 @@ sematic_py_lib(
         "//sematic:abstract_future",
         "//sematic:storage",
         "//sematic/types:serialization",
+        "//sematic/utils:json",
+        "//sematic/utils:hashing",
     ],
 )
 

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -58,7 +58,7 @@ class ClonedFutureGraph:
         root_future = next(
             future
             for future in self.futures_by_original_id.values()
-            if future.parent_future is None
+            if future.is_root_future()
         )
 
         if root_future.id in self.input_artifacts:

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -261,7 +261,7 @@ class DBStateMachineTestResolver(LocalResolver):
             future.calculator.__module__, future.calculator.__name__
         )
         assert run.parent_id == (
-            future.parent_future.id if future.parent_future is not None else None
+            future.parent_future.id if not future.is_root_future() else None
         )
         assert run.started_at is not None
 

--- a/sematic/tests/test_graph.py
+++ b/sematic/tests/test_graph.py
@@ -63,7 +63,7 @@ def test_clone_futures(
 
     assert root_future.state == FutureState.RESOLVED
     assert root_future.calculator._func is pipeline._func
-    assert root_future.parent_future is None
+    assert root_future.is_root_future()
     # the entire pipeline resolution was cloned,
     # so the root run was never actually executed
     assert root_future.original_future_id == future.id
@@ -139,7 +139,7 @@ def test_clone_futures_reset(
 
     assert root_future.state == FutureState.RAN
     assert root_future.calculator._func is pipeline._func
-    assert root_future.parent_future is None
+    assert root_future.is_root_future()
     assert root_future.original_future_id is None
 
     second_add3_future = root_future.nested_future

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -40,3 +40,17 @@ sematic_py_lib(
     srcs = ["sorting.py"],
     deps = [],
 )
+
+sematic_py_lib(
+    name = "json",
+    srcs = ["json.py"],
+    deps = [],
+)
+
+sematic_py_lib(
+    name = "hashing",
+    srcs = ["hashing.py"],
+    deps = [
+        ":json",
+    ],
+)

--- a/sematic/utils/git.py
+++ b/sematic/utils/git.py
@@ -13,7 +13,7 @@ from sematic.db.models.git_info import GitInfo
 logger = logging.getLogger(__name__)
 
 
-def get_git_info(object_: Any) -> Optional["Repo"]:  # type: ignore # noqa: F821
+def get_git_info(object_: Any) -> Optional[GitInfo]:
     """
     Returns git repository details for the current workspace.
 

--- a/sematic/utils/hashing.py
+++ b/sematic/utils/hashing.py
@@ -1,0 +1,42 @@
+# Standard Library
+import hashlib
+import json
+from typing import Any
+
+# Sematic
+from sematic.utils.json import fix_nan_inf
+
+
+def get_str_sha1_digest(string: str) -> str:
+    """
+    Get SHA1 hex digest for a string.
+    """
+    # we don't need a cryptographic hash, but we do need a fast hash
+    # unfortunately the builtin hash is initialized with a random salt seed on program
+    # initialization, and this cannot be reset,
+    # so we use sha1 for now
+    # https://automationrhapsody.com/md5-sha-1-sha-256-sha-512-speed-performance/
+    binary = string.encode("utf-8")
+    sha1_digest = hashlib.sha1(binary)
+
+    return sha1_digest.hexdigest()
+
+
+def get_value_and_type_sha1_digest(
+    value_serialization: Any,
+    type_serialization: Any,
+    json_summary: Any,
+) -> str:
+    """
+    Get SHA1 digest for a value and its type.
+    """
+    # TODO #403: do this in a sustainable and efficient way
+    payload = {
+        "value": value_serialization,
+        "type": type_serialization,
+        "summary": json_summary,
+        # TODO: Should there be some sort of type versioning concept here?
+    }
+
+    string_payload = fix_nan_inf(json.dumps(payload, sort_keys=True, default=str))
+    return get_str_sha1_digest(string_payload)

--- a/sematic/utils/json.py
+++ b/sematic/utils/json.py
@@ -1,0 +1,13 @@
+def fix_nan_inf(string: str) -> str:
+    """
+    Dirty hack to remedy mismatches between ECMAS6 JSON specs and Pythoh JSON
+    specs Python respects the JSON5 spec (https://spec.json5.org/) which
+    supports NaN, Infinity, and -Infinity as numbers, whereas ECMAS6 does not
+    (Unexpected token N in JSON at position)
+    """
+    # TODO: find a more sustainable solution
+    return (
+        string.replace("NaN", '"NaN"')
+        .replace("Infinity", '"Infinity"')
+        .replace('-"Infinity"', '"-Infinity"')
+    )

--- a/sematic/utils/tests/BUILD
+++ b/sematic/utils/tests/BUILD
@@ -29,3 +29,12 @@ pytest_test(
         "//sematic/utils:sorting",
     ],
 )
+
+pytest_test(
+    name = "test_hashing",
+    srcs = ["test_hashing.py"],
+    deps = [
+        "//sematic/types:serialization",
+        "//sematic/utils:hashing",
+    ],
+)

--- a/sematic/utils/tests/test_hashing.py
+++ b/sematic/utils/tests/test_hashing.py
@@ -1,0 +1,34 @@
+# Standard Library
+from typing import Dict
+
+# Sematic
+from sematic.types.serialization import (
+    get_json_encodable_summary,
+    type_to_json_encodable,
+    value_to_json_encodable,
+)
+from sematic.utils.hashing import get_str_sha1_digest, get_value_and_type_sha1_digest
+
+HASH_1 = "356a192b7913b04c54574d18c28d46e6395428ab"
+HASH_A = "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8"
+HASH_VALUE_AND_TYPE = "cb7a7ae1a4d8ec92524ce5eee7aa1570b0ca5799"
+
+
+def test_str_digest():
+    assert get_str_sha1_digest(str(1)) == HASH_1
+    assert get_str_sha1_digest("a") == HASH_A
+
+
+def test_value_and_type_digest():
+    value = {"a": 1}
+    type_ = Dict[str, int]
+
+    type_serialization = type_to_json_encodable(type_)
+    value_serialization = value_to_json_encodable(value, type_)
+    json_summary = get_json_encodable_summary(value, type_)
+
+    actual = get_value_and_type_sha1_digest(
+        value_serialization, type_serialization, json_summary
+    )
+
+    assert actual == HASH_VALUE_AND_TYPE


### PR DESCRIPTION
This is the second in a series of PRs that will implement #338. The previous one is #390.

Introduces a module that can be used to generate the final cache key based on a user-specified cache namespace and on a Future func.

Currently uses SHA1 for the actual hashing, at it is [fast](https://automationrhapsody.com/md5-sha-1-sha-256-sha-512-speed-performance) and easy to use (see code comments), until a more efficient system can be implemented (see #403).

Also introduces a utility function that generates the cache key based on the git commit SHA, as it was requested by users.

The module is currently unused. Subsequent PRs will use this code.

### Testing

Unit tests were introduced for the base cache key generation:
```bash
$ bazel test //sematic/caching/tests:test_caching
```

For the git-based utility function, the existing git utility module failed to get the git info from the Bazel test runtime. I had to test manually, as this works for the normal Bazel run runtime.

The manual test was done by adding the `"//sematic:calculator"` dependency and doing:

```ipython
~/work/sematic$ bazel run //sematic/caching:git_ipython
INFO: Analyzed target //sematic/caching:git_ipython (38 packages loaded, 3663 targets configured).
INFO: Found 1 target...
Target //sematic/caching:git_ipython up-to-date:
  bazel-bin/sematic/caching/git_ipython
INFO: Elapsed time: 1.888s, Critical Path: 1.03s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Build completed successfully, 4 total actions
Python 3.8.13 (default, May  2 2022, 18:13:58)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from sematic.caching.git import get_git_sha_caching_namespace

In [2]: from sematic.calculator import func

In [3]: @func
   ...: def f(a:int) -> int:
   ...:     return a
   ...:

In [4]: get_git_sha_caching_namespace(f(1))
Out[4]: '02e5f193e7c1f973b5e1616b12ad5ea7517c4d60+True'

In [5]: quit()
~/work/sematic$ git log
commit 02e5f193e7c1f973b5e1616b12ad5ea7517c4d60 (HEAD -> tudor/caching_module, origin/tudor/caching_module)
Author: Tudor Scurtu <tudor@sematic.dev>
Date:   Wed Dec 14 21:20:29 2022 +0200

    Git commit SHA-based utility cache namespace
```
