### PR TITLE
Deeplink for run tabs

### DIFF
--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -7,11 +7,12 @@ import { Filter, ResolutionPayload, RunListPayload, RunViewPayload } from "../Pa
 import PipelinePanelsContext from "../pipelines/PipelinePanelsContext";
 import PipelineRunViewContext from "../pipelines/PipelineRunViewContext";
 import { useHttpClient } from "./httpHooks";
-import { atomWithHash } from 'jotai-location'
+import { atomWithHashCustomSerialization } from "../utils";
 
 export type QueryParams = {[key: string]: string};
 
-export const selectedRunHashAtom = atomWithHash('run', '')
+export const selectedRunHashAtom = atomWithHashCustomSerialization('run', '')
+export const selectedTabHashAtom = atomWithHashCustomSerialization('tab', '')
 
 export function usePipelineRunContext() {
     const contextValue = useContext(PipelineRunViewContext);

--- a/sematic/ui/src/pipelines/RunTree.tsx
+++ b/sematic/ui/src/pipelines/RunTree.tsx
@@ -18,18 +18,16 @@ export default function RunTree(props: {
 }) {
   let { runTreeNodes } = props;
 
-  const { selectedRun, setSelectedPanelItem, setSelectedRunId, setSelectedRunTab, setSelectedArtifactName  } 
+  const { selectedRun, setSelectedPanelItem, setSelectedRunId, setSelectedArtifactName  } 
   = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
     selectedRun: Run
   };
 
   const onSelectRun = useCallback((runId: string) => {
-    const defaultTab = selectedRun.future_state === "FAILED" ? "logs" : "output";
-    setSelectedRunTab(defaultTab);
     setSelectedArtifactName("");
     setSelectedRunId(runId);
     setSelectedPanelItem('run');
-  }, [selectedRun.future_state, setSelectedArtifactName, setSelectedPanelItem, setSelectedRunId, setSelectedRunTab]);
+  }, [setSelectedArtifactName, setSelectedPanelItem, setSelectedRunId]);
 
   if (runTreeNodes.length === 0) {
     return <></>;

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import io from "socket.io-client";
+import { atomWithHash } from 'jotai-location'
 
 interface IFetchJSON {
   url: string;
@@ -66,6 +67,18 @@ export function useLogger() {
     devLogger
   }
 } 
+
+
+export function atomWithHashCustomSerialization(
+  name: string, initialValue: string, 
+  options: Parameters<typeof atomWithHash>[2] = {}) {
+  let overridenOptions = options || {};
+  // Use custom serialization function to avoid generating `"`(%22) in the hash
+  overridenOptions.serialize = (value: unknown) => (value as any).toString() ;
+  overridenOptions.deserialize = (value: unknown) => value as string ;
+
+  return atomWithHash<string>(name, initialValue, options as any); 
+}
 
 export const graphSocket = io("/graph");
 


### PR DESCRIPTION
Supports deep links with the center panel tab selected.

The deep link now has a form of 

```
pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/5d6592fb50c84fbf83e59350325ff903#tab=input&run=7c32dcb60c2f4ac0b1c07cf18c69dddb
```
![capture1](https://user-images.githubusercontent.com/1046489/212446103-68ed48c2-4d0f-4978-bdb5-b503e2726c87.gif)

