### PR TITLE
Install Sqlite3 from sources in the Sematic Docker image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -6,6 +6,11 @@
 # for why --platform
 FROM --platform=linux/amd64 python:3.9-bullseye
 
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y sqlite3
+COPY install_sqlite3.sh .
+RUN bash install_sqlite3.sh
 RUN python3 -m pip install --upgrade pip
 
 # RUN pip install sematic
@@ -14,4 +19,5 @@ COPY sematic-*.whl .
 RUN pip install sematic-*.whl
 
 EXPOSE 80
-CMD python3 -m sematic.db.migrate up --verbose --env cloud && python3 -m sematic.api.server --env cloud
+CMD python3 -m sematic.db.migrate up --verbose --env cloud; python3 -m sematic.api.server --env cloud
+

--- a/docker/install_sqlite3.sh
+++ b/docker/install_sqlite3.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+wget https://www.sqlite.org/src/tarball/sqlite.tar.gz
+tar xzf sqlite.tar.gz
+pushd sqlite/
+
+export CFLAGS="-DSQLITE_ENABLE_FTS3 \
+    -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+    -DSQLITE_ENABLE_FTS4 \
+    -DSQLITE_ENABLE_FTS5 \
+    -DSQLITE_ENABLE_JSON1 \
+    -DSQLITE_ENABLE_LOAD_EXTENSION \
+    -DSQLITE_ENABLE_RTREE \
+    -DSQLITE_ENABLE_STAT4 \
+    -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT \
+    -DSQLITE_SOUNDEX \
+    -DSQLITE_TEMP_STORE=3 \
+    -DSQLITE_USE_URI \
+    -O2 \
+    -fPIC"
+
+export PREFIX="/usr/local"
+
+LIBS="-lm" ./configure --disable-tcl --enable-shared --enable-tempstore=always --prefix="$PREFIX"
+
+make
+make install
+
+popd
+


### PR DESCRIPTION
The minimum required version of Sqlite3 is 3.35.0, but our Docker base image comes with 3.34.1.

This updates the Sematic Docker image build to install the latest version from scratch.
