### PR TITLE
Compute cache key only for resolved args

### DIFF
--- a/sematic/caching/tests/BUILD
+++ b/sematic/caching/tests/BUILD
@@ -6,6 +6,7 @@ pytest_test(
         "//sematic:abstract_future",
         "//sematic:init",
         "//sematic/caching:caching",
+        "//sematic/resolvers:state_machine_resolver",
         "//sematic/types:serialization",
     ],
 )


### PR DESCRIPTION
The function that computes the cache key incorrectly uses the Future's initial input arguments with which it was instantiated, instead of the definitely resolved input arguments. This means that Futures which take as input arguments other Futures (instead of constants), will have their cache key computed based on non-deterministic Futures as values, resulting in non-deterministic cache keys as well.

This PR updates the function to use the resolved arguments and adds validation to only accept Futures whose arguments have been resolved.

### Testing

A new unit test is added to verify the validation, and existing unit tests are updated with correct Future fixtures that have resolved input arguments.

```bash
$ bazel test sematic/caching/tests:test_caching
```

