### PR TITLE
Avoids unnecessary unmount that causes screen flashing

### DIFF
--- a/sematic/ui/src/pipelines/MenuPanel.tsx
+++ b/sematic/ui/src/pipelines/MenuPanel.tsx
@@ -83,8 +83,8 @@ export default function MenuPanel() {
           pt: 3,
         }}
       >
-        <Loading isLoaded={!isLoading} />
-        {!isLoading && <RunTree runTreeNodes={runTreeMetaNode!.children}/>}
+        {!graph && <Loading isLoaded={!isLoading} />}
+        {!!runTreeMetaNode && <RunTree runTreeNodes={runTreeMetaNode!.children}/>}
       </Box>
     </Box>
   );

--- a/sematic/ui/src/pipelines/PipelinePanels.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanels.tsx
@@ -54,7 +54,7 @@ export default function PipelinePanels() {
     }
   }, [selectedRunId, graph, rootRun, setSelectedRunId])
 
-  if (error || isGraphLoading) {
+  if (error || (!graph && isGraphLoading)) {
     return (
       <Box sx={{ p: 5, gridColumn: "1 / 4" }}>
         <Loading error={error} isLoaded={false} />


### PR DESCRIPTION
There was a UI defect from the previous refactoring --- we used to show the loading indicator synced to the state of `isLoading`. The main content component is not shown when the loading indicator is shown. Hence caused the unmount of the main content component and screen flashings. 

Also, it is helpful to explain the mechanism of `useAsync` (`useAsyncRetry` is the same) 

```typescript
    const {value, loading, error, retry} = useAsyncRetry(async () => { ... })
```

When the `loading` state is switched from false to true, the `value` state will remain at its old value until the async loading completes (when the `loading` value switches back to `false`). This also means the `value` will not turn to `null` during the loading. This allows us to reuse the old value during the async loading, and we don't have to replace the main content area with the loading indicator. This also means whatever `value` renders into will suddenly change after the loading completes. This looks ok for the scenarios of run tree and graph. 

Ideally, there should be some indicator to prompt the user an async loading process is ongoing in the background. This might be done in the future to display the indicator alongside the main content area. Currently, though, not showing the loading indicator is the lesser of the two evils. Unmounting the main content component is worse. 

Presentation of the change:

Before: 
![capture2](https://user-images.githubusercontent.com/1046489/210892204-b5437ade-95cb-4326-ad52-7c608370475f.gif)


After: 
![capture1](https://user-images.githubusercontent.com/1046489/210892214-e0748b33-9624-46f9-8e83-28b0c6c21ec7.gif)
