### PR TITLE
Avoid Artifact overwrite

### DIFF
--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -51,6 +51,8 @@ class Artifact(Base, JSONEncodableMixin):
         for column in Artifact.__table__.columns:
             if column.key in ignore_fields:
                 continue
+            if column.key is None:
+                continue
             current_val = getattr(self, column.key)
             other_val = getattr(other, column.key)
             if current_val != other_val:

--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -10,6 +10,13 @@ from sematic.db.models.json_encodable_mixin import JSON_KEY, JSONEncodableMixin
 
 
 class Artifact(Base, JSONEncodableMixin):
+    # we use content-addressed values for artifacts, with the id being
+    # generated from the type and value themselves
+    # when a resolution generates an artifact which has been seen before and which is
+    # present in the db, only the updated_at field is actually updated
+    # if you need to add new fields, these probably need to be handled in an appropriate
+    # manner in the location where artifacts are saved to the db, which at the time of
+    # writing is `sematic.db.queries.py`
 
     __tablename__ = "artifacts"
 

--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -34,3 +34,27 @@ class Artifact(Base, JSONEncodableMixin):
         default=datetime.datetime.utcnow,
         onupdate=datetime.datetime.utcnow,
     )
+
+    def assert_matches(self, other: "Artifact") -> None:
+        """Ensure the content of this artifact matches the content of the other.
+
+        Ignore timestamp fields, as these do not represent differences in the
+        artifact itself (but rather metadata about it).
+
+        Parameters
+        ----------
+        other:
+            The artifact to compare against.
+        """
+        ignore_fields = {"created_at", "updated_at"}
+
+        for column in Artifact.__table__.columns:
+            if column.key in ignore_fields:
+                continue
+            current_val = getattr(self, column.key)
+            other_val = getattr(other, column.key)
+            if current_val != other_val:
+                raise ValueError(
+                    f"Artifact content change detected for field '{column.key}': "
+                    f" original: '{current_val}' new: '{other_val}'"
+                )

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -178,7 +178,7 @@ def save_resolution(resolution: Resolution) -> Resolution:
 
 def save_graph(runs: List[Run], artifacts: List[Artifact], edges: List[Edge]):
     """
-    Update a graph
+    Update a graph.
     """
     _assert_external_jobs_not_removed(runs)
     with db().get_session() as session:
@@ -186,12 +186,28 @@ def save_graph(runs: List[Run], artifacts: List[Artifact], edges: List[Edge]):
             session.merge(run)
 
         for artifact in artifacts:
-            session.merge(artifact)
+            _save_artifact(artifact=artifact, session=session)
 
         for edge in edges:
             session.merge(edge)
 
         session.commit()
+
+
+def _save_artifact(artifact: Artifact, session: sqlalchemy.orm.Session) -> Artifact:
+    """
+    Saves or updates an Artifact, returning the actual persisted Artifact element.
+    """
+    previous_artifact = session.get(entity=Artifact, ident=artifact.id)
+
+    if previous_artifact is not None:
+        # we use content-addressed values for artifacts, with the id being
+        # generated from the type and value themselves
+        # there are currently no other fields that can be updated
+        logger.debug("Updating existing artifact %s", artifact.id)
+        artifact.created_at = previous_artifact.created_at
+
+    return session.merge(artifact)
 
 
 def _assert_external_jobs_not_removed(runs):

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -205,7 +205,8 @@ def _save_artifact(artifact: Artifact, session: sqlalchemy.orm.Session) -> Artif
         # generated from the type and value themselves
         # there are currently no other fields that can be updated
         logger.debug("Updating existing artifact %s", artifact.id)
-        artifact.created_at = previous_artifact.created_at
+        previous_artifact.assert_matches(artifact)
+        return previous_artifact
 
     return session.merge(artifact)
 

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -14,7 +14,7 @@ from sematic.db.models.factories import make_artifact, make_user
 from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
-from sematic.db.queries import save_resolution, save_run, save_user
+from sematic.db.queries import _save_artifact, save_resolution, save_run, save_user
 from sematic.resolvers.resource_requirements import (
     KubernetesResourceRequirements,
     ResourceRequirements,
@@ -194,7 +194,7 @@ def persisted_artifact(test_db, test_storage):  # noqa: F811
     artifact = make_artifact(42, int, storage=test_storage)
 
     with db.db().get_session() as session:
-        session.add(artifact)
+        artifact = _save_artifact(artifact=artifact, session=session)
         session.commit()
         session.refresh(artifact)
 

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -126,7 +126,6 @@ def test_update_artifact(test_db, test_storage):  # noqa: F811
     assert updated_artifact.created_at != original_created_at
 
     save_graph(artifacts=[updated_artifact], runs=[], edges=[])
-    assert updated_artifact.created_at == original_created_at
 
     persisted_artifact = get_artifact(original_artifact.id)  # noqa: F811
 
@@ -135,9 +134,35 @@ def test_update_artifact(test_db, test_storage):  # noqa: F811
     assert persisted_artifact.json_summary == original_artifact.json_summary
 
     assert persisted_artifact.created_at == original_created_at
+    assert persisted_artifact.updated_at == original_updated_at
 
-    assert persisted_artifact.updated_at == updated_artifact.updated_at
-    assert persisted_artifact.updated_at != original_updated_at
+
+def test_update_artifact_changed_content(test_db, test_storage):  # noqa: F811
+    original_artifact = make_artifact(42, int, storage=test_storage)
+    # create copies of these values, as sqlalchemy updates models in-place
+    original_created_at = original_artifact.created_at
+    original_updated_at = original_artifact.updated_at
+    save_graph(artifacts=[original_artifact], runs=[], edges=[])
+
+    updated_artifact = make_artifact(42, int, storage=test_storage)
+
+    # json of " 42" still deserializes to 42, but this change
+    # helps us validate immutability
+    updated_artifact.json_summary = f" {updated_artifact.json_summary}"
+
+    with pytest.raises(
+        ValueError, match="Artifact content change detected for field 'json_summary'"
+    ):
+        save_graph(artifacts=[updated_artifact], runs=[], edges=[])
+
+    persisted_artifact = get_artifact(original_artifact.id)  # noqa: F811
+
+    assert persisted_artifact.id == original_artifact.id
+    assert persisted_artifact.type_serialization == original_artifact.type_serialization
+    assert persisted_artifact.json_summary == original_artifact.json_summary
+
+    assert persisted_artifact.created_at == original_created_at
+    assert persisted_artifact.updated_at == original_updated_at
 
 
 @func

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -10,6 +10,7 @@ from sematic.api.tests.fixtures import (  # noqa: F401
 )
 from sematic.calculator import func
 from sematic.db.models.artifact import Artifact
+from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.queries import (
@@ -19,6 +20,7 @@ from sematic.db.queries import (
     get_root_graph,
     get_run,
     get_run_graph,
+    save_graph,
     save_resolution,
     save_run,
 )
@@ -99,6 +101,43 @@ def test_get_artifact(test_db, persisted_artifact: Artifact):  # noqa: F811
     assert artifact.id == persisted_artifact.id
     assert artifact.type_serialization == persisted_artifact.type_serialization
     assert artifact.json_summary == artifact.json_summary
+
+
+def test_save_artifact(test_db, test_storage):  # noqa: F811
+    artifact = make_artifact(42, int, storage=test_storage)
+    save_graph(artifacts=[artifact], runs=[], edges=[])
+    persisted_artifact = get_artifact(artifact.id)  # noqa: F811
+
+    assert persisted_artifact.id == artifact.id
+    assert persisted_artifact.type_serialization == artifact.type_serialization
+    assert persisted_artifact.json_summary == artifact.json_summary
+    assert persisted_artifact.created_at == artifact.created_at
+    assert persisted_artifact.updated_at == artifact.updated_at
+
+
+def test_update_artifact(test_db, test_storage):  # noqa: F811
+    original_artifact = make_artifact(42, int, storage=test_storage)
+    # create copies of these values, as sqlalchemy updates models in-place
+    original_created_at = original_artifact.created_at
+    original_updated_at = original_artifact.updated_at
+    save_graph(artifacts=[original_artifact], runs=[], edges=[])
+
+    updated_artifact = make_artifact(42, int, storage=test_storage)
+    assert updated_artifact.created_at != original_created_at
+
+    save_graph(artifacts=[updated_artifact], runs=[], edges=[])
+    assert updated_artifact.created_at == original_created_at
+
+    persisted_artifact = get_artifact(original_artifact.id)  # noqa: F811
+
+    assert persisted_artifact.id == original_artifact.id
+    assert persisted_artifact.type_serialization == original_artifact.type_serialization
+    assert persisted_artifact.json_summary == original_artifact.json_summary
+
+    assert persisted_artifact.created_at == original_created_at
+
+    assert persisted_artifact.updated_at == updated_artifact.updated_at
+    assert persisted_artifact.updated_at != original_updated_at
 
 
 @func


### PR DESCRIPTION
Artifacts are addressed by content, with the ID being generated from the type and value themselves. When a Resolution generates an Artifact which has been seen before and which is present in the DB, this DB entry is completely overwritten.

The consequence given the current array of Artifact fields is that the `created_at` field is always updated to the latest Resolution time of any pipeline that produces it, meaning it can't be actually trusted.

This PR changes the behavior to only update the `updated_at` field when an Artifact is recreated, and to provide instructions via code comments to future developers regarding how to update the Artifact model.

## Testing

Added 2 unit tests:
- validate creating a new Artifact
- validate updating an existing Artifact does not overwrite the `created_at` column.

Manual testing:

**Before:**

```
sqlite> select * from artifacts where id = "c57acf05da95135cc5112c6b241e51845448f715";
c57acf05da95135cc5112c6b241e51845448f715|"9.0"|2022-12-19 18:56:12.496309|2022-12-19 18:56:12.496309|"{\"registry\": {\"float\": []}, \"type\": [\"builtin\", \"float\", {}]}"

# run the pipeline; log from an un-committed feature branch:
INFO:sematic.resolvers.local_resolver:Created artifact `None` with id c57acf05da95135cc5112c6b241e51845448f715 for run 1219a72e47284732af26e59b53746fed

sqlite> select * from artifacts where id = "c57acf05da95135cc5112c6b241e51845448f715";
c57acf05da95135cc5112c6b241e51845448f715|"9.0"|2022-12-20 15:29:37.690774|2022-12-20 15:29:37.690775|"{\"registry\": {\"float\": []}, \"type\": [\"builtin\", \"float\", {}]}"
```

The `created_at` field is overwritten from `2022-12-19 18:56:12.496309` to `2022-12-20 15:29:37.690774`.

**After:**

```
sqlite> select * from artifacts where id = "c57acf05da95135cc5112c6b241e51845448f715";
c57acf05da95135cc5112c6b241e51845448f715|"9.0"|2022-12-20 15:29:37.690774|2022-12-20 15:29:37.690775|"{\"registry\": {\"float\": []}, \"type\": [\"builtin\", \"float\", {}]}"

# run the pipeline; log from an un-committed feature branch:
INFO:sematic.resolvers.local_resolver:Created artifact `None` with id c57acf05da95135cc5112c6b241e51845448f715 for run 1219a72e47284732af26e59b53746fed

sqlite> select * from artifacts where id = "c57acf05da95135cc5112c6b241e51845448f715";
c57acf05da95135cc5112c6b241e51845448f715|"9.0"|2022-12-20 15:29:37.690774|2022-12-21 10:43:07.776778|"{\"registry\": {\"float\": []}, \"type\": [\"builtin\", \"float\", {}]}"
```

The `created_at` field keeps its value of `2022-12-20 15:29:37.690774`, and the `updated_at_field` is updated from `2022-12-20 15:29:37.690775` to `2022-12-21 10:43:07.776778`.
