### PR TITLE
Fix env var override for settings

### DIFF
--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -179,6 +179,13 @@ def get_plugin_setting(
         if len(args) > 0:
             return args[0]
 
+        # _apply_env_var_overrides only applies overrides
+        # to settings present in the settings file
+        # This ensures env var overrides are still applied
+        # if the setting was not set in the file
+        if var.value in os.environ:
+            return os.environ[var.value]
+
         raise MissingSettingsError(plugin, var)
 
     return plugin_settings[var]
@@ -205,7 +212,6 @@ def set_plugin_setting(
         plugin_settings = get_plugin_settings(plugin)
     except MissingSettingsError:
         plugin_settings = {}
-        get_active_settings().settings[plugin.get_path()] = plugin_settings
 
     if _normalize_enum(plugin.get_settings_vars(), var) is None:
         raise ValueError(
@@ -216,6 +222,8 @@ def set_plugin_setting(
     plugin_settings[_PLUGIN_VERSION_KEY] = ".".join(
         str(v) for v in plugin.get_version()
     )
+
+    get_active_settings().settings[plugin.get_path()] = plugin_settings
 
     save_settings(get_settings())
 
@@ -234,6 +242,8 @@ def delete_plugin_setting(
 
     if var in plugin_settings:
         del plugin_settings[var]
+
+    get_active_settings().settings[plugin.get_path()] = plugin_settings
 
     save_settings(get_settings())
 

--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -176,15 +176,15 @@ def get_plugin_setting(
         plugin_settings = {}
 
     if var not in plugin_settings:
-        if len(args) > 0:
-            return args[0]
-
         # _apply_env_var_overrides only applies overrides
         # to settings present in the settings file
         # This ensures env var overrides are still applied
         # if the setting was not set in the file
         if var.value in os.environ:
             return os.environ[var.value]
+
+        if len(args) > 0:
+            return args[0]
 
         raise MissingSettingsError(plugin, var)
 

--- a/sematic/config/tests/BUILD
+++ b/sematic/config/tests/BUILD
@@ -33,6 +33,7 @@ pytest_test(
         ":fixtures",
         "//sematic:abstract_plugin",
         "//sematic/config:settings",
+        "//sematic/tests:fixtures",
     ],
 )
 

--- a/sematic/config/tests/test_settings.py
+++ b/sematic/config/tests/test_settings.py
@@ -18,6 +18,7 @@ from sematic.config.settings import (
     get_settings,
 )
 from sematic.config.tests.fixtures import mock_settings
+from sematic.tests.fixtures import environment_variables
 
 
 class SettingsVar(AbstractPluginSettingsVar):
@@ -131,3 +132,8 @@ def test_from_scratch(no_settings_file):
     assert (
         get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING, "default") == "default"
     )
+
+
+def test_env_override(no_settings_file):
+    with environment_variables({"SOME_SETTING": "override"}):
+        assert get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING) == "override"

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -94,7 +94,7 @@ def _load_settings_yaml(file_name: str) -> Dict[str, Any]:
 
     if os.path.isfile(settings_file_path):
         with open(settings_file_path, "r") as f:
-            return yaml.load(f, yaml.Loader)
+            return yaml.load(f, yaml.Loader) or {}
 
     return {}
 

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -22,7 +22,7 @@ def up():
     if schema_version != THIS_MIGRATION_SCHEMA_VERSION - 1:
         raise RuntimeError(
             f"Cannot upgrade settings file from version {schema_version} "
-            "to version {THIS_MIGRATION_SCHEMA_VERSION}"
+            f"to version {THIS_MIGRATION_SCHEMA_VERSION}"
         )
 
     new_settings = {

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -45,7 +45,8 @@ def up():
     with open(user_settings_file_path, "w") as f:
         f.write(yaml.dump(new_settings, Dumper=yaml.Dumper))
 
-    os.remove(server_settings_file_path)
+    if os.path.isfile(server_settings_file_path):
+        os.remove(server_settings_file_path)
 
 
 def down():


### PR DESCRIPTION
The current mechanism for overriding settings at runtime with environment variables only overrides settings that are already defined in the settings file.

This PR fixes this along with a number of small bugs in the migration file.

Tested on dev1: https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.add.pipeline.pipeline/d0a340b14e04483bbab8ccfedec51ad8