### PR TITLE
Fix missing requirement for example testing pipeline

### DIFF
--- a/sematic/examples/testing_pipeline/BUILD
+++ b/sematic/examples/testing_pipeline/BUILD
@@ -2,6 +2,9 @@ load("//bazel:pipeline.bzl", "sematic_pipeline")
 
 sematic_example(
     name = "testing_pipeline",
+    requirements = [
+        "debugpy",
+    ],
 )
 
 sematic_pipeline(


### PR DESCRIPTION
Adds a missing requirement to the `sematic_example` target of the testing pipeline.