### PR TITLE
Add props to cloned future to fix rerun name

### DIFF
--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -1,6 +1,7 @@
 # Standard Library
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field
+import json
 from typing import Any, Callable, Dict, Iterable, List, Optional
 from typing import OrderedDict as OrderedDictType
 from typing import Tuple
@@ -481,6 +482,9 @@ class Graph:
             future = func(**kwargs)
 
         future.name = run.name
+
+        future.props.name = run.name
+        future.props.tags = json.loads(run.tags)
 
         cloned_graph.input_artifacts[future.id] = run_input_artifacts
 


### PR DESCRIPTION
This PR fixes issue #393 . I chose to hardcode the props for name and tags because https://github.com/sematic-ai/sematic/blob/main/sematic/db/models/factories.py#L30 erases the name and tags from the existing future. It seems like for normal runs `.set` is called after this which sets the props but it doesn't seem to be the case for rerun resolutions.

At least from my understanding, this is why this issue happens.