### PR TITLE
Ability to expand the shared memory on worker pods

### DIFF
--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -120,10 +120,10 @@ You can select what hardware resources are available to each job by passing a
 For example:
 
 ```python
-from sematic import ResourceRequirements, KubernetesRequirements
+from sematic import ResourceRequirements, KubernetesResourceRequirements
 
 GPU_RESOURCE_REQS = ResourceRequirements(
-    kubernetes=KubernetesRequirements(
+    kubernetes=KubernetesResourceRequirements(
         # Note: the kind of node selector options that are valid will depend on
         # your particular deployment of Kubernetes. Talk to the person who manages
         # your Kubernetes cluster if you think you might need this. It is primarily
@@ -132,11 +132,15 @@ GPU_RESOURCE_REQS = ResourceRequirements(
 
         # The resource requirements of the job. Information on the format of valid
         # values can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        # the dictionary provided here will be used for both "limits" and "requests"
+        # the dictionary provided here will be used for both "limits" and "requests".
         requests={"cpu": "1", "memory": "1Gi"},
+
+        # By default, Docker uses a 64MB /dev/shm partition. If this flag is set,
+        # a memory-backed tmpfs that expands up to half of the available memory file
+        # is used instead.
+        mount_expanded_shared_memory=True,
     )
 )
-
 @sematic.func(resource_requirements=GPU_RESOURCE_REQS)
 def train_model(...):
     ...

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import Dict
+from typing import Dict, Optional
 
 # Third-party
 import debugpy
@@ -14,6 +14,10 @@ import debugpy
 # Sematic
 from sematic import CloudResolver, LocalResolver, SilentResolver
 from sematic.examples.testing_pipeline.pipeline import testing_pipeline
+from sematic.resolvers.resource_requirements import (
+    KubernetesResourceRequirements,
+    ResourceRequirements,
+)
 from sematic.resolvers.state_machine_resolver import StateMachineResolver
 
 logger = logging.getLogger(__name__)
@@ -31,7 +35,7 @@ DESCRIPTION = (
 )
 LOG_LEVEL_HELP = "The log level for the pipeline and Resolver. Defaults to INFO."
 CLOUD_HELP = (
-    "Whether to run the resolution in the cloud, or locally. Defaults to False."
+    "Whether to run the resolution in the cloud, or locally. Defaults to False. "
     "Only one of --silent or --cloud are allowed."
 )
 SILENT_HELP = (
@@ -82,9 +86,15 @@ EXTERNAL_RESOURCE_HELP = (
     "Whether to use an artificial external resource when executing some of "
     "the 'add' functions."
 )
+EXPAND_SHARED_MEMORY_HELP = (
+    "Whether to include a function that runs on a Kubernetes pod which uses an expanded "
+    "shared memory partition. This option is added to a shared function which uses one "
+    "KubernetesResourceRequirements configuration containing all the relevant specified "
+    "CLI parameters. Defaults to False."
+)
 EXIT_HELP = (
     "Includes a function which will exit with the specified code. "
-    "If specified without a value, defaults to 0."
+    "If specified without a value, defaults to 0. Defaults to None."
 )
 
 
@@ -104,7 +114,9 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         help=CLOUD_HELP,
-        **_required_by("--detach", "--max-parallelism", "--oom"),
+        **_required_by(
+            "--detach", "--expand-shared-memory", "--max-parallelism", "--oom"
+        ),
     )
     parser.add_argument(
         "--silent",
@@ -167,6 +179,12 @@ def _parse_args() -> argparse.Namespace:
         help=EXTERNAL_RESOURCE_HELP,
     )
     parser.add_argument(
+        "--expand-shared-memory",
+        action="store_true",
+        default=False,
+        help=EXPAND_SHARED_MEMORY_HELP,
+    )
+    parser.add_argument(
         "--exit",
         type=int,
         nargs="?",
@@ -192,6 +210,10 @@ def _parse_args() -> argparse.Namespace:
             "Only one of '--silent' or '--cloud' can be used, but both were specified"
         )
 
+    resource_requirements = _get_resource_requirements(args)
+    if resource_requirements is not None:
+        args.resource_requirements = resource_requirements
+
     return args
 
 
@@ -209,6 +231,21 @@ def _get_resolver(args: argparse.Namespace) -> StateMachineResolver:
     )
 
 
+def _get_resource_requirements(
+    args: argparse.Namespace,
+) -> Optional[ResourceRequirements]:
+    """Instantiates ResourceRequirements based on the passed arguments."""
+    # add all new resource requirements here
+    if not args.expand_shared_memory:
+        return None
+
+    k8_resource_requirements = KubernetesResourceRequirements(
+        mount_expanded_shared_memory=args.expand_shared_memory
+    )
+
+    return ResourceRequirements(kubernetes=k8_resource_requirements)
+
+
 def _wait_for_debugger():
     debugpy.listen(5724)
 
@@ -220,6 +257,7 @@ def _wait_for_debugger():
 def main() -> None:
     if os.environ.get("DEBUGPY", None) is not None:
         _wait_for_debugger()
+
     args = _parse_args()
     logging.basicConfig(level=args.log_level)
     logger.info("Command line arguments: %s", args)
@@ -229,8 +267,10 @@ def main() -> None:
     logger.info("Pipeline arguments: %s", effective_args)
 
     resolver = _get_resolver(args)
+
     future = testing_pipeline(**effective_args).set(
-        name="Sematic Testing Pipeline", tags=["example", "testing"]
+        name="Sematic Testing Pipeline",
+        tags=["example", "testing"],
     )
 
     logger.info("Invoking the pipeline...")

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -219,12 +219,18 @@ class KubernetesResourceRequirements:
         get scheduled on which nodes, this enables control over how your workload
         interacts with these node taints. More information can be found here:
         https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    mount_expanded_shared_memory:
+        By default Docker uses a 64MB /dev/shm partition. If this flag is set, a
+        memory-backed tmpfs that expands up to half of the available memory file is used
+        instead. Defaults to False. If that file is expanded to more than that limit
+        (through external action), then the pod will be terminated.
     """
 
     node_selector: Dict[str, str] = field(default_factory=dict)
     requests: Dict[str, str] = field(default_factory=dict)
     secret_mounts: KubernetesSecretMount = field(default_factory=KubernetesSecretMount)
     tolerations: List[KubernetesToleration] = field(default_factory=list)
+    mount_expanded_shared_memory: bool = field(default=False)
 
 
 @dataclass

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -220,7 +220,7 @@ class KubernetesResourceRequirements:
         interacts with these node taints. More information can be found here:
         https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     mount_expanded_shared_memory:
-        By default Docker uses a 64MB /dev/shm partition. If this flag is set, a
+        By default, Docker uses a 64MB /dev/shm partition. If this flag is set, a
         memory-backed tmpfs that expands up to half of the available memory file is used
         instead. Defaults to False. If that file is expanded to more than that limit
         (through external action), then the pod will be terminated.

--- a/sematic/resolvers/tests/test_resource_requirements.py
+++ b/sematic/resolvers/tests/test_resource_requirements.py
@@ -35,6 +35,7 @@ def test_is_serializable():
                     toleration_seconds=42,
                 )
             ],
+            mount_expanded_shared_memory=True,
         )
     )
     encoded = value_to_json_encodable(requirements, ResourceRequirements)

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -426,7 +426,7 @@ def _get_most_recent_pod_details(
 
 
 def load_kube_config():
-    """Load the kubeconfig either from file or the in-cluster config"""
+    """Load the kubeconfig either from file or the in-cluster config."""
     global _kubeconfig_loaded
     if _kubeconfig_loaded:
         return
@@ -470,7 +470,7 @@ def cancel_job(job: KubernetesExternalJob) -> KubernetesExternalJob:
 
 @retry(exceptions=(ApiException, ConnectionError), tries=3, delay=5, jitter=2)
 def refresh_job(job: ExternalJob) -> KubernetesExternalJob:
-    """Reach out to K8s for updates on the status of the job"""
+    """Reach out to K8s for updates on the status of the job."""
     load_kube_config()
     if not isinstance(job, KubernetesExternalJob):
         raise ValueError(
@@ -771,7 +771,7 @@ def schedule_run_job(
 def _volume_secrets(
     secret_mount: KubernetesSecretMount,
 ) -> Optional[Tuple[V1Volume, V1VolumeMount]]:
-    """Configure a volume and corresponding mount for secrets requested for a func
+    """Configure a volume and corresponding mount for secrets requested for a func.
 
     Parameters
     ----------
@@ -780,7 +780,7 @@ def _volume_secrets(
 
     Returns
     -------
-    None if no file secrets were requested. Otherwise a volume and a volume mount
+    None if no file secrets were requested. Otherwise, a volume and a volume mount
     for the secrets requested.
     """
     if len(secret_mount.file_secrets) == 0:
@@ -851,6 +851,9 @@ def _environment_secrets(
 
 
 def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
+    """
+    Returns a memory-backed shared memory partition and mount with a default size.
+    """
     # the "Memory" medium cannot have a size_limit specified by default;
     # it requires the SizeMemoryBackedVolumes feature gate be activated by the
     # cluster admin - please see

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -599,8 +599,8 @@ def _schedule_kubernetes_job(
 
         logger.debug("kubernetes node_selector %s", node_selector)
         logger.debug("kubernetes resource requests %s", resource_requests)
-        logger.info("kubernetes volumes: %s", volumes)
-        logger.info("kubernetes volume mounts: %s", volume_mounts)
+        logger.debug("kubernetes volumes: %s", volumes)
+        logger.debug("kubernetes volume mounts: %s", volume_mounts)
         logger.debug("kubernetes environment secrets: %s", secret_env_vars)
         logger.debug("kubernetes tolerations: %s", tolerations)
 

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -9,7 +9,14 @@ from typing import Any, Dict, List, Optional, Tuple
 # Third-party
 import kubernetes
 from kubernetes.client.exceptions import ApiException, OpenApiException
-from kubernetes.client.models import V1ContainerStatus, V1Job, V1Pod, V1PodCondition
+from kubernetes.client.models import (
+    V1ContainerStatus,
+    V1Job,
+    V1Pod,
+    V1PodCondition,
+    V1Volume,
+    V1VolumeMount,
+)
 from urllib3.exceptions import ConnectionError
 
 # Sematic
@@ -564,14 +571,22 @@ def _schedule_kubernetes_job(
     volume_mounts = []
     secret_env_vars = []
     tolerations = []
+
     if resource_requirements is not None:
         node_selector = resource_requirements.kubernetes.node_selector
         resource_requests = resource_requirements.kubernetes.requests
         volume_info = _volume_secrets(resource_requirements.kubernetes.secret_mounts)
+
         if volume_info is not None:
             volume, mount = volume_info
             volumes.append(volume)
             volume_mounts.append(mount)
+
+        if resource_requirements.kubernetes.mount_expanded_shared_memory:
+            volume, mount = _shared_memory()
+            volumes.append(volume)
+            volume_mounts.append(mount)
+
         secret_env_vars.extend(
             _environment_secrets(resource_requirements.kubernetes.secret_mounts)
         )
@@ -581,9 +596,11 @@ def _schedule_kubernetes_job(
             )
             for toleration in resource_requirements.kubernetes.tolerations
         ]
+
         logger.debug("kubernetes node_selector %s", node_selector)
         logger.debug("kubernetes resource requests %s", resource_requests)
-        logger.debug("kubernetes volumes and mounts: %s, %s", volumes, volume_mounts)
+        logger.info("kubernetes volumes: %s", volumes)
+        logger.info("kubernetes volume mounts: %s", volume_mounts)
         logger.debug("kubernetes environment secrets: %s", secret_env_vars)
         logger.debug("kubernetes tolerations: %s", tolerations)
 
@@ -753,9 +770,7 @@ def schedule_run_job(
 
 def _volume_secrets(
     secret_mount: KubernetesSecretMount,
-) -> Optional[  # type: ignore
-    Tuple[kubernetes.client.V1Volume, kubernetes.client.V1VolumeMount]
-]:
+) -> Optional[Tuple[V1Volume, V1VolumeMount]]:
     """Configure a volume and corresponding mount for secrets requested for a func
 
     Parameters
@@ -780,7 +795,7 @@ def _volume_secrets(
 
     volume_name = "sematic-func-secrets-volume"
 
-    volume = kubernetes.client.V1Volume(  # type: ignore
+    volume = V1Volume(
         name=volume_name,
         secret=kubernetes.client.V1SecretVolumeSource(  # type: ignore
             items=[
@@ -795,7 +810,7 @@ def _volume_secrets(
         ),
     )
 
-    mount = kubernetes.client.V1VolumeMount(  # type: ignore
+    mount = V1VolumeMount(
         mount_path=secret_mount.file_secret_root_path,
         name=volume_name,
         read_only=True,
@@ -833,3 +848,21 @@ def _environment_secrets(
             )
         )
     return env_vars
+
+
+def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
+    # the "Memory" medium cannot have a size_limit specified by default;
+    # it requires the SizeMemoryBackedVolumes feature gate be activated by the
+    # cluster admin - please see
+    # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+    # without that, it will default to half the available memory
+    empty_dir = kubernetes.client.V1EmptyDirVolumeSource(
+        medium="Memory",
+    )
+
+    volume_name = "expanded-shared-memory-volume"
+
+    volume = V1Volume(name=volume_name, empty_dir=empty_dir)
+    volume_mount = V1VolumeMount(mount_path="/dev/shm", name=volume_name)
+
+    return volume, volume_mount


### PR DESCRIPTION
Fixes #430.

By default Docker uses a 64MB `/dev/shm` partition. This limits the performance of software which uses that partition for data processing.

This PR adds a new flag to `KubernetesResourceRequirements` that enables the mounting of an expanded memory-backed `/dev/shm` tmpfs file, that expands to 50% of available memory on the pod.

Further configuration of the memory limit is not done because in order to configure this for memory-backed files, the `SizeMemoryBackedVolumes` feature gate must be activated by the cluster admin - please see [this resource](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).

### Testing

Existing unit tests are updated with assertions.

The testing pipeline is enhanced with a function that allows the configuration of resource requirements. Currently only this new flag is configurable. The intention is to add other parameters (existing or new) to this function in the future.

These are the results of printing the partition sizes on pods which have and don't have the flag activated:

Flag not activated:
```
root@sematic-worker-9a5a7a6f14954e22aefb8a2015078154-811f03-d9gf2:/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic# df -h
Filesystem      Size  Used Avail Use% Mounted on
[...]
shm              64M     0   64M   0% /dev/shm
[...]
```

Flag activated:
```
root@sematic-worker-92c49e830def49789595c3acd07b8941-fda268-99gw6:/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic# df -h
Filesystem      Size  Used Avail Use% Mounted on
[...]
tmpfs           7.0G     0  7.0G   0% /dev/shm
[...]
```
