### PR TITLE
[3/N] Storage plugins integration

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
 {{ end }}
 {{ if .Values.aws.enabled }}
   AWS_S3_BUCKET: {{ .Values.aws.storage_bucket | quote }}
+  STORAGE: "sematic.plugins.storage.s3_storage.S3Storage"
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -8,9 +8,9 @@ sematic_py_lib(
         ":container_images",
         ":resolver",
         ":retry_settings",
-        "//sematic/plugins/external_resource:timed_message",
         "//sematic:future_context",
         "//sematic/future_operators:init",
+        "//sematic/plugins/external_resource:timed_message",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:local_resolver",
         "//sematic/resolvers:resource_requirements",
@@ -44,7 +44,6 @@ sematic_py_lib(
     # buildifier: leave-alone
     deps = [
         "//sematic:abstract_future",
-        "//sematic:storage",
         "//sematic:versions",
         "//sematic/config:config",
         "//sematic/config:settings",
@@ -78,10 +77,10 @@ sematic_py_lib(
     deps = [
         "//sematic:abstract_future",
         "//sematic:api_client",
-        "//sematic:storage",
         "//sematic/db:queries",
         "//sematic/db/models:resolution",
         "//sematic/db/models:run",
+        "//sematic/plugins/storage:s3_storage",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/scheduling:external_job",
     ],
@@ -186,13 +185,14 @@ sematic_py_lib(
     srcs = ["graph.py"],
     deps = [
         ":abstract_future",
+        ":api_client",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",
         "//sematic/db/models:run",
         "//sematic/resolvers:type_utils",
-        "//sematic/utils:memoized_property",
         "//sematic/utils:algorithms",
+        "//sematic/utils:memoized_property",
     ],
 )
 

--- a/sematic/abstract_plugin.py
+++ b/sematic/abstract_plugin.py
@@ -124,6 +124,8 @@ def import_plugin(plugin_import_path: str) -> Type[AbstractPlugin]:
     MissingPluginError
         The requested plug-in cannot be found.
     """
+    logger.info("Importing plug-in %s", plugin_import_path)
+
     try:
         split_import_path = plugin_import_path.split(".")
         import_path, plugin_name = (

--- a/sematic/abstract_plugin.py
+++ b/sematic/abstract_plugin.py
@@ -124,8 +124,6 @@ def import_plugin(plugin_import_path: str) -> Type[AbstractPlugin]:
     MissingPluginError
         The requested plug-in cannot be found.
     """
-    logger.info("Importing plug-in %s", plugin_import_path)
-
     try:
         split_import_path = plugin_import_path.split(".")
         import_path, plugin_name = (

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -15,7 +15,7 @@ from sematic.api.endpoints.request_parameters import (
     get_request_parameters,
     jsonify_error,
 )
-from sematic.config.settings import get_active_plugins, get_active_settings
+from sematic.config.settings import get_active_plugins
 from sematic.db.db import db
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.user import User

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -1,4 +1,5 @@
 # Standard Library
+import logging
 from http import HTTPStatus
 from typing import List, Optional, Type, cast
 
@@ -22,6 +23,8 @@ from sematic.db.models.user import User
 from sematic.db.queries import get_artifact
 from sematic.plugins.abstract_storage import AbstractStorage, PayloadType
 from sematic.plugins.storage.local_storage import LocalStorage
+
+logger = logging.getLogger(__name__)
 
 
 @sematic_api.route("/api/v1/artifacts", methods=["GET"])
@@ -84,6 +87,8 @@ def get_artifact_location_endpoint(user: Optional[User], artifact_id: str):
         return jsonify_error(
             "Incorrect storage plugin scope", HTTPStatus.INTERNAL_SERVER_ERROR
         )
+
+    logger.info("Using storage plug-in %s", repr(storage_class))
 
     location = storage_class().get_write_location("artifacts", artifact_id)
 

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -88,7 +88,7 @@ def get_artifact_location_endpoint(user: Optional[User], artifact_id: str):
             "Incorrect storage plugin scope", HTTPStatus.INTERNAL_SERVER_ERROR
         )
 
-    logger.info("Using storage plug-in %s", repr(storage_class))
+    logger.info("Using storage plug-in %s", storage_class)
 
     location = storage_class().get_write_location("artifacts", artifact_id)
 
@@ -105,6 +105,8 @@ def get_artifact_data_endpoint(user: Optional[User], artifact_id: str):
         return jsonify_error(
             "Incorrect storage plugin scope", HTTPStatus.INTERNAL_SERVER_ERROR
         )
+
+    logger.info("Using storage plug-in %s", storage_class)
 
     read_payload = storage_class().get_read_payload("artifacts", artifact_id)
 

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -15,7 +15,7 @@ from sematic.api.endpoints.request_parameters import (
     get_request_parameters,
     jsonify_error,
 )
-from sematic.config.settings import get_active_plugins
+from sematic.config.settings import get_active_plugins, get_active_settings
 from sematic.db.db import db
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.user import User

--- a/sematic/api/endpoints/tests/test_artifacts.py
+++ b/sematic/api/endpoints/tests/test_artifacts.py
@@ -43,7 +43,7 @@ def test_upload_download(
 
     location = response.json["location"]  # type: ignore
 
-    response = test_client.put(location, data=value)
+    response = test_client.put(f"/api/v1{location}", data=value)
     assert response.status_code == 200
 
     response = test_client.get("/api/v1/artifacts/123/data")

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -31,7 +31,6 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     test_db,
 )
 from sematic.log_reader import LogLineResult
-from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
 from sematic.scheduling.external_job import JobType
 from sematic.scheduling.kubernetes import KubernetesExternalJob
 from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
@@ -444,7 +443,6 @@ def pipeline(a: float, b: float) -> float:
     "root, run_count, artifact_count, edge_count", ((0, 1, 3, 3), (1, 3, 4, 8))
 )
 def test_get_run_graph_endpoint(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     root: int,

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -99,7 +99,7 @@ def store_artifact_bytes(artifact_id: str, bytes_: bytes) -> None:
 
 
 def _get_artifact_bytes(artifact_id: str) -> bytes:
-    return _get(f"/artifacts/{artifact_id}/data", content=True)
+    return _get(f"/artifacts/{artifact_id}/data", decode_json=False)
 
 
 def get_run(run_id: str) -> Run:
@@ -327,13 +327,24 @@ def _notify_event(namespace: str, event: str, payload: Any = None):
     backoff=2,
     jitter=0.1,
 )
-def _get(endpoint: str, content: bool = False) -> Any:
+def _get(endpoint: str, decode_json: bool = True) -> Any:
+    """
+    Get a payload from the API server.
+
+    Parameters
+    ----------
+    endpoint: str
+        Endpoint to query. `/api/v1` will be prepended and authentication
+        headers will be added.
+    decode_json: bool
+        Defaults to `True`. Whether the returned payload should be JSON-decoded.
+    """
     response = _request(requests.get, endpoint)
 
-    if content:
-        return response.content
+    if decode_json:
+        return response.json()
 
-    return response.json()
+    return response.content
 
 
 @retry(

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -14,11 +14,10 @@ from sematic.config.user_settings import UserSettings, UserSettingsVar, get_user
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.external_resource import ExternalResource
-from sematic.db.models.factories import get_artifact_value
+from sematic.db.models.factories import deserialize_artifact_value
 from sematic.db.models.resolution import Resolution
 from sematic.db.models.run import Run
 from sematic.plugins.abstract_external_resource import AbstractExternalResource
-from sematic.storage import S3Storage, Storage
 from sematic.utils.retry import retry
 from sematic.versions import CURRENT_VERSION, version_as_string
 
@@ -54,9 +53,7 @@ class ResourceNotFoundError(BadRequestError):
     pass
 
 
-def get_artifact_value_by_id(
-    artifact_id: str, storage: Optional[Storage] = None
-) -> Any:
+def get_artifact_value_by_id(artifact_id: str) -> Any:
     """
     Retrieve the value of an artifact by ID.
 
@@ -71,13 +68,15 @@ def get_artifact_value_by_id(
     Any
         The value of the requiested artifact.
     """
-    # TODO: Store storage type on artifact
-    if storage is None:
-        storage = S3Storage()
-
     artifact = _get_artifact(artifact_id)
 
-    return get_artifact_value(artifact, storage)
+    return get_artifact_value(artifact)
+
+
+def get_artifact_value(artifact: Artifact) -> Any:
+    payload = _get_artifact_bytes(artifact.id)
+
+    return deserialize_artifact_value(artifact, payload)
 
 
 def _get_artifact(artifact_id: str) -> Artifact:
@@ -87,6 +86,20 @@ def _get_artifact(artifact_id: str) -> Artifact:
     response = _get("/artifacts/{}".format(artifact_id))
 
     return Artifact.from_json_encodable(response["content"])
+
+
+def store_artifact_bytes(artifact_id: str, bytes_: bytes) -> None:
+    response = _get(f"/artifacts/{artifact_id}/location")
+
+    location: str = response["location"]
+
+    put = requests.put if location.startswith("https://") else _put
+
+    put(location, data=bytes_)
+
+
+def _get_artifact_bytes(artifact_id: str) -> bytes:
+    return _get(f"/artifacts/{artifact_id}/data", content=True)
 
 
 def get_run(run_id: str) -> Run:
@@ -314,8 +327,11 @@ def _notify_event(namespace: str, event: str, payload: Any = None):
     backoff=2,
     jitter=0.1,
 )
-def _get(endpoint) -> Any:
+def _get(endpoint: str, content: bool = False) -> Any:
     response = _request(requests.get, endpoint)
+
+    if content:
+        return response.content
 
     return response.json()
 
@@ -343,8 +359,12 @@ def _post(endpoint, json_payload) -> Any:
     backoff=2,
     jitter=0.1,
 )
-def _put(endpoint, json_payload) -> Any:
-    response = _request(requests.put, endpoint, dict(json=json_payload))
+def _put(
+    endpoint: str,
+    json_payload: Optional[Dict[str, Any]] = None,
+    data: Optional[bytes] = None,
+) -> Any:
+    response = _request(requests.put, endpoint, dict(json=json_payload, data=data))
 
     if len(response.content) == 0:
         return None

--- a/sematic/cli/tests/test_logs.py
+++ b/sematic/cli/tests/test_logs.py
@@ -19,6 +19,7 @@ from sematic.tests.fixtures import MockStorage  # noqa: F401
 @pytest.fixture
 def mock_storage():
     storage = MockStorage()
+    storage._store.clear()
     with mock.patch("sematic.log_reader.S3Storage", return_value=storage):
         yield storage
 

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -29,11 +29,10 @@ sematic_py_lib(
         ":run",
         ":user",
         "//sematic:abstract_future",
-        "//sematic:storage",
-        "//sematic/types/types:union",
         "//sematic/types:serialization",
-        "//sematic/utils:json",
+        "//sematic/types/types:union",
         "//sematic/utils:hashing",
+        "//sematic/utils:json",
     ],
 )
 

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -11,10 +11,8 @@ from sematic.abstract_future import FutureState
 from sematic.calculator import func
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import (
-    _make_artifact_storage_key,
     clone_resolution,
     clone_root_run,
-    get_artifact_value,
     make_artifact,
     make_run_from_future,
 )
@@ -25,7 +23,6 @@ from sematic.resolvers.resource_requirements import (
     KubernetesResourceRequirements,
     ResourceRequirements,
 )
-from sematic.storage import MemoryStorage
 from sematic.types.serialization import (
     get_json_encodable_summary,
     type_to_json_encodable,
@@ -74,7 +71,7 @@ def f():
 
 
 def test_make_artifact():
-    artifact = make_artifact(42, int)
+    artifact, _ = make_artifact(42, int)
 
     value_serialization = value_to_json_encodable(42, int)
     type_serialization = type_to_json_encodable(int)
@@ -94,7 +91,7 @@ def test_make_artifact():
 
 
 def test_make_artifact_with_optional_type_hint():
-    artifact = make_artifact([42], Optional[List[int]])
+    artifact, _ = make_artifact([42], Optional[List[int]])
 
     value_serialization = value_to_json_encodable([42], List[int])
     type_serialization = type_to_json_encodable(List[int])
@@ -114,7 +111,7 @@ def test_make_artifact_with_optional_type_hint():
 
 
 def test_make_artifact_with_nested_union_type_hint():
-    artifact = make_artifact([42], Union[Union[List[int], str], List[str]])
+    artifact, _ = make_artifact([42], Union[Union[List[int], str], List[str]])
 
     value_serialization = value_to_json_encodable([42], List[int])
     type_serialization = type_to_json_encodable(List[int])
@@ -142,28 +139,9 @@ def test_make_artifact_with_nested_union_type_hint():
     ),
 )
 def test_make_artifact_special_floats(value, expected_value):
-    artifact = make_artifact(value, float)
+    artifact, _ = make_artifact(value, float)
 
     assert json.loads(artifact.json_summary) == expected_value
-
-
-def test_make_artifact_store():
-    storage = MemoryStorage()
-    artifact = make_artifact(42, int, storage=storage)
-
-    storage_key = _make_artifact_storage_key(artifact)
-
-    assert storage.get(storage_key) == "42".encode("utf-8")
-
-
-def test_get_artifact_value():
-    storage = MemoryStorage()
-    artifact = make_artifact(42, int, storage=storage)
-
-    value = get_artifact_value(artifact, storage)
-
-    assert value == 42
-    assert isinstance(value, int)
 
 
 def test_clone_root_run(run: Run):  # noqa: F811

--- a/sematic/db/tests/BUILD
+++ b/sematic/db/tests/BUILD
@@ -44,7 +44,6 @@ pytest_test(
         "//sematic/db:db",
         "//sematic/db:queries",
         "//sematic/db/models:artifact",
-        "//sematic/db/models:edge",
         "//sematic/db/models:external_resource",
         "//sematic/db/models:factories",
         "//sematic/db/models:resolution",
@@ -53,6 +52,7 @@ pytest_test(
         "//sematic/resolvers/tests:fixtures",
         "//sematic/tests:fixtures",
         "//sematic/types:init",
+        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -206,11 +206,15 @@ def persisted_artifact(test_db, test_storage):  # noqa: F811
     """
     Persisted artifact fixture.
     """
-    artifact = make_artifact(42, int, storage=test_storage)
+    artifact, bytes_ = make_artifact(42, int)
 
     with db.db().get_session() as session:
         artifact = _save_artifact(artifact=artifact, session=session)
         session.commit()
         session.refresh(artifact)
+
+    test_storage.set(
+        test_storage().get_write_location("artifacts", artifact.id), bytes_
+    )
 
     return artifact

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -46,7 +46,6 @@ from sematic.plugins.abstract_external_resource import (
     ManagedBy,
     ResourceState,
 )
-from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
 from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
 from sematic.utils.exceptions import IllegalStateTransitionError
 
@@ -117,8 +116,8 @@ def test_get_artifact(test_db, persisted_artifact: Artifact):  # noqa: F811
     assert artifact.json_summary == artifact.json_summary
 
 
-def test_save_artifact(test_db, test_storage):  # noqa: F811
-    artifact = make_artifact(42, int, storage=test_storage)
+def test_save_artifact(test_db):  # noqa: F811
+    artifact, _ = make_artifact(42, int)
     save_graph(artifacts=[artifact], runs=[], edges=[])
     persisted_artifact = get_artifact(artifact.id)  # noqa: F811
 
@@ -129,14 +128,14 @@ def test_save_artifact(test_db, test_storage):  # noqa: F811
     assert persisted_artifact.updated_at == artifact.updated_at
 
 
-def test_update_artifact(test_db, test_storage):  # noqa: F811
-    original_artifact = make_artifact(42, int, storage=test_storage)
+def test_update_artifact(test_db):  # noqa: F811
+    original_artifact, _ = make_artifact(42, int)
     # create copies of these values, as sqlalchemy updates models in-place
     original_created_at = original_artifact.created_at
     original_updated_at = original_artifact.updated_at
     save_graph(artifacts=[original_artifact], runs=[], edges=[])
 
-    updated_artifact = make_artifact(42, int, storage=test_storage)
+    updated_artifact, _ = make_artifact(42, int)
     assert updated_artifact.created_at != original_created_at
 
     save_graph(artifacts=[updated_artifact], runs=[], edges=[])
@@ -151,14 +150,14 @@ def test_update_artifact(test_db, test_storage):  # noqa: F811
     assert persisted_artifact.updated_at == original_updated_at
 
 
-def test_update_artifact_changed_content(test_db, test_storage):  # noqa: F811
-    original_artifact = make_artifact(42, int, storage=test_storage)
+def test_update_artifact_changed_content(test_db):  # noqa: F811
+    original_artifact, _ = make_artifact(42, int)
     # create copies of these values, as sqlalchemy updates models in-place
     original_created_at = original_artifact.created_at
     original_updated_at = original_artifact.updated_at
     save_graph(artifacts=[original_artifact], runs=[], edges=[])
 
-    updated_artifact = make_artifact(42, int, storage=test_storage)
+    updated_artifact, _ = make_artifact(42, int)
 
     # json of " 42" still deserializes to 42, but this change
     # helps us validate immutability
@@ -195,7 +194,6 @@ def pipeline(a: float, b: float) -> float:
 )
 def test_get_run_graph(
     mock_auth,  # noqa: F811
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     fn,
     run_count: int,

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -6,13 +6,12 @@ from typing import OrderedDict as OrderedDictType
 from typing import Tuple
 
 # Sematic
+import sematic.api_client as api_client
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
-from sematic.db.models.factories import get_artifact_value
 from sematic.db.models.run import Run
 from sematic.resolvers.type_utils import make_list_type, make_tuple_type
-from sematic.storage import Storage
 from sematic.utils.algorithms import breadth_first_search, topological_sort
 from sematic.utils.memoized_property import memoized_indexed, memoized_property
 
@@ -114,7 +113,6 @@ class Graph:
     runs: Iterable[Run]
     edges: Iterable[Edge]
     artifacts: Iterable[Artifact]
-    storage: Storage
 
     def __post_init__(self):
         self.runs = tuple(self.runs)
@@ -384,7 +382,7 @@ class Graph:
     @memoized_indexed
     def _get_artifact_value(self, artifact_id: str) -> Any:
         artifact = self._artifacts_by_id[artifact_id]
-        return get_artifact_value(artifact, self.storage)
+        return api_client.get_artifact_value(artifact)
 
     def _get_cloned_future_inputs(
         self, run_id: RunID, cloned_graph: ClonedFutureGraph

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -13,12 +13,12 @@ from sematic.abstract_future import FutureState
 from sematic.db import queries as db_queries
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
+from sematic.plugins.storage.s3_storage import S3Storage
 from sematic.resolvers.cloud_resolver import (
     END_INLINE_RUN_INDICATOR,
     START_INLINE_RUN_INDICATOR,
 )
 from sematic.scheduling.external_job import JobType
-from sematic.storage import S3Storage
 
 # Why the "V1"/"V2"? Because we changed the structure of the logs. Originally,
 # each file on s3 held the entirety of the logs. Now each file contains a

--- a/sematic/plugins/abstract_storage.py
+++ b/sematic/plugins/abstract_storage.py
@@ -2,7 +2,7 @@
 import abc
 import enum
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Type
 
 
 class PayloadType(enum.Enum):
@@ -44,6 +44,6 @@ class AbstractStorage(abc.ABC):
         pass
 
 
-class NoSuchStorageKey(KeyError):
-    def __init__(self, storage: AbstractStorage, key: str):
-        super().__init__(f"No such storage key for {storage.__class__.__name__}: {key}")
+class NoSuchStorageKeyError(KeyError):
+    def __init__(self, storage: Type[AbstractStorage], key: str):
+        super().__init__(f"No such storage key for {storage.__name__}: {key}")

--- a/sematic/plugins/storage/local_storage.py
+++ b/sematic/plugins/storage/local_storage.py
@@ -14,7 +14,7 @@ from sematic.config.config import get_config
 from sematic.db.models.user import User
 from sematic.plugins.abstract_storage import (
     AbstractStorage,
-    NoSuchStorageKey,
+    NoSuchStorageKeyError,
     PayloadType,
     ReadPayload,
 )
@@ -40,14 +40,14 @@ class LocalStorage(AbstractStorage, AbstractPlugin):
         return _PLUGIN_VERSION
 
     def get_write_location(self, namespace: str, key: str) -> str:
-        return f"{get_config().api_url}/upload/{namespace}/{key}"
+        return f"/upload/{namespace}/{key}"
 
     def get_read_payload(self, namespace: str, key: str) -> ReadPayload:
         try:
             with open(os.path.join(_get_data_dir(), namespace, key), "rb") as file:
                 content = file.read()
         except FileNotFoundError:
-            raise NoSuchStorageKey(self, key)
+            raise NoSuchStorageKeyError(self.__class__, key)
 
         return ReadPayload(type_=PayloadType.BYTES, content=content)
 

--- a/sematic/plugins/storage/tests/test_local_storage.py
+++ b/sematic/plugins/storage/tests/test_local_storage.py
@@ -23,9 +23,8 @@ def test_upload_download(
         with mock.patch(
             "sematic.plugins.storage.local_storage._get_data_dir", return_value=tempdir
         ):
-            response = test_client.put(
-                local_storage.get_write_location("artifacts", "123"), data=value
-            )
+            location = local_storage.get_write_location("artifacts", "123")
+            response = test_client.put(f"/api/v1{location}", data=value)
 
             assert response.status_code == 200
 

--- a/sematic/plugins/storage/tests/test_memory_storage.py
+++ b/sematic/plugins/storage/tests/test_memory_storage.py
@@ -15,9 +15,9 @@ def test_upload(
 
     memory_storage = MemoryStorage()
 
-    response = test_client.put(
-        memory_storage.get_write_location("artifacts", "123"), data=value
-    )
+    location = memory_storage.get_write_location("artifacts", "123")
+
+    response = test_client.put(f"/api/v1{location}", data=value)
 
     assert response.status_code == 200
 

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -13,22 +13,24 @@ sematic_py_lib(
         "python-socketio",
         "websocket-client",
     ],
+    # buildifier: leave-alone
     deps = [
         ":silent_resolver",
         "//sematic:abstract_calculator",
         "//sematic:abstract_future",
         "//sematic:api_client",
-        "//sematic/resolvers:abstract_resource_manager",
-        "//sematic/resolvers/resource_managers:server_manager",
         "//sematic:graph",
+        "//sematic:versions",
         "//sematic/config:config",
+        "//sematic/config:user_settings",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",
         "//sematic/db/models:run",
+        "//sematic/resolvers:abstract_resource_manager",
+        "//sematic/resolvers/resource_managers:server_manager",
         "//sematic/utils:exceptions",
         "//sematic/utils:git",
-        "//sematic:versions",
     ],
 )
 
@@ -51,8 +53,8 @@ sematic_py_lib(
         "//sematic:future_context",
         "//sematic/plugins:abstract_external_resource",
         "//sematic/resolvers:abstract_resource_manager",
-        "//sematic/resolvers/resource_managers:memory_manager",
         "//sematic/resolvers:state_machine_resolver",
+        "//sematic/resolvers/resource_managers:memory_manager",
     ],
 )
 
@@ -65,7 +67,9 @@ sematic_py_lib(
     deps = [
         ":local_resolver",
         "//sematic:abstract_future",
+        "//sematic:api_client",
         "//sematic:container_images",
+        "//sematic:storage",
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:resolution",
@@ -87,9 +91,10 @@ sematic_py_lib(
 sematic_py_lib(
     name = "log_streamer",
     srcs = ["log_streamer.py"],
+    # buildifier: leave-alone
     deps = [
-        "//sematic:storage",
         "//sematic/config:config",
+        "//sematic/plugins/storage:s3_storage",
         "//sematic/utils:retry",
         "//sematic/utils:stdout",
     ],

--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional
 
 # Sematic
 from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR
-from sematic.storage import S3Storage
+from sematic.plugins.storage.s3_storage import S3Storage
 from sematic.utils.retry import retry
 from sematic.utils.stdout import redirect_to_file_descriptor
 

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -32,7 +32,6 @@ class SilentResolver(StateMachineResolver):
     _RESOURCE_UPDATE_INTERVAL_SECONDS = 1
 
     def _schedule_future(self, future: AbstractFuture) -> None:
-        print("_schedule_future")
         self._run_inline(future)
 
     def _run_inline(self, future: AbstractFuture) -> None:
@@ -76,7 +75,6 @@ class SilentResolver(StateMachineResolver):
         self._deactivate_all_resources()
 
     def _deactivate_all_resources(self) -> None:
-        print("_deactivate_all_resources")
         resources = self._resource_manager.resources_by_root_id(self._root_future.id)
         logger.warning("Deactivating all resources due to resolution failure.")
         failed_to_deactivate = []
@@ -95,7 +93,6 @@ class SilentResolver(StateMachineResolver):
     def activate_resource_for_run(  # type: ignore
         cls, resource: AbstractExternalResource, run_id: str, root_id: str
     ) -> AbstractExternalResource:
-        print("activate_resource_for_run")
         is_local = True
         cls._resource_manager.save_resource(resource)
         cls._resource_manager.link_resource_to_run(resource.id, run_id, root_id)
@@ -132,7 +129,6 @@ class SilentResolver(StateMachineResolver):
     def deactivate_resource(  # type: ignore
         cls, resource_id: str
     ) -> AbstractExternalResource:
-        print("deactivate_resource")
         resource = cls._resource_manager.get_resource_for_id(resource_id)
         if resource.status.state.is_terminal():
             return resource

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -32,6 +32,7 @@ class SilentResolver(StateMachineResolver):
     _RESOURCE_UPDATE_INTERVAL_SECONDS = 1
 
     def _schedule_future(self, future: AbstractFuture) -> None:
+        print("_schedule_future")
         self._run_inline(future)
 
     def _run_inline(self, future: AbstractFuture) -> None:
@@ -75,6 +76,7 @@ class SilentResolver(StateMachineResolver):
         self._deactivate_all_resources()
 
     def _deactivate_all_resources(self) -> None:
+        print("_deactivate_all_resources")
         resources = self._resource_manager.resources_by_root_id(self._root_future.id)
         logger.warning("Deactivating all resources due to resolution failure.")
         failed_to_deactivate = []
@@ -93,6 +95,7 @@ class SilentResolver(StateMachineResolver):
     def activate_resource_for_run(  # type: ignore
         cls, resource: AbstractExternalResource, run_id: str, root_id: str
     ) -> AbstractExternalResource:
+        print("activate_resource_for_run")
         is_local = True
         cls._resource_manager.save_resource(resource)
         cls._resource_manager.link_resource_to_run(resource.id, run_id, root_id)
@@ -129,6 +132,7 @@ class SilentResolver(StateMachineResolver):
     def deactivate_resource(  # type: ignore
         cls, resource_id: str
     ) -> AbstractExternalResource:
+        print("deactivate_resource")
         resource = cls._resource_manager.get_resource_for_id(resource_id)
         if resource.status.state.is_terminal():
             return resource

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -98,11 +98,7 @@ pytest_test(
 sematic_py_lib(
     name = "fixtures",
     srcs = ["fixtures.py"],
-    pip_deps = [
-        "pytest",
-    ],
     deps = [
         "//sematic/plugins:abstract_external_resource",
-        "//sematic/tests:fixtures",
     ],
 )

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -40,13 +40,13 @@ pytest_test(
     name = "test_silent_resolver",
     srcs = ["test_silent_resolver.py"],
     deps = [
-        ":fixtures",
         "//sematic:abstract_calculator",
         "//sematic:calculator",
         "//sematic:future_context",
-        "//sematic/plugins:abstract_external_resource",
         "//sematic:retry_settings",
+        "//sematic/plugins:abstract_external_resource",
         "//sematic/resolvers:silent_resolver",
+        "//sematic/resolvers/tests:fixtures",
         "//sematic/utils:exceptions",
     ],
 )
@@ -63,7 +63,6 @@ pytest_test(
     name = "test_cloud_resolver",
     srcs = ["test_cloud_resolver.py"],
     deps = [
-        ":fixtures",
         "//sematic:api_client",
         "//sematic:calculator",
         "//sematic/api/tests:fixtures",
@@ -103,7 +102,7 @@ sematic_py_lib(
         "pytest",
     ],
     deps = [
-        "//sematic/tests:fixtures",
         "//sematic/plugins:abstract_external_resource",
+        "//sematic/tests:fixtures",
     ],
 )

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -1,17 +1,12 @@
 # Standard Library
 from dataclasses import dataclass, replace
 from typing import List, Optional, Tuple
-from unittest import mock
-
-# Third-party
-import pytest
 
 # Sematic
 from sematic.plugins.abstract_external_resource import (
     AbstractExternalResource,
     ResourceState,
 )
-from sematic.tests.fixtures import MockStorage
 
 _fake_resource_history: List["FakeExternalResource"] = []
 _fake_resource_call_history: List[Tuple["FakeExternalResource", str]] = []

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -13,25 +13,6 @@ from sematic.plugins.abstract_external_resource import (
 )
 from sematic.tests.fixtures import MockStorage
 
-
-@pytest.fixture
-def mock_local_resolver_storage():
-    mock_storage = MockStorage()
-    with mock.patch(
-        "sematic.resolvers.local_resolver.LocalStorage", return_value=mock_storage
-    ):
-        yield mock_storage
-
-
-@pytest.fixture
-def mock_cloud_resolver_storage():
-    mock_storage = MockStorage()
-    with mock.patch(
-        "sematic.resolvers.cloud_resolver.S3Storage", return_value=mock_storage
-    ):
-        yield mock_storage
-
-
 _fake_resource_history: List["FakeExternalResource"] = []
 _fake_resource_call_history: List[Tuple["FakeExternalResource", str]] = []
 

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -19,7 +19,6 @@ from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.tests.fixtures import test_db  # noqa: F401
 from sematic.resolvers.cloud_resolver import CloudResolver
-from sematic.resolvers.tests.fixtures import mock_cloud_resolver_storage  # noqa: F401
 from sematic.tests.fixtures import valid_client_version  # noqa: F401
 
 
@@ -49,7 +48,6 @@ def test_simulate_cloud_exec(
     mock_auth,  # noqa: F811
     mock_requests,  # noqa: F811
     test_db,  # noqa: F811
-    mock_cloud_resolver_storage,  # noqa: F811
     valid_client_version,  # noqa: F811
 ):
     # On the user's machine
@@ -88,11 +86,12 @@ def test_simulate_cloud_exec(
             run.future_state = FutureState.RESOLVED
             updates[run.id] = FutureState.RESOLVED
             edge = driver_resolver._get_output_edges(run.id)[0]
-            artifact = make_artifact(3, int, storage=mock_cloud_resolver_storage)
+            artifact, bytes_ = make_artifact(3, int)
             edge.artifact_id = artifact.id
             api_client.save_graph(
                 run.id, runs=[run], artifacts=[artifact], edges=[edge]
             )
+            api_client.store_artifact_bytes(artifact.id, bytes_)
             driver_resolver._refresh_graph(run.id)
         return updates
 

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -21,7 +21,6 @@ from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
 from sematic.db.queries import get_resolution, get_root_graph, get_run
 from sematic.db.tests.fixtures import pg_mock, test_db  # noqa: F401
 from sematic.resolvers.local_resolver import LocalResolver
-from sematic.resolvers.tests.fixtures import mock_local_resolver_storage  # noqa: F401
 from sematic.retry_settings import RetrySettings
 from sematic.tests.fixtures import valid_client_version  # noqa: F401
 from sematic.utils.exceptions import ExceptionMetadata, ResolutionError
@@ -45,7 +44,6 @@ def pipeline(a: float, b: float) -> float:
 
 
 def test_single_function(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -64,9 +62,9 @@ def test_single_function(
     assert len(artifacts) == 3
     assert len(edges) == 3
 
-    artifact_a = make_artifact(1.0, float)
-    artifact_b = make_artifact(2.0, float)
-    artifact_output = make_artifact(3.0, float)
+    artifact_a, _ = make_artifact(1.0, float)
+    artifact_b, _ = make_artifact(2.0, float)
+    artifact_output, _ = make_artifact(3.0, float)
 
     assert set(edges) == {
         Edge(
@@ -101,7 +99,6 @@ def add_add_add(a: float, b: float) -> float:
 
 
 def test_add_add(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -122,7 +119,6 @@ def test_add_add(
 
 
 def test_pipeline(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -160,7 +156,6 @@ def test_pipeline(
 
 
 def test_failure(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -203,7 +198,6 @@ def test_failure(
 
 
 def test_resolver_error(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -393,7 +387,6 @@ class CallbackTrackingResolver(LocalResolver):
 
 
 def test_db_state_machine(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -404,7 +397,6 @@ def test_db_state_machine(
 
 
 def test_list_conversion(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -419,7 +411,6 @@ def test_list_conversion(
 
 
 def test_exceptions(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     mock_requests,  # noqa: F811
@@ -488,7 +479,6 @@ def try_three_times():
 
 
 def test_retry(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -548,7 +538,6 @@ class RerunTestResolver(LocalResolver):
 
 
 def test_rerun_from_here(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811
@@ -580,7 +569,6 @@ def test_rerun_from_here(
 
 
 def test_cancel_non_terminal_futures(
-    mock_local_resolver_storage,  # noqa: F811
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811
     test_db,  # noqa: F811

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -79,10 +79,6 @@ def test_silent_resolver():
     assert SilentResolver().resolve(pipeline(3, 5)) == 24
 
 
-def test_add():
-    assert SilentResolver().resolve(add(1, 2)) == 3
-
-
 def test_silent_resolver_context():
     future = context_pipeline()
     result = SilentResolver().resolve(future)

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -79,6 +79,10 @@ def test_silent_resolver():
     assert SilentResolver().resolve(pipeline(3, 5)) == 24
 
 
+def test_add():
+    assert SilentResolver().resolve(add(1, 2)) == 3
+
+
 def test_silent_resolver_context():
     future = context_pipeline()
     result = SilentResolver().resolve(future)

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -16,7 +16,7 @@ from sematic.abstract_future import FutureState
 from sematic.calculator import Calculator
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
-from sematic.db.models.factories import get_artifact_value, make_artifact
+from sematic.db.models.factories import make_artifact
 from sematic.db.models.run import Run
 from sematic.future import Future
 from sematic.future_context import PrivateContext, SematicContext, set_context
@@ -58,8 +58,8 @@ def _get_input_kwargs(
     artifacts_by_id = {artifact.id: artifact for artifact in artifacts}
 
     kwargs = {
-        edge.destination_name: get_artifact_value(
-            artifacts_by_id[edge.artifact_id], storage=S3Storage()
+        edge.destination_name: api_client.get_artifact_value(
+            artifacts_by_id[edge.artifact_id]
         )
         for edge in edges
         if edge.destination_run_id == run_id
@@ -104,7 +104,10 @@ def _set_run_output(run: Run, output: Any, type_: Any, edges: List[Edge]):
         run.ended_at = datetime.datetime.utcnow()
 
     else:
-        artifacts.append(make_artifact(output, type_, storage=storage))
+        artifact, payload = make_artifact(output, type_)
+        artifacts.append(artifact)
+
+        api_client.store_artifact_bytes(artifact.id, payload)
 
         # Set output artifact on output edges
         for edge in edges:

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -37,7 +37,8 @@ pytest_test(
         "//sematic:api_client",
         "//sematic:versions",
         "//sematic/config:config",
-        "//sematic/db/models:factories",
+        "//sematic/api/tests:fixtures",
+        "//sematic/db/tests:fixtures",
         "//sematic/tests:fixtures",
     ],
 )
@@ -120,7 +121,7 @@ sematic_py_lib(
     srcs = ["fixtures.py"],
     deps = [
         "//sematic:api_client",
-        "//sematic:storage",
+        "//sematic/plugins/storage:memory_storage",
     ],
 )
 
@@ -136,6 +137,5 @@ pytest_test(
         "//sematic/db/models:factories",
         "//sematic/db/tests:fixtures",
         "//sematic/resolvers:local_resolver",
-        "//sematic/resolvers/tests:fixtures",
     ],
 )

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -8,10 +8,10 @@ import pytest
 
 # Sematic
 import sematic.api_client as api_client
-import sematic.storage as storage
+from sematic.plugins.storage.memory_storage import MemoryStorage
 
 
-class MockStorage(storage.MemoryStorage):
+class MockStorage(MemoryStorage):
     def set_from_file(self, key, file_path):
         with open(file_path, "rb") as fp:
             self._store[key] = b"".join(fp)
@@ -30,7 +30,7 @@ class MockStorage(storage.MemoryStorage):
 
 @pytest.fixture(scope="function")
 def test_storage():
-    yield MockStorage()
+    yield MockStorage
 
 
 @pytest.fixture

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -8,6 +8,10 @@ from unittest import mock
 import pytest
 
 # Sematic
+from sematic.api.tests.fixtures import (  # noqa: F401
+    mock_requests as mock_requests_fixture,
+)
+from sematic.api.tests.fixtures import test_client
 from sematic.api_client import (
     IncompatibleClientError,
     ServerError,
@@ -15,8 +19,12 @@ from sematic.api_client import (
     get_artifact_value_by_id,
 )
 from sematic.config.config import get_config
-from sematic.db.models.factories import make_artifact
-from sematic.tests.fixtures import MockStorage, valid_client_version  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    persisted_artifact,
+    test_db,
+    test_storage,
+)
+from sematic.tests.fixtures import valid_client_version  # noqa: F401
 from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
 
 
@@ -138,16 +146,10 @@ def test_validate_server_compatibility_new_server_still_supports(mock_requests):
     mock_requests.get.assert_called_once()
 
 
-@mock.patch("sematic.api_client.requests")
-def test_get_artifact_value_by_id(mock_requests, valid_client_version):  # noqa: F811
-    mock_storage = MockStorage()
-    artifact = make_artifact(42, int, mock_storage)
-    mock_requests.get.return_value = MockResponse(
-        status_code=200,
-        json_contents=dict(content=artifact.to_json_encodable()),
-    )
-
-    value = get_artifact_value_by_id(artifact.id, mock_storage)
+def test_get_artifact_value_by_id(
+    mock_requests_fixture, persisted_artifact  # noqa: F811
+):
+    value = get_artifact_value_by_id(persisted_artifact.id)
 
     assert isinstance(value, int)
     assert value == 42

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -11,7 +11,7 @@ import pytest
 from sematic.api.tests.fixtures import (  # noqa: F401
     mock_requests as mock_requests_fixture,
 )
-from sematic.api.tests.fixtures import test_client
+from sematic.api.tests.fixtures import test_client  # noqa: F401
 from sematic.api_client import (
     IncompatibleClientError,
     ServerError,

--- a/sematic/types/types/pandas/tests/test_dataframe.py
+++ b/sematic/types/types/pandas/tests/test_dataframe.py
@@ -34,7 +34,7 @@ def test_dataframe_datetime():
     timestamp = datetime.datetime.now()
     df = pandas.DataFrame([dict(a=timestamp)])
 
-    artifact = make_artifact(df, pandas.DataFrame)
+    artifact, _ = make_artifact(df, pandas.DataFrame)
 
     assert json.loads(artifact.json_summary)["dataframe"] == {
         "a": {"0": str(timestamp)}

--- a/sematic/utils/retry.py
+++ b/sematic/utils/retry.py
@@ -10,6 +10,7 @@ import logging
 import random
 import time
 from functools import partial, wraps
+from typing import Optional, Tuple, Type, Union
 
 logging_logger = logging.getLogger(__name__)
 
@@ -35,13 +36,13 @@ def decorator(caller):
 
 def __retry_internal(
     f,
-    exceptions=Exception,
-    tries=-1,
-    delay=0,
-    max_delay=None,
-    backoff=1,
-    jitter=0,
-    logger=logging_logger,
+    exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = Exception,
+    tries: int = -1,
+    delay: float = 0,
+    max_delay: Optional[float] = None,
+    backoff: float = 1,
+    jitter: float = 0,
+    logger: Optional[logging.Logger] = logging_logger,
 ):
     """Executes a function and retries it if it failed.
 
@@ -95,13 +96,13 @@ def __retry_internal(
 
 
 def retry(
-    exceptions=Exception,
-    tries=-1,
-    delay=0,
-    max_delay=None,
-    backoff=1,
-    jitter=0,
-    logger=logging_logger,
+    exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = Exception,
+    tries: int = -1,
+    delay: float = 0,
+    max_delay: Optional[float] = None,
+    backoff: float = 1,
+    jitter: float = 0,
+    logger: Optional[logging.Logger] = logging_logger,
 ):
     """Returns a retry decorator.
 


### PR DESCRIPTION
This PR is a follow-up to #396 and #407.

It integrates storage plugins introduced by #424 to actually use them store artifacts.

After this PR is merged, client code (resolvers) are not aware of storage backends (local vs. cloud). They simply query the API server for upload locations.

Follow-up work:
- Upload pickled nested futures using the same mechanism. They currently still use the legacy storage code.
- Migrate auth logic to plug-ins
- Change support for matplotlib to download artifact data to display plots