### PR TITLE
Update requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -55,11 +55,8 @@ xgboost
 
 # Types
 ## Snowflake
-snowflake-connector-python
-
-# exclusion pinned because 22.1.0 gives a version
-# dependency conflict with snowflake 2.7.12
-pyOpenSSL!=22.1.0
+snowflake-connector-python>=2.8.0
+pyOpenSSL
 pyarrow
 
 # Cloud execution

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -50,7 +50,7 @@ contourpy==1.0.5
     # via matplotlib
 coverage @ git+https://github.com/ulfjack/coveragepy.git@lcov-support
     # via -r requirements/requirements.in
-cryptography==36.0.2
+cryptography==38.0.4
     # via
     #   pyopenssl
     #   snowflake-connector-python
@@ -210,7 +210,7 @@ pygments==2.13.0
     # via ipython
 pyjwt==2.5.0
     # via snowflake-connector-python
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.in
     #   snowflake-connector-python
@@ -279,7 +279,7 @@ six==1.16.0
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
-snowflake-connector-python==2.7.12
+snowflake-connector-python==2.9.0
     # via -r requirements/requirements.in
 sqlalchemy==1.4.36
     # via -r requirements/requirements.in


### PR DESCRIPTION
Some recent lib updates appear to have broken the snowflake connector's SSL usage. It is breaking the build. See [here](https://app.circleci.com/pipelines/github/sematic-ai/sematic/1589/workflows/061ed3d6-dd8b-4530-a165-24e647c51610/jobs/1566) for example. This fixes it.