### PR TITLE
Fix schema dump relative file path usage

### DIFF
--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -319,6 +319,7 @@ def dump_schema(file: str):
     )
 
     # make sure the file is created in the workspace, and not in the bazel runtime dir
+    # TODO #462: cwd for all cli commands when running bazel
     if not os.path.isabs(file):
         workspace = os.getenv("BUILD_WORKSPACE_DIRECTORY")
         if workspace is not None:

--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -318,6 +318,12 @@ def dump_schema(file: str):
         + ";\n"
     )
 
+    # make sure the file is created in the workspace, and not in the bazel runtime dir
+    if not os.path.isabs(file):
+        workspace = os.getenv("BUILD_WORKSPACE_DIRECTORY")
+        if workspace is not None:
+            file = os.path.join(workspace, file)
+
     logging.info("Writing schema to %s", file)
     with open(file, "w") as f:
         f.write(schema)


### PR DESCRIPTION
When dumping the DB schema to a relative file path, the file is actually created inside the Bazel runtime dir:

```bash
~/work/sematic$ bazel run //sematic/db:migrate -- dump --schema-file my_schema.sql
INFO: Analyzed target //sematic/db:migrate (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //sematic/db:migrate up-to-date:
  bazel-bin/sematic/db/migrate
INFO: Elapsed time: 0.320s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
~/work/sematic$
~/work/sematic$ git st
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
~/work/sematic$
~/work/sematic$ find /private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e -iname my_schema.sql
/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/db/migrate.runfiles/sematic/my_schema.sql
~/work/sematic$
```

This fixes it to always write the file to the user's workspace:

```bash
~/work/sematic$ bazel run //sematic/db:migrate -- dump --schema-file my_schema.sql
INFO: Analyzed target //sematic/db:migrate (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //sematic/db:migrate up-to-date:
  bazel-bin/sematic/db/migrate
INFO: Elapsed time: 0.316s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
~/work/sematic$
~/work/sematic$
~/work/sematic$ git st
On branch tudor/fix-db-schema-dump-relative-path
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
    modified:   sematic/db/migrate.py

Untracked files:
  (use "git add <file>..." to include in what will be committed)
    my_schema.sql

no changes added to commit (use "git add" and/or "git commit -a")
~/work/sematic$
```
