### PR TITLE
[1/2] Reactors the state management of Pipeline scenarios

### DIFF
--- a/sematic/ui/src/components/MenuPanel.tsx
+++ b/sematic/ui/src/components/MenuPanel.tsx
@@ -9,18 +9,16 @@ import {
   useTheme,
 } from "@mui/material";
 import { useMemo } from "react";
+import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
 import { Run } from "../Models";
 import RunTree from "./RunTree";
 
 export default function MenuPanel(props: {
   runsById: Map<string, Run>;
-  selectedRun: Run;
-  selectedPanel: string;
-  onPanelSelect: (panel: string) => void;
-  onRunSelect: (run: Run) => void;
 }) {
-  const { runsById, selectedRun, selectedPanel, onPanelSelect, onRunSelect } =
-    props;
+  const { runsById } = props;
+  
+  const { selectedPanelItem, setSelectedPanelItem } = usePipelinePanelsContext();
 
   const theme = useTheme();
 
@@ -37,15 +35,14 @@ export default function MenuPanel(props: {
       label: "graph",
       title: "Execution graph",
       icon: <BubbleChart />,
-      onClick: () => onPanelSelect("graph"),
+      onClick: () => setSelectedPanelItem("graph"),
     },
     {
       label: "run",
       title: "Nested runs",
       icon: <FormatListBulleted />,
       onClick: () => {
-        onPanelSelect("run");
-        onRunSelect(selectedRun);
+        setSelectedPanelItem("run");
       },
     },
   ];
@@ -76,7 +73,7 @@ export default function MenuPanel(props: {
             <ListItemButton
               onClick={panel.onClick}
               sx={{ height: "4em" }}
-              selected={selectedPanel === panel.label}
+              selected={selectedPanelItem === panel.label}
             >
               <ListItemIcon sx={{ minWidth: "40px" }}>
                 {panel.icon}
@@ -97,11 +94,6 @@ export default function MenuPanel(props: {
         <RunTree
           runsByParentId={runsByParentId}
           parentId={null}
-          selectedRunId={selectedRun?.id}
-          onSelectRun={(run) => {
-            onPanelSelect("run");
-            onRunSelect(run);
-          }}
         />
       </Box>
     </Box>

--- a/sematic/ui/src/components/NotesPanel.tsx
+++ b/sematic/ui/src/components/NotesPanel.tsx
@@ -9,19 +9,24 @@ import {
   useState,
 } from "react";
 import { UserContext } from "..";
+import { usePipelinePanelsContext, usePipelineRunContext } from "../hooks/pipelineHooks";
 import { Note, Run, User } from "../Models";
 import { NoteCreatePayload, NoteListPayload } from "../Payloads";
+import PipelineRunViewContext from "../pipelines/PipelineRunViewContext";
 import { fetchJSON } from "../utils";
 import { NoteView } from "./Notes";
+import { ExtractContextType } from "./utils/typings";
 
-export default function NotesPanel(props: {
-  rootRun: Run;
-  selectedRun: Run;
-}) {
+export default function NotesPanel() {
   const theme = useTheme();
   const { user } = useContext(UserContext);
 
-  const { rootRun, selectedRun } = props;
+  const { rootRun } 
+    = usePipelineRunContext() as ExtractContextType<typeof PipelineRunViewContext> & {
+      rootRun: Run
+  };;
+  const { selectedRun } = usePipelinePanelsContext();
+
 
   const calculatorPath = useMemo(
     () => rootRun.calculator_path,

--- a/sematic/ui/src/components/ReactFlowDag.tsx
+++ b/sematic/ui/src/components/ReactFlowDag.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import buildDagLayout from "./utils/buildDagLayout";
 import RunNode from "./RunNode";
 import ArtifactNode from "./ArtifactNode";
+import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
 
 var util = require("dagre/lib/util");
 var graphlib = require("graphlib");
@@ -42,8 +43,6 @@ interface ReactFlowDagProps {
   runs: Run[];
   edges: Edge[];
   artifactsById: Map<string, Artifact>;
-  onSelectRun: (run: Run) => void;
-  selectedRunId: string;
 }
 
 const nodeTypes = {
@@ -52,7 +51,14 @@ const nodeTypes = {
 };
 
 function ReactFlowDag(props: ReactFlowDagProps) {
-  const { runs, edges, artifactsById, onSelectRun, selectedRunId } = props;
+  const { runs, edges, artifactsById } = props;
+
+  const { selectedRun, setSelectedPanelItem, setSelectedRun } = usePipelinePanelsContext();
+
+  const onSelectRun = useCallback((run: Run) => {
+    setSelectedRun(run);
+    setSelectedPanelItem("run");
+  }, [setSelectedRun, setSelectedPanelItem]);
 
   const runsById = useMemo(
     () => new Map(runs.map((run) => [run.id, run])),
@@ -95,7 +101,7 @@ function ReactFlowDag(props: ReactFlowDagProps) {
         id: run.id,
         data: { label: run.name, run: run, argNames: runArgNames },
         parentNode: run.parent_id === null ? undefined : run.parent_id,
-        selected: run.id === selectedRunId,
+        selected: run.id === selectedRun.id,
         position: { x: 0, y: 0 },
         extent: run.parent_id === null ? undefined : "parent",
         // Always render below edges.

--- a/sematic/ui/src/components/RunTree.tsx
+++ b/sematic/ui/src/components/RunTree.tsx
@@ -5,7 +5,8 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
-import { Fragment, useMemo } from "react";
+import { Fragment, useCallback, useMemo } from "react";
+import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
 import { Run } from "../Models";
 import RunStateChip from "./RunStateChip";
 
@@ -17,10 +18,15 @@ function getTime(run: Run) {
 export default function RunTree(props: {
   runsByParentId: Map<string | null, Run[]>;
   parentId: string | null;
-  selectedRunId: string | undefined;
-  onSelectRun: (run: Run) => void;
 }) {
-  let { runsByParentId, parentId, selectedRunId, onSelectRun } = props;
+  let { runsByParentId, parentId } = props;
+
+  const { selectedRun, setSelectedPanelItem, setSelectedRun } = usePipelinePanelsContext();
+
+  const onSelectRun = useCallback((run: Run) => {
+    setSelectedRun(run);
+    setSelectedPanelItem('run');
+  }, [setSelectedPanelItem, setSelectedRun]);
 
   const directChildren = useMemo(() => {
     let runs = runsByParentId.get(parentId);
@@ -52,7 +58,7 @@ export default function RunTree(props: {
             onClick={() => onSelectRun(run)}
             key={run.id}
             sx={{ height: "30px" }}
-            selected={selectedRunId === run.id}
+            selected={selectedRun.id === run.id}
           >
             <ListItemIcon sx={{ minWidth: "20px" }}>
               <RunStateChip state={run.future_state} />
@@ -64,8 +70,6 @@ export default function RunTree(props: {
               <RunTree
                 runsByParentId={runsByParentId}
                 parentId={run.id}
-                selectedRunId={selectedRunId}
-                onSelectRun={onSelectRun}
               />
             </Box>
           )}

--- a/sematic/ui/src/components/utils/typings.ts
+++ b/sematic/ui/src/components/utils/typings.ts
@@ -1,0 +1,3 @@
+export type ExtractContextType<T> = Exclude<
+    T extends React.Context<infer U> ? U : never, 
+    null>

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -1,10 +1,34 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useAsyncFn } from "react-use";
-import { Filter, RunListPayload } from "../Payloads";
+import useAsync from "react-use/lib/useAsync";
+import useAsyncFn from "react-use/lib/useAsyncFn";
+import { Resolution, Run } from "../Models";
+import { Filter, ResolutionPayload, RunListPayload, RunViewPayload } from "../Payloads";
+import PipelinePanelsContext from "../pipelines/PipelinePanelsContext";
+import PipelineRunViewContext from "../pipelines/PipelineRunViewContext";
 import { useHttpClient } from "./httpHooks";
 
 export type QueryParams = {[key: string]: string};
+
+export function usePipelineRunContext() {
+    const contextValue = useContext(PipelineRunViewContext);
+
+    if (!contextValue) {
+        throw new Error('usePipelineRunContext() should be called under a provider.')
+    }
+
+    return contextValue;
+}
+
+export function usePipelinePanelsContext() {
+    const contextValue = useContext(PipelinePanelsContext);
+
+    if (!contextValue) {
+        throw new Error('usePipelinePanelsContext() should be called under a provider.')
+    }
+
+    return contextValue;
+}
 
 export function useFetchRunsFn(runFilters: Filter | undefined = undefined,
     otherQueryParams: QueryParams = {}) {
@@ -52,6 +76,36 @@ export function useFetchRuns(runFilters: Filter | undefined = undefined,
     }, [load])
 
     return {isLoaded, isLoading, error, runs: runs?.content, reloadRuns};
+}
+
+export function useFetchRun(runID: string): [
+    Run | undefined, boolean, Error | undefined
+] {
+    const {fetch} = useHttpClient();
+
+    const {value, loading, error} = useAsync(async () => {
+        const response: RunViewPayload = await fetch({
+            url: `/api/v1/runs/${runID}`
+        });
+        return response.content
+    }, [runID]);
+    
+    return [value, loading, error];
+}
+
+export function useFetchResolution(resolutionId: string): [
+    Resolution | undefined, boolean, Error | undefined
+] {
+    const {fetch} = useHttpClient();
+
+    const {value, loading, error} = useAsync(async () => {
+        const response: ResolutionPayload = await fetch({
+            url: `/api/v1/resolutions/${resolutionId}`
+        });
+        return response.content;
+    }, [resolutionId]);
+    
+    return [value, loading, error];
 }
 
 export function getPipelineUrlPattern(pipelinePath: string, requestedRootId: string) {

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -115,12 +115,10 @@ function App() {
               <Route path="" element={<Home />} />
               <Route path="pipelines" element={<PipelineIndex />} />
               <Route
-                path="pipelines/:calculatorPath/:rootId"
-                element={<PipelineRunView />}
+                path="pipelines/:pipelinePath/:rootId" element={<PipelineRunView />}
               />
               <Route
-                path="pipelines/:calculatorPath"
-                element={<PipelineView />}
+                path="pipelines/:pipelinePath" element={<PipelineView />}
               />
             </Route>
           </Routes>

--- a/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Run } from "../Models";
+
+export const PipelinePanelsContext = React.createContext<{
+    selectedPanelItem: string;
+    setSelectedPanelItem: (panelItem: string) => void;
+    selectedRun: Run;
+    setSelectedRun: (run: Run) => void;
+} | null>(null);
+
+export default PipelinePanelsContext;

--- a/sematic/ui/src/pipelines/PipelineRunViewContext.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunViewContext.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Resolution, Run } from "../Models";
+
+export const PipelineRunViewContext = React.createContext<{
+    rootRun: Run | undefined;
+    resolution: Resolution | undefined;
+    isLoading: boolean;
+    pipelinePath: string | null;
+} | null>(null);
+
+export default PipelineRunViewContext;

--- a/sematic/ui/src/pipelines/PipelineView.tsx
+++ b/sematic/ui/src/pipelines/PipelineView.tsx
@@ -13,14 +13,14 @@ import { Alert } from "@mui/material";
  */
 export default function PipelineView() {
     const params = useParams();
-    const { calculatorPath } = params;
+    const { pipelinePath } = params;
 
     const runFilters = useMemo(() => ({
         "AND": [
           { parent_id: { eq: null } },
-          { calculator_path: { eq: calculatorPath! } },
+          { calculator_path: { eq: pipelinePath! } },
         ]
-      }), [calculatorPath]);
+      }), [pipelinePath]);
 
     const otherQueryParams = useMemo(() => ({
         limit: '10'
@@ -28,7 +28,7 @@ export default function PipelineView() {
 
     const {isLoaded, error, runs: latestRuns} = useFetchRuns(runFilters, otherQueryParams);
 
-    const navigate = usePipelineNavigation(calculatorPath!);
+    const navigate = usePipelineNavigation(pipelinePath!);
 
     useEffect(() => {
         if (!isLoaded || !!error) {


### PR DESCRIPTION
Elevate `rootRun`, `resolution`, and `selectedPanelItem` into supervisor contexts

Maintain the selected nested run ( `selectedRuns`) in a supervisor context. This is to pave the way to implement deep linking more easily.

What's next:
Due to the size of this PR, a follow-up PR will divide RunPanels into GraphPanel and RunDetailsPanel sections. So we have a dedicated component to deal with Graph manipulations.
Graph data derivative runsById data will also stay in a context. 
