### PR TITLE
Allow multi-domain auth

### DIFF
--- a/sematic/api/endpoints/auth.py
+++ b/sematic/api/endpoints/auth.py
@@ -99,7 +99,6 @@ def google_login() -> flask.Response:
         )
 
         if authorized_email_domain is not None:
-            print(idinfo.get("hd"), authorized_email_domain.split(","))
             if idinfo.get("hd") not in authorized_email_domain.split(","):
                 raise ValueError("Incorrect email domain")
 

--- a/sematic/api/endpoints/auth.py
+++ b/sematic/api/endpoints/auth.py
@@ -99,7 +99,8 @@ def google_login() -> flask.Response:
         )
 
         if authorized_email_domain is not None:
-            if idinfo.get("hd") != authorized_email_domain:
+            print(idinfo.get("hd"), authorized_email_domain.split(","))
+            if idinfo.get("hd") not in authorized_email_domain.split(","):
                 raise ValueError("Incorrect email domain")
 
     except (ValueError, GoogleAuthError):


### PR DESCRIPTION
Closes #114
This PR enables `SEMATIC_AUTHORIZED_EMAIL_DOMAIN` to accept multiple comma-separated email domains.