### PR TITLE
Add testing code to wheel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
+    * [bugfix] Add `sematic.testing` to python wheel
 * [0.21.1](https://pypi.org/project/sematic/0.21.1/)
     * [bugfix] Add back feature allowing configuration of custom API URL to be used by workers
 * [0.21.0](https://pypi.org/project/sematic/0.21.0/)

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -227,6 +227,7 @@ sematic_py_wheel(
     deps = [
         "//sematic:client",
         "//sematic:init",
+        "//sematic/testing:init",
         "//sematic/cli:main_lib",
     ],
 )


### PR DESCRIPTION
The code in `sematic.testing` was not getting built into the wheel, because the wheel only depends on certain select top-level modules and their transitive dependencies. This PR adds `sematic.testing` to that list.

Testing
--------
```
$ make wheel
$ virtualenv --python=$(which python3.8) ~/venvs/checktesting
$ source ~/venvs/checktesting/bin/activate
$ pip install ~/code/sematic/bazel-bin/sematic/sematic-0.21.1-py3-none-any.whl
$ cd ~/
$ python3 -c "from sematic.testing import mock_sematic_funcs; print(mock_sematic_funcs)"
<function mock_sematic_funcs at 0x1174d28b0>
```