### PR TITLE
Don't upload empty log files

### DIFF
--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -172,6 +172,11 @@ def _do_upload(file_path: str, remote_prefix: str):
         The prefix for the remote file. The full remote path will be
         this concatenated with `/<epoch timestamp>.log`.
     """
+    file_has_contents = (
+        os.path.exists(file_path) and os.stat(file_path)[stat.ST_SIZE] > 0
+    )
+    if not file_has_contents:
+        return
     if remote_prefix.endswith("/"):
         remote_prefix = remote_prefix[:-1]
     remote = f"{remote_prefix}/{int(time.time() * 1000)}.log"


### PR DESCRIPTION
We currently upload log files from workers every 10 seconds. If logs are only created sparsely, this can mean uploading a lot of empty log files. That means it can take a long time to accumulate enough log lines to fill a single request for N log lines. This PR makes it so that we don't upload to s3 when there are no actual log lines.

Testing
-------
Ran a [run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/88fd25c4b282478fbe3ddcfa880afb62) that had a pause for 50 seconds. Checked [s3](https://s3.console.aws.amazon.com/s3/buckets/sematic-dev?region=us-west-2&prefix=logs/v2/run_id/c68b13c09743490a80581fe924c830bc/worker/&showversions=false) to ensure it only had log files that were non-empty, and had no files for the delay period.