### PR TITLE
Add functionality to click artifacts in the DAG view

### DIFF
--- a/sematic/ui/src/pipelines/Artifacts.tsx
+++ b/sematic/ui/src/pipelines/Artifacts.tsx
@@ -12,6 +12,8 @@ import {
 } from "@mui/material";
 import { ErrorBoundary } from "react-error-boundary";
 import { CopyButton } from "../components/CopyButton";
+import { useEffect, useMemo, useRef } from "react";
+import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
 
 function ArtifactError(props: { error: Error }) {
   return (
@@ -57,18 +59,31 @@ export function ArtifactList(props: {
 }) {
   let { artifacts } = props;
 
+  const { selectedArtifactName } = usePipelinePanelsContext();
+
+  const refs = useRef(new Array(artifacts.size));
+  const artifactIds = useMemo(()=>Array.from(artifacts.keys()), [artifacts]);
+
+  useEffect(()=>{
+    if (selectedArtifactName !== "") {
+      const selectedRefIdx = artifactIds.indexOf(selectedArtifactName);
+      refs.current[selectedRefIdx]?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [artifactIds, selectedArtifactName]);
+
   if (artifacts.size === 0) {
     return <Alert severity="info">No values</Alert>;
   }
+
   if (artifacts.size === 1 && Array.from(artifacts.keys())[0] === "null") {
     let artifact = artifacts.get("null");
-    return <>{artifact && <ArtifactView artifact={artifact} />}</>;
+    return <>{artifact && <div ref={el => refs.current[0] = el} ><ArtifactView artifact={artifact} /></div>}</>;
   } else {
     return (
       <Table>
         <TableBody>
-          {Array.from(artifacts).map(([name, artifact]) => (
-            <TableRow key={name}>
+          {Array.from(artifacts).map(([name, artifact], idx) => (
+            <TableRow key={name} ref={el => refs.current[idx] = el}>
               <TableCell sx={{ verticalAlign: "top" }}>
                 <b>{name}</b>
               </TableCell>

--- a/sematic/ui/src/pipelines/PipelinePanels.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanels.tsx
@@ -41,10 +41,16 @@ export default function PipelinePanels() {
     return graph.runsById.get(runId) || rootRun;
   }, [selectedRunId, graph, rootRun]);
 
+  const defaultTab = selectedRun?.future_state === "FAILED" ? "logs" : "output";
+  const [selectedRunTab, setSelectedRunTab] = useState(defaultTab);
+  const [selectedArtifactName, setSelectedArtifactName] = useState("");
+
   const pipelinePanelsContext = useMemo<ExtractContextType<typeof PipelinePanelsContext>>(() => ({
     selectedPanelItem, setSelectedPanelItem,
-    selectedRun, setSelectedRunId
-  }), [selectedPanelItem, setSelectedPanelItem, selectedRun, setSelectedRunId]);
+    selectedRun, setSelectedRunId,
+    selectedRunTab, setSelectedRunTab,
+    selectedArtifactName, setSelectedArtifactName
+  }), [selectedPanelItem, selectedRun, setSelectedRunId, selectedRunTab, selectedArtifactName]);
 
   useEffect(()=> {
     if (selectedRunId === rootRun.id || 

--- a/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
@@ -6,6 +6,10 @@ export const PipelinePanelsContext = React.createContext<{
     setSelectedPanelItem: (panelItem: string) => void;
     selectedRun: Run | undefined;
     setSelectedRunId: (runId: string) => void;
+    selectedRunTab: string;
+    setSelectedRunTab: (runTab: string) => void;
+    selectedArtifactName: string;
+    setSelectedArtifactName: (artifactName: string) => void;
 } | null>(null);
 
 export default PipelinePanelsContext;

--- a/sematic/ui/src/pipelines/RunTabs.tsx
+++ b/sematic/ui/src/pipelines/RunTabs.tsx
@@ -5,9 +5,10 @@ import { Alert } from "@mui/material";
 import Box from "@mui/material/Box";
 import Tab from "@mui/material/Tab";
 import { styled } from '@mui/system';
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { EnvContext } from "..";
 import GrafanaPanel from "../addons/grafana/GrafanaPanel";
+import { usePipelinePanelsContext} from "../hooks/pipelineHooks";
 import { Artifact, Run } from "../Models";
 import { ArtifactList } from "./Artifacts";
 import Docstring from "../components/Docstring";
@@ -33,12 +34,10 @@ export default function RunTabs(props: {
 }) {
   const { run, artifacts } = props;
 
-  const defaultTab = run.future_state === "FAILED" ? "logs" : "output";
-
-  const [selectedTab, setSelectedTab] = useState(defaultTab);
-
+  const {selectedRunTab, setSelectedRunTab, setSelectedArtifactName} = usePipelinePanelsContext();
   const handleChange = (event: React.SyntheticEvent, newValue: string) => {
-    setSelectedTab(newValue);
+    setSelectedArtifactName("");
+    setSelectedRunTab(newValue);
   };
 
   const env: Map<string, string> = useContext(EnvContext);
@@ -49,7 +48,7 @@ export default function RunTabs(props: {
 
   return (
     <>
-      <TabContext value={selectedTab}>
+      <TabContext value={selectedRunTab}>
         <Box sx={{ borderBottom: 1, borderColor: "divider", flexShrink: 1 }}>
           <TabList onChange={handleChange} aria-label="Selected run tabs">
             <Tab label="Input" value="input" />
@@ -76,7 +75,7 @@ export default function RunTabs(props: {
         <TabPanel value="documentation">
           <Docstring docstring={run.description} />
         </TabPanel>
-        <ExpandedTabPanel hidden={selectedTab != "logs"} value="logs">
+        <ExpandedTabPanel hidden={selectedRunTab !== "logs"} value="logs">
           <LogPanel run={run} />
         </ExpandedTabPanel>
         <TabPanel value="source">

--- a/sematic/ui/src/pipelines/RunTree.tsx
+++ b/sematic/ui/src/pipelines/RunTree.tsx
@@ -18,15 +18,18 @@ export default function RunTree(props: {
 }) {
   let { runTreeNodes } = props;
 
-  const { selectedRun, setSelectedPanelItem, setSelectedRunId } 
+  const { selectedRun, setSelectedPanelItem, setSelectedRunId, setSelectedRunTab, setSelectedArtifactName  } 
   = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
     selectedRun: Run
   };
 
   const onSelectRun = useCallback((runId: string) => {
+    const defaultTab = selectedRun.future_state === "FAILED" ? "logs" : "output";
+    setSelectedRunTab(defaultTab);
+    setSelectedArtifactName("");
     setSelectedRunId(runId);
     setSelectedPanelItem('run');
-  }, [setSelectedPanelItem, setSelectedRunId]);
+  }, [selectedRun.future_state, setSelectedArtifactName, setSelectedPanelItem, setSelectedRunId, setSelectedRunTab]);
 
   if (runTreeNodes.length === 0) {
     return <></>;


### PR DESCRIPTION
This PR addresses issue #331. I have added the code linking artifact nodes in the DAG to the run panel. 
Further, for input artifacts with no source run, I have added the ability to scroll down to the relevant artifact automatically.  

Only part missing in the PR, is to make the artifact green when it is selected which I will address in the future.