### PR TITLE
[Bug] Fixes an issue that not being able to unmount a component causes unnecessary complexity in the downstream processing.

### DIFF
--- a/sematic/ui/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunView.tsx
@@ -59,7 +59,9 @@ export default function PipelineRunViewRouter() {
   const [_, setSelectedRunId] = useAtom(selectedRunHashAtom);
 
   useEffect(() => {
-    if (!run) {
+    // The new run might be loading, so we have to wait for run.id == rootId
+    // to get the updated `run`
+    if (!run || run.id !== rootId) {
       return;
     }
     if (rootId !== run.root_id) { 
@@ -70,7 +72,7 @@ export default function PipelineRunViewRouter() {
         navigate(run.root_id);
       });
     }
-  }, [run, rootId, navigate, setSelectedRunId]);
+  }, [run, rootId, isLoading, navigate, setSelectedRunId]);
 
   if (error || isLoading) {
     return <Loading error={error} isLoaded={!isLoading} />

--- a/sematic/ui/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/src/pipelines/PipelineRunView.tsx
@@ -9,6 +9,7 @@ import { selectedRunHashAtom, useFetchResolution, useFetchRun, usePipelineNaviga
 import PipelineRunViewContext from './PipelineRunViewContext'
 import { Run } from "../Models";
 import { useAtom } from "jotai";
+
 interface PipelineRunViewPresentationProps {
   pipelinePath: string
   rootRun: Run
@@ -45,7 +46,7 @@ export function PipelineRunViewPresentation({
   );
 }
 
-export default function PipelineRunViewRouter() {
+export function PipelineRunViewRouter() {
   const { pipelinePath, rootId } = useParams();
 
   for (const [key, value] of Object.entries({pipelinePath, rootId})) {
@@ -59,9 +60,7 @@ export default function PipelineRunViewRouter() {
   const [_, setSelectedRunId] = useAtom(selectedRunHashAtom);
 
   useEffect(() => {
-    // The new run might be loading, so we have to wait for run.id == rootId
-    // to get the updated `run`
-    if (!run || run.id !== rootId) {
+    if (!run) {
       return;
     }
     if (rootId !== run.root_id) { 
@@ -72,7 +71,7 @@ export default function PipelineRunViewRouter() {
         navigate(run.root_id);
       });
     }
-  }, [run, rootId, isLoading, navigate, setSelectedRunId]);
+  }, [run, rootId, navigate, setSelectedRunId]);
 
   if (error || isLoading) {
     return <Loading error={error} isLoaded={!isLoading} />
@@ -87,3 +86,10 @@ export default function PipelineRunViewRouter() {
   // Otherwise, load `PipelineRunViewPresentation` to actually render root run.
   return <PipelineRunViewPresentation pipelinePath={pipelinePath!} rootRun={run!} />
 }
+
+export default function PipelineRunViewWraper() {
+  const { pipelinePath, rootId } = useParams();
+  const key = `${pipelinePath}--${rootId}`;
+  return <PipelineRunViewRouter key={key}/>
+}
+


### PR DESCRIPTION
Fixes an issue that switching runs from the dropdown box does not switch the pages.

The reason why it didn't work is that the run data is not updated in time when we make a judgement whether the current run is a nested run in :

https://github.com/sematic-ai/sematic/blob/7c8af36651f6ea437ef402978d3a2cb9f1511ec6/sematic/ui/src/pipelines/PipelineRunView.tsx#L65-L73

In other words, this issue can also be fixed by [507b53](https://github.com/sematic-ai/sematic/commit/507b53e0490b49ef4e42bbe718c2fe40314d6900)

But I don't choose that way because there will be more complexities to consider in the future if we don't unmount the component and still attempt to fix things up based on the existing component state. IMHO, unmounting and remounting the component fresh is worry-free and more robust in the long run. Switching the run in the dropdown box will trigger a significant re-rendering of the entire page data. We gain little performance keeping the component live anyway. 