### PR TITLE
Setup Circle CI run for ESLINT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ orbs:
   python: circleci/python@1.5.0
   slack: circleci/slack@4.9.3
   codecov: codecov/codecov@3.2.3
+  node: circleci/node@5.0.3
 
 parameters:
   run_coverage:
@@ -40,6 +41,13 @@ commands:
       - run:
           name: MyPy
           command: mypy --version && mypy sematic
+      - node/install-packages:
+          app-dir: ./sematic/ui
+      - run:
+          name: ESlint
+          working_directory: ./sematic/ui
+          command: npm run lint
+
   non-coverage-tests:
     description: Do tests without tracking code coverage
     steps:

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -53,7 +53,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "analyze": "source-map-explorer 'build/static/js/*.js'"
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
+    "lint": "eslint --config node_modules/eslint-config-react-app/index.js --ext .ts,.tsx --max-warnings=0 ./src"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
1. Lint command is added as `npm run` script, it reuses `--config node_modules/eslint-config-react-app/index.js` config, which is precisely the same one used by `react-scripts start`. So we keep the development experience and CI experience the same.
2. Any warnings will trigger the exit code of `eslint` as 1 (Error), so it will fail the CI run in case of any warning. 
3. We install npm packages using Circle CI Orb: `node/install-packages`. It is said this Ord [Install your Node packages with automated caching and best practices](https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages).
4. The lint errors will be fixed in a separate PR. (This PR cannot be merged before the lint errors are fixed, since it is guarded by the ESlint step now)


Please see example Circle CI run:
https://app.circleci.com/pipelines/github/sematic-ai/sematic/1729/workflows/89e8dc9d-7081-4723-8906-07820d5e5e38/jobs/1705

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/1046489/211633256-8ee0a65b-dfc1-4f6e-954b-64b2e8b5fb8d.png">

