### PR TITLE
Implement deep link for selected runs

### DIFF
--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -27,6 +27,8 @@
         "dagre": "^0.8.5",
         "date-fns": "^2.29.3",
         "javascript-time-ago": "^2.3.13",
+        "jotai": "^1.12.1",
+        "jotai-location": "^0.3.2",
         "mpld3": "^0.5.8",
         "plotly.js-cartesian-dist": "^2.12.1",
         "react": "^18.1.0",
@@ -12750,6 +12752,67 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmmirror.com/jotai/-/jotai-1.12.1.tgz",
+      "integrity": "sha512-t6gsYM1WkQHMOazaZYLykCA+fh9KPDGrA+tDYzDeV0268QsCqmX6S4lO46uswgt1LGUeG0EDFGuMd9ac8cWNTA==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "@babel/template": "*",
+        "jotai-immer": "*",
+        "jotai-optics": "*",
+        "jotai-redux": "*",
+        "jotai-tanstack-query": "*",
+        "jotai-urql": "*",
+        "jotai-valtio": "*",
+        "jotai-xstate": "*",
+        "jotai-zustand": "*",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "jotai-immer": {
+          "optional": true
+        },
+        "jotai-optics": {
+          "optional": true
+        },
+        "jotai-redux": {
+          "optional": true
+        },
+        "jotai-tanstack-query": {
+          "optional": true
+        },
+        "jotai-urql": {
+          "optional": true
+        },
+        "jotai-valtio": {
+          "optional": true
+        },
+        "jotai-xstate": {
+          "optional": true
+        },
+        "jotai-zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jotai-location": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/jotai-location/-/jotai-location-0.3.2.tgz",
+      "integrity": "sha512-VQe3CzArXqzdmJ8EqRppsXn9/rjRjIWjlshWUc1FaB/XeFq5bQwfVq9tGK9JNpwT7Er56LXnf1ez20IPntUY0g==",
+      "peerDependencies": {
+        "jotai": "*"
       }
     },
     "node_modules/js-cookie": {
@@ -28839,6 +28902,18 @@
           }
         }
       }
+    },
+    "jotai": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmmirror.com/jotai/-/jotai-1.12.1.tgz",
+      "integrity": "sha512-t6gsYM1WkQHMOazaZYLykCA+fh9KPDGrA+tDYzDeV0268QsCqmX6S4lO46uswgt1LGUeG0EDFGuMd9ac8cWNTA==",
+      "requires": {}
+    },
+    "jotai-location": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/jotai-location/-/jotai-location-0.3.2.tgz",
+      "integrity": "sha512-VQe3CzArXqzdmJ8EqRppsXn9/rjRjIWjlshWUc1FaB/XeFq5bQwfVq9tGK9JNpwT7Er56LXnf1ez20IPntUY0g==",
+      "requires": {}
     },
     "js-cookie": {
       "version": "2.2.1",

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -23,6 +23,8 @@
     "dagre": "^0.8.5",
     "date-fns": "^2.29.3",
     "javascript-time-ago": "^2.3.13",
+    "jotai": "^1.12.1",
+    "jotai-location": "^0.3.2",
     "mpld3": "^0.5.8",
     "plotly.js-cartesian-dist": "^2.12.1",
     "react": "^18.1.0",

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import useAsync from "react-use/lib/useAsync";
 import useAsyncFn from "react-use/lib/useAsyncFn";
 import { Resolution, Run } from "../Models";
@@ -7,8 +7,11 @@ import { Filter, ResolutionPayload, RunListPayload, RunViewPayload } from "../Pa
 import PipelinePanelsContext from "../pipelines/PipelinePanelsContext";
 import PipelineRunViewContext from "../pipelines/PipelineRunViewContext";
 import { useHttpClient } from "./httpHooks";
+import { atomWithHash } from 'jotai-location'
 
 export type QueryParams = {[key: string]: string};
+
+export const selectedRunHashAtom = atomWithHash('run', '')
 
 export function usePipelineRunContext() {
     const contextValue = useContext(PipelineRunViewContext);
@@ -115,14 +118,18 @@ export function getPipelineUrlPattern(pipelinePath: string, requestedRootId: str
 export function usePipelineNavigation(pipelinePath: string) {
     const navigate = useNavigate();
     const { rootId } = useParams();
+    const { hash } = useLocation();
 
     return useCallback((requestedRootId: string, replace: boolean = false) => {
         if ( rootId === requestedRootId ) {
             return
         }
 
-        navigate(getPipelineUrlPattern(pipelinePath, requestedRootId), {
+        navigate({
+            pathname: getPipelineUrlPattern(pipelinePath, requestedRootId),
+            hash
+        }, {
             replace
         });
-    }, [pipelinePath, rootId, navigate]);
+    }, [pipelinePath, rootId, hash, navigate]);
 }

--- a/sematic/ui/src/pipelines/NotesPanel.tsx
+++ b/sematic/ui/src/pipelines/NotesPanel.tsx
@@ -16,6 +16,7 @@ import PipelineRunViewContext from "./PipelineRunViewContext";
 import { fetchJSON } from "../utils";
 import { NoteView } from "../components/Notes";
 import { ExtractContextType } from "../components/utils/typings";
+import PipelinePanelsContext from "./PipelinePanelsContext";
 
 export default function NotesPanel() {
   const theme = useTheme();
@@ -24,8 +25,10 @@ export default function NotesPanel() {
   const { rootRun } 
     = usePipelineRunContext() as ExtractContextType<typeof PipelineRunViewContext> & {
       rootRun: Run
-  };;
-  const { selectedRun } = usePipelinePanelsContext();
+  };
+  const { selectedRun } = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
+    selectedRun: Run
+  };
 
 
   const calculatorPath = useMemo(

--- a/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanelsContext.tsx
@@ -4,8 +4,8 @@ import { Run } from "../Models";
 export const PipelinePanelsContext = React.createContext<{
     selectedPanelItem: string;
     setSelectedPanelItem: (panelItem: string) => void;
-    selectedRun: Run;
-    setSelectedRun: (run: Run) => void;
+    selectedRun: Run | undefined;
+    setSelectedRunId: (runId: string) => void;
 } | null>(null);
 
 export default PipelinePanelsContext;

--- a/sematic/ui/src/pipelines/RunDetailsPanel.tsx
+++ b/sematic/ui/src/pipelines/RunDetailsPanel.tsx
@@ -5,19 +5,22 @@ import { ActionMenu, ActionMenuItem } from "../components/ActionMenu";
 import CalculatorPath from "../components/CalculatorPath";
 import Docstring from "../components/Docstring";
 import RunStateChip from "../components/RunStateChip";
-import RunTabs, { IOArtifacts } from "./RunTabs";
 import { RunTime } from "../components/RunTime";
 import { SnackBarContext } from "../components/SnackBarProvider";
 import Tags from "../components/Tags";
 import { ExtractContextType } from "../components/utils/typings";
 import { useGraphContext } from "../hooks/graphHooks";
 import { usePipelinePanelsContext, usePipelineRunContext } from "../hooks/pipelineHooks";
-import { Artifact, Run, Resolution, Edge } from "../Models";
+import { Artifact, Edge, Resolution, Run } from "../Models";
 import { fetchJSON } from "../utils";
+import PipelinePanelsContext from "./PipelinePanelsContext";
 import PipelineRunViewContext from "./PipelineRunViewContext";
+import RunTabs, { IOArtifacts } from "./RunTabs";
 
 export function RunDetailsPanel() {
-    const { selectedRun } = usePipelinePanelsContext();
+    const { selectedRun } = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
+      selectedRun: Run
+    };
     const { graph } = useGraphContext();
 
     const { edges, artifactsById } = graph!;

--- a/sematic/ui/src/pipelines/RunTree.tsx
+++ b/sematic/ui/src/pipelines/RunTree.tsx
@@ -10,18 +10,23 @@ import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
 import { RunTreeNode } from "../interfaces/graph";
 import { Run } from "../Models";
 import RunStateChip from "../components/RunStateChip";
+import { ExtractContextType } from "../components/utils/typings";
+import PipelinePanelsContext from "./PipelinePanelsContext";
 
 export default function RunTree(props: {
   runTreeNodes: Array<RunTreeNode>;
 }) {
   let { runTreeNodes } = props;
 
-  const { selectedRun, setSelectedPanelItem, setSelectedRun } = usePipelinePanelsContext();
+  const { selectedRun, setSelectedPanelItem, setSelectedRunId } 
+  = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
+    selectedRun: Run
+  };
 
-  const onSelectRun = useCallback((run: Run) => {
-    setSelectedRun(run);
+  const onSelectRun = useCallback((runId: string) => {
+    setSelectedRunId(runId);
     setSelectedPanelItem('run');
-  }, [setSelectedPanelItem, setSelectedRun]);
+  }, [setSelectedPanelItem, setSelectedRunId]);
 
   if (runTreeNodes.length === 0) {
     return <></>;
@@ -35,7 +40,7 @@ export default function RunTree(props: {
       {runTreeNodes.map(({run, children}) => (
         <Fragment key={run!.id}>
           <ListItemButton
-            onClick={() => onSelectRun(run!)}
+            onClick={() => onSelectRun(run!.id)}
             key={run!.id}
             sx={{ height: "30px" }}
             selected={selectedRun.id === run!.id}

--- a/sematic/ui/src/pipelines/graph/ReactFlowDag.tsx
+++ b/sematic/ui/src/pipelines/graph/ReactFlowDag.tsx
@@ -16,6 +16,8 @@ import RunNode from "./RunNode";
 import ArtifactNode from "./ArtifactNode";
 import { usePipelinePanelsContext } from "../../hooks/pipelineHooks";
 import { useGraphContext } from "../../hooks/graphHooks";
+import { ExtractContextType } from "../../components/utils/typings";
+import PipelinePanelsContext from "../PipelinePanelsContext";
 
 var util = require("dagre/lib/util");
 var graphlib = require("graphlib");
@@ -50,12 +52,15 @@ function ReactFlowDag() {
 
   const { runs, edges } = graph!;
 
-  const { selectedRun, setSelectedPanelItem, setSelectedRun } = usePipelinePanelsContext();
+  const { selectedRun, setSelectedPanelItem, setSelectedRunId } 
+  = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
+    selectedRun: Run
+  };
 
-  const onSelectRun = useCallback((run: Run) => {
-    setSelectedRun(run);
+  const onSelectRun = useCallback((runId: string) => {
+    setSelectedRunId(runId);
     setSelectedPanelItem("run");
-  }, [setSelectedRun, setSelectedPanelItem]);
+  }, [setSelectedRunId, setSelectedPanelItem]);
 
   const runsById = useMemo(
     () => new Map(runs.map((run) => [run.id, run])),
@@ -195,7 +200,7 @@ function ReactFlowDag() {
     (event: any, node: Node) => {
       let selectedRun = runsById.get(node.id);
       if (selectedRun) {
-        onSelectRun(selectedRun);
+        onSelectRun(selectedRun.id);
       }
     },
     [runsById, onSelectRun]


### PR DESCRIPTION
Implements deep link thanks to the help of [Jotai](https://jotai.org/) library.

Deep link has a pattern of 
```
http://localhost:3000/pipelines/sematic.examples.add.pipeline.pipeline/46b01356e2864c4f917d1d9125288ee7#selRun=%2224da63e8353d4cd3b49e0dbf96f881a4%22
```

Here is a demo:
![capture1](https://user-images.githubusercontent.com/1046489/210659808-7a9491a2-1cd7-4d9e-8017-75d951506691.gif)


Some other maintenance work:
* Changed the API for reporting selected runs to `setSelectedRunId`, so we avoid client reporting with inconsistent runs. The real run instance will be given by the `PipelinePanelsContext`, so this keeps the references to the run instances as consistent as possible.  


Planned job in the near future:
1. Support "host:/pipelines/[pipelineName]/[nest_run_id]" style URL
2. Support deep links to run tabs and the selected artifact.