### PR TITLE
Warn about Sqlite3 version only when used

### DIFF
--- a/sematic/config/BUILD
+++ b/sematic/config/BUILD
@@ -50,5 +50,6 @@ sematic_py_lib(
         ":server_settings",
         ":settings",
         ":user_settings",
+        "//sematic:versions"
     ],
 )

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,6 +1,5 @@
 # Standard Library
 import logging
-import sqlite3
 import typing
 
 logger = logging.getLogger(__name__)
@@ -16,27 +15,8 @@ CURRENT_VERSION = (0, 21, 1)
 # is made to the web API.
 MIN_CLIENT_SERVER_SUPPORTS = (0, 21, 1)
 
-# Support for dropping columns added in 3.35.0
-MIN_SQLITE_VERSION = (3, 35, 0)
-
 # Version of the settings file schema
 SETTINGS_SCHEMA_VERSION = 1
-
-
-def _check_sqlite_version():
-    version_tuple = sqlite3.sqlite_version.split(".")
-
-    # get major/minor as ints. Patch can sometimes have non-digit chars
-    major, minor = int(version_tuple[0]), int(version_tuple[1])
-    if (major, minor) < MIN_SQLITE_VERSION:
-        # TODO #302: implement sustainable way to upgrade sqlite3 DBs
-        logger.warning(
-            "Sematic will soon require the sqlite3 version to be at least %s, but your "
-            "Python is using %s. Please upgrade. You may find this useful: "
-            "https://stackoverflow.com/a/55729735/2540669",
-            version_as_string(MIN_SQLITE_VERSION),
-            sqlite3.sqlite_version,
-        )
 
 
 def version_as_string(version: typing.Tuple[int, int, int]) -> str:
@@ -76,7 +56,7 @@ def string_version_to_tuple(version_string: str) -> typing.Tuple[int, int, int]:
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)
 MIN_CLIENT_SERVER_SUPPORTS_STR = version_as_string(MIN_CLIENT_SERVER_SUPPORTS)
-_check_sqlite_version()
+
 
 if __name__ == "__main__":
     # It can be handy for deployment scripts and similar things to be able to get quick


### PR DESCRIPTION
Currently we warn if the Sqlite3 version is outdated even if PostgreSQL would be used instead, which confuses users.

This logs the warning only when the Sqlite database is used:
```bash
~/work/sematic$ bazel run //sematic/api:server
INFO: Analyzed target //sematic/api:server (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //sematic/api:server up-to-date:
  bazel-bin/sematic/api/server
INFO: Elapsed time: 0.359s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
Sematic will soon require the sqlite3 version to be at least 3.35.0, but your Python is using 3.7.17. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
[...]
```