### PR TITLE
Ability to order model results on backend endpoints

### DIFF
--- a/sematic/api/endpoints/edges.py
+++ b/sematic/api/endpoints/edges.py
@@ -3,7 +3,6 @@ from typing import List
 
 # Third-party
 import flask
-import sqlalchemy
 
 # Sematic
 from sematic.api.app import sematic_api
@@ -14,7 +13,9 @@ from sematic.db.models.edge import Edge
 
 @sematic_api.route("/api/v1/edges", methods=["GET"])
 def list_edges_endpoint() -> flask.Response:
-    limit, _, _, sql_predicates = get_request_parameters(flask.request.args, Edge)
+    limit, order, _, _, sql_predicates = get_request_parameters(
+        args=flask.request.args, model=Edge
+    )
 
     with db().get_session() as session:
         query = session.query(Edge)
@@ -22,7 +23,7 @@ def list_edges_endpoint() -> flask.Response:
         if sql_predicates is not None:
             query = query.filter(sql_predicates)
 
-        query = query.order_by(sqlalchemy.desc(Edge.created_at))
+        query = query.order_by(order(Edge.created_at))
 
         edges: List[Edge] = query.limit(limit).all()
 

--- a/sematic/api/endpoints/notes.py
+++ b/sematic/api/endpoints/notes.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 
 # Third-party
 import flask
-import sqlalchemy
 from sqlalchemy.orm.exc import NoResultFound
 
 # Sematic
@@ -25,10 +24,10 @@ from sematic.db.queries import delete_note, get_note, save_note
 @sematic_api.route("/api/v1/notes", methods=["GET"])
 @authenticate
 def list_notes_endpoint(user: Optional[User]) -> flask.Response:
-    limit, _, _, sql_predicates = get_request_parameters(
-        flask.request.args,
-        Note,
+    limit, order, _, _, sql_predicates = get_request_parameters(
+        args=flask.request.args, model=Note, default_order="asc"
     )
+
     with db().get_session() as session:
         query = session.query(Note)
 
@@ -40,7 +39,7 @@ def list_notes_endpoint(user: Optional[User]) -> flask.Response:
                 Run.calculator_path == flask.request.args["calculator_path"]
             )
 
-        query = query.order_by(sqlalchemy.asc(Note.created_at))
+        query = query.order_by(order(Note.created_at))
 
         # query = query.limit(limit)
 


### PR DESCRIPTION
Adds the ability to sort the results when fetching Sqlalchemy model instances from the server endpoint.

This is required by #414.

Extends the shared URL parameter extraction logic to also extract a parameter which specifies the ordering direction, and updates existing code to use that instead of hardcoded local ordering.

Also adds a client function which queries the `runs` server endpoint and uses the new functionality, which is also required by #414.

### Testing

Added new unit tests which validate the ordering, and also added missing unit tests to cover the functionality of touched code.
