### PR TITLE
Restrict the size of logs area

### DIFF
--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -21,7 +21,7 @@ export default function LogPanel(props: { run: Run }) {
       filterString={filterString} />
   );
   const logErrorView = (
-    <Alert severity="error">
+    <Alert severity="error" sx={{ my: 5 }}>
       The server returned an error when asked for logs for this run.
     </Alert>
   );

--- a/sematic/ui/src/components/LogPanel.tsx
+++ b/sematic/ui/src/components/LogPanel.tsx
@@ -28,21 +28,22 @@ export default function LogPanel(props: { run: Run }) {
   const logView = error === undefined ? standardLogView : logErrorView;
 
   return (
-    <Box sx={{ display: "grid" }} >
-      <Box sx={{ gridRow: 1, paddingBottom: 4, }} >
-        {run.external_exception_metadata_json && <ExternalException
-            exception_metadata={run.external_exception_metadata_json} />}
-      </Box>
-      <Box sx={{ gridRow: 2, paddingBottom: 4, }} >
-        {run.exception_metadata_json &&
-            <Exception exception_metadata={run.exception_metadata_json} />}
-      </Box>
-      <Box sx={{ gridRow: 3, paddingBottom: 4, }} >
+    <Box sx={{ display: "flex", flexGrow: 1 }} >
+      {run.external_exception_metadata_json && <Box sx={{ paddingBottom: 4, }} >
+        <ExternalException
+          exception_metadata={run.external_exception_metadata_json} />
+      </Box>}
+
+      {run.exception_metadata_json && <Box sx={{ paddingBottom: 4, }} >
+        <Exception exception_metadata={run.exception_metadata_json} /></Box>}
+
+      <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column'}} >
         <TextField
           variant="standard"
           fullWidth={true}
           placeholder={"Filter..."}
           onChange={onFilterStringChange}
+          style={{ flexShrink: 1 }}
         />
         {logView}
       </Box>

--- a/sematic/ui/src/components/RunPanel.tsx
+++ b/sematic/ui/src/components/RunPanel.tsx
@@ -1,4 +1,3 @@
-import { FileCopy, History, Insights } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
 import { useCallback, useContext, useMemo } from "react";
 import { Artifact, Edge, Resolution, Run } from "../Models";
@@ -99,8 +98,9 @@ export default function RunPanel(props: {
         </>
       )}
       {selectedPanel === "run" && (
-        <Box sx={{ p: 5 }}>
-          <Box sx={{ display: "grid", gridTemplateColumns: "1fr auto auto" }}>
+        <Box sx={{ p: 5, height: '100%', 'boxSizing': 'border-box', display: 'flex', 
+          flexFlow: 'column'}}>
+          <Box sx={{ display: "grid", gridTemplateColumns: "1fr auto auto", flexShrink: 1 }}>
             <Box sx={{ paddingBottom: 3, gridColumn: 1 }}>
               <Box marginBottom={3}>
                 <Typography variant="h6">{selectedRun.name}</Typography>
@@ -134,7 +134,7 @@ export default function RunPanel(props: {
               <RunTime run={selectedRun} prefix="in " />
             </Box>
           </Box>
-          <Box sx={{ mb: 10, mt: 5 }}>
+          <Box sx={{ mb: 10, mt: 5, flexShrink: 1}}>
             <Docstring docstring={selectedRun.description} />
           </Box>
           <RunTabs run={selectedRun} artifacts={selectedRunArtifacts} />

--- a/sematic/ui/src/components/RunTabs.tsx
+++ b/sematic/ui/src/components/RunTabs.tsx
@@ -1,27 +1,30 @@
-import Box from "@mui/material/Box";
-import { useState, useContext } from "react";
-import { Artifact, Edge, Run } from "../Models";
-import { ArtifactList } from "./Artifacts";
-import SourceCode from "./SourceCode";
-import Tab from "@mui/material/Tab";
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import Docstring from "./Docstring";
 import { Alert } from "@mui/material";
-import LogPanel from "./LogPanel";
-import GrafanaPanel from "../addons/grafana/GrafanaPanel";
+import Box from "@mui/material/Box";
+import Tab from "@mui/material/Tab";
+import { styled } from '@mui/system';
+import { useContext, useState } from "react";
 import { EnvContext } from "../";
+import GrafanaPanel from "../addons/grafana/GrafanaPanel";
+import { Artifact, Run } from "../Models";
+import { ArtifactList } from "./Artifacts";
+import Docstring from "./Docstring";
+import LogPanel from "./LogPanel";
+import SourceCode from "./SourceCode";
+
+const ExpandedTabPanel = styled(TabPanel)<{hidden: boolean}>( 
+  ({hidden}) => hidden ? {} : {
+    display: 'flex',
+    flexGrow: 1,
+    paddingBottom: 0
+  });
+
 
 export type IOArtifacts = {
   input: Map<string, Artifact | undefined>;
   output: Map<string, Artifact | undefined>;
-};
-
-type Graph = {
-  runs: Map<string, Run>;
-  edges: Edge[];
-  artifacts: Artifact[];
 };
 
 export default function RunTabs(props: {
@@ -47,7 +50,7 @@ export default function RunTabs(props: {
   return (
     <>
       <TabContext value={selectedTab}>
-        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Box sx={{ borderBottom: 1, borderColor: "divider", flexShrink: 1 }}>
           <TabList onChange={handleChange} aria-label="Selected run tabs">
             <Tab label="Input" value="input" />
             <Tab label="Output" value="output" />
@@ -73,9 +76,9 @@ export default function RunTabs(props: {
         <TabPanel value="documentation">
           <Docstring docstring={run.description} />
         </TabPanel>
-        <TabPanel value="logs">
+        <ExpandedTabPanel hidden={selectedTab != "logs"} value="logs">
           <LogPanel run={run} />
-        </TabPanel>
+        </ExpandedTabPanel>
         <TabPanel value="source">
           <SourceCode run={run} />
         </TabPanel>

--- a/sematic/ui/src/components/ScrollingLogView.tsx
+++ b/sematic/ui/src/components/ScrollingLogView.tsx
@@ -111,26 +111,20 @@ export default function ScrollingLogView(props: {
   }, [getNext, hasPulledData]);
 
   return (
-    <Box
-      sx={{
-        mt: 5,
-        position: "relative",
-        left: 0,
-        top: 0,
-      }}
-    >
-      
+    <>
       <Box
         id={scrollerId}
         ref={scrollMonitorRef}
         sx={{
-          height: "400px",
-          my: 5,
+          height: 0,
+          mt: 5,
           pt: 1,
-          whiteSpace: "nowrap",
+          whiteSpace: "break-spaces",
           overflow: "hidden",
           overflowY: "scroll",
-          gridRow: 2,
+          width: `100%`,
+          lineBreak: 'anywhere',
+          flexGrow: 1,
         }}
       >
         <InfiniteScroll
@@ -152,6 +146,7 @@ export default function ScrollingLogView(props: {
                 color: theme.palette.grey[800],
                 backgroundColor:
                   index % 2 === 0 ? "white" : theme.palette.grey[50],
+                paddingRight: 1
               }}
               key={index}
             >
@@ -168,10 +163,11 @@ export default function ScrollingLogView(props: {
           onClick={accumulateLogsUntilEnd}
           sx={{ width: "100%" }}
           disabled={isAccumulating || isLoading}
+          style={{flexShrink: 1}}
         >
           {accumulatorButtonMessage}
         </Button>
       )}
-    </Box>
+    </>
   );
 }

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -34,7 +34,7 @@ export function useHttpClient(): HttpClient {
 
         const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
 
-        devLogger("fetch() ", method, url, reqBody);
+        devLogger("HttpClient.fetch ", method, url, reqBody);
 
         const abortController = new AbortController();
         abortControllerRef.current = (abortController);

--- a/sematic/ui/src/hooks/scrollingHooks.ts
+++ b/sematic/ui/src/hooks/scrollingHooks.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLogger } from "../utils";
+import { useSetTimeout } from "./setTimeoutHooks";
+
+const SCROLL_EVENTS = ['mousewheel', 'DOMMouseScroll', 'wheel', 'MozMousePixelScroll'];
+const SCROLL_DOWN_CONTINUATION = 800;
+/**
+ * A hook tracks that whether `refElement` has scrolled down to the bottom,
+ * and then user has kept scrolling down for SCROLL_DOWN_CONTINUATION consecutive
+ * milliseconds. If so, `callback` will be triggered.
+ * 
+ * @param refElement The scrolling container to monitor. Its height should be 
+ *        taller than its content's height. (or there will be no scrolling)
+ * @param callback The callback to call.
+ * @returns 
+ */
+export function usePulldownTrigger(
+    refElement: React.MutableRefObject<HTMLElement | undefined>,
+    callback: () => Promise<void>
+) {
+    const { devLogger } = useLogger();
+    const hasElementScrolledToBottom = useCallback(() => {
+        if (!refElement.current) {
+            return;
+        }
+        const {scrollTop, clientHeight, scrollHeight } = refElement.current;
+
+        return scrollHeight - scrollTop - clientHeight < 10;
+    }, [refElement]);
+
+    const [pullDownTriggerEnabled, setPullDownTriggerEnabled] = useState(false);
+    const [markPulldownTriggerEnabled, cancelPulldownTriggerEnabled] = useSetTimeout(useCallback(() => {
+        // Mark the `enabled` state only when the scrolling has completely ceased.
+        // (in other words, there is not another follow-up scroll event to cancel this marking.)
+        setPullDownTriggerEnabled(true);
+    }, [setPullDownTriggerEnabled]), 50);
+
+    // This timeout function cancels the above timeout function
+    const [startDroppingPulldownTrigger, cancelDroppingPulldownTrigger] = useSetTimeout(() => {
+        cancelPulldownTriggerCall();
+        setPulldownProgress(0);
+    }, SCROLL_DOWN_CONTINUATION *.3);
+
+    // This is the timeout function who eventually trigger the `callback`
+    const [startPullDownTriggerCall, 
+        cancelPulldownTriggerCall, 
+        isPullDownTriggerCallInitiated
+    ] = useSetTimeout(useCallback(async () => {
+        setPulldownProgress(100);
+        devLogger('Pulldown triggered');
+        cancelDroppingPulldownTrigger();
+        pulldownCallbackInprogress.current = true;
+
+        await callback();
+        devLogger('Pulled down callback completed');
+
+        setPulldownProgress(0);
+        pulldownCallbackInprogress.current = false;
+    }, [callback, cancelDroppingPulldownTrigger, devLogger]), SCROLL_DOWN_CONTINUATION);
+
+    
+    const pullDownTriggerStarttime = useRef<number>(0);
+    const pulldownCallbackInprogress = useRef<boolean>(false);
+
+    const [pullDownProgress, setPulldownProgress] = useState<number>(0);
+
+    const onScroll = useCallback((event: Event) => {
+        if (pulldownCallbackInprogress.current) {
+            return;
+        }
+        event.stopPropagation();
+
+        // Phase 1: detect whether the scrolling has reached to the bottom
+        const hasReachedBottom = hasElementScrolledToBottom();
+        cancelPulldownTriggerEnabled();
+
+        if (hasReachedBottom) {
+            if (!pullDownTriggerEnabled) {
+                // mark pulldown trigger enabled in a delayed way.
+                markPulldownTriggerEnabled();
+            }
+        } else {
+            setPullDownTriggerEnabled(false);
+        }
+
+        if (!pullDownTriggerEnabled) {
+            return false;
+        }
+
+        // Phase 2: detect whether there is a continous scrolling down for 
+        // SCROLL_DOWN_CONTINUATION milliseconds. If it has, then `callback`
+        // will be triggered.
+        const { deltaY } = event as WheelEvent;
+        if (deltaY >= 0) { // deltaY >= 0 means it is scrolling down
+            // initiate pulldown trigger if not yet
+            if (!isPullDownTriggerCallInitiated()) {
+                setPulldownProgress(0);
+                startPullDownTriggerCall();
+                pullDownTriggerStarttime.current = performance.now();
+            }
+            // cancel previous attempt of cancelling pulldown trigger, so
+            // the cancellation of pulldownTrigger is delayed.
+            cancelDroppingPulldownTrigger();
+            
+            setPulldownProgress(
+                (performance.now() - pullDownTriggerStarttime.current) / SCROLL_DOWN_CONTINUATION * 100
+            );
+
+            // prepare to cancel pulldown trigger, so if there is not a consecutive
+            // scroll down event soon, the pull down trigger will be cancelled.
+            startDroppingPulldownTrigger();
+        } else {
+            // If it is not scrolling down, immediately cancel the current pull down detection
+            cancelPulldownTriggerCall();
+            setPulldownProgress(0);
+        }
+    }, [hasElementScrolledToBottom, markPulldownTriggerEnabled,
+        isPullDownTriggerCallInitiated, cancelPulldownTriggerCall, startPullDownTriggerCall, 
+        startDroppingPulldownTrigger, cancelDroppingPulldownTrigger, cancelPulldownTriggerEnabled,
+        pullDownTriggerEnabled, setPullDownTriggerEnabled]);
+    
+    const attachedDomElement = useRef<HTMLElement | undefined>(undefined);
+
+    useEffect(() => {
+        attachedDomElement.current = refElement.current;
+
+        SCROLL_EVENTS.forEach(eventName => {
+            attachedDomElement.current?.addEventListener(eventName, onScroll);
+        });
+
+        return () => {
+            SCROLL_EVENTS.forEach(eventName => {
+                attachedDomElement.current?.removeEventListener(eventName, onScroll);
+            });
+        };
+    }, [refElement, onScroll, attachedDomElement]);
+
+    return {pullDownProgress, pullDownTriggerEnabled};
+}

--- a/sematic/ui/src/hooks/setTimeoutHooks.ts
+++ b/sematic/ui/src/hooks/setTimeoutHooks.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * A utility to drive the function controlled by setTimeout.
+ * Does not trigger re-render.
+ * 
+ * @param callback Function to call.
+ * @param timeout how soon to call the function.
+ */
+export function useSetTimeout<T extends (...args: any[]) => any>(callback: T, timeout: number, label = 0): [
+    (...args: Parameters<T>) => void,
+    () => void,
+    () => boolean
+] {
+    const handle = useRef<number | undefined>(undefined);
+    const isPending = useRef<boolean>(false);
+
+    const call = useCallback((...args: Parameters<T>) => {
+        isPending.current = true;
+        handle.current = window.setTimeout(async () => {
+            const result = await callback(...args);
+            isPending.current = false;
+            return result;
+        }, timeout);
+    }, [callback, handle, timeout, isPending]);
+
+    const cancel = useCallback(() => {
+        !!handle.current && clearTimeout(handle.current);
+        handle.current = undefined;
+        isPending.current = false;
+    }, [handle, isPending]);
+
+    const isPendingFn = useCallback(() => isPending.current, [isPending]);
+
+    return [call, cancel, isPendingFn];
+}


### PR DESCRIPTION
Restrict the width and height of the logs' area. The area's height is confined to the remaining space of the RunPanel minus the height of the header area.

![capture1](https://user-images.githubusercontent.com/1046489/207944202-e202dfad-783a-49ed-b1ec-9d7326afbbc7.gif)


