### PR TITLE
Add proper deserialization for tuple

### DIFF
--- a/sematic/types/types/tests/test_tuple.py
+++ b/sematic/types/types/tests/test_tuple.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Tuple
+from typing import Optional, Tuple
 
 # Third-party
 import pytest
@@ -10,6 +10,8 @@ from sematic.types.serialization import (
     get_json_encodable_summary,
     type_from_json_encodable,
     type_to_json_encodable,
+    value_from_json_encodable,
+    value_to_json_encodable,
 )
 
 
@@ -50,3 +52,17 @@ def test_type_from_json_encodable():
     json_encodable = type_to_json_encodable(Tuple[float, str])
     type_ = type_from_json_encodable(json_encodable)
     assert type_ is Tuple[float, str]
+
+
+@pytest.mark.parametrize(
+    "value, type_",
+    (
+        ((42, "foo"), Tuple[float, str]),
+        (("foo", "bar"), Tuple[str, Optional[str]]),
+        (("foo", None), Tuple[str, Optional[str]]),
+    ),
+)
+def test_serdes(value, type_):
+    serialized = value_to_json_encodable(value, type_)
+    deserialized = value_from_json_encodable(serialized, type_)
+    assert value == deserialized

--- a/sematic/types/types/tuple.py
+++ b/sematic/types/types/tuple.py
@@ -4,12 +4,14 @@ from typing import Any, Iterable, List, Optional, Tuple, Type
 # Sematic
 from sematic.types.casting import safe_cast
 from sematic.types.registry import (
+    register_from_json_encodable,
     register_safe_cast,
     register_to_json_encodable,
     register_to_json_encodable_summary,
 )
 from sematic.types.serialization import (
     get_json_encodable_summary,
+    value_from_json_encodable,
     value_to_json_encodable,
 )
 
@@ -57,6 +59,19 @@ def _tuple_to_json_encodable(value: Tuple, type_: Type) -> List:
         value_to_json_encodable(element, element_type)
         for element, element_type in zip(value, type_.__args__)
     ]
+
+
+@register_from_json_encodable(tuple)
+def _tuple_from_json_encodable(value: Tuple, type_: Type) -> Tuple[Any, ...]:
+    """
+    Serialization of tuples
+    """
+    return tuple(
+        [
+            value_from_json_encodable(element, element_type)
+            for element, element_type in zip(value, type_.__args__)
+        ]
+    )
 
 
 @register_to_json_encodable_summary(tuple)

--- a/sematic/types/types/tuple.py
+++ b/sematic/types/types/tuple.py
@@ -63,9 +63,7 @@ def _tuple_to_json_encodable(value: Tuple, type_: Type) -> List:
 
 @register_from_json_encodable(tuple)
 def _tuple_from_json_encodable(value: Tuple, type_: Type) -> Tuple[Any, ...]:
-    """
-    Serialization of tuples
-    """
+    """Deserialize a tuple."""
     return tuple(
         [
             value_from_json_encodable(element, element_type)


### PR DESCRIPTION
`Tuple` was delegating to element types for serialization, but (having no deserializer at all) was not delegating to element types for deserialization. This PR fixes that.