### PR TITLE
[bugfix] Fix corrupted settings files from 0.21.1

### DIFF
--- a/sematic/cli/BUILD
+++ b/sematic/cli/BUILD
@@ -1,6 +1,7 @@
 sematic_py_lib(
     name = "main_lib",
     srcs = ["main.py"],
+    # buildifier: leave-alone
     deps = [
         ":cancel",
         ":cli",
@@ -8,9 +9,12 @@ sematic_py_lib(
         ":start",
         ":stop",
         ":run",
+        ":migrate",
         ":new",
         ":settings",
         ":version",
+        "//sematic/config:config",
+        "//sematic/db:migrate_lib",
         # Examples
         "//sematic/examples/template:template_lib",
         # These do not add dependencies on 3rd party packages
@@ -26,10 +30,7 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
-    deps = [
-        "//sematic/config:config",
-        "//sematic/db:migrate_lib",
-    ],
+    deps = [],
 )
 
 sematic_py_lib(
@@ -50,11 +51,12 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
+    # buildifier: leave-alone
     deps = [
         ":cli",
         "//sematic:api_client",
-        "//sematic/config:config",
         "//sematic:log_reader",
+        "//sematic/config:config",
     ],
 )
 
@@ -64,6 +66,7 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
+    # buildifier: leave-alone
     deps = [
         ":cli",
         ":process_utils",
@@ -90,10 +93,19 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
+    # buildifier: leave-alone
     deps = [
         ":cli",
         ":process_utils",
         "//sematic/config:config",
+    ],
+)
+
+sematic_py_lib(
+    name = "migrate",
+    srcs = ["migrate.py"],
+    deps = [
+        ":cli",
     ],
 )
 
@@ -103,6 +115,7 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
+    # buildifier: leave-alone
     deps = [
         ":cli",
         ":examples_utils",
@@ -113,6 +126,7 @@ sematic_py_lib(
 sematic_py_lib(
     name = "process_utils",
     srcs = ["process_utils.py"],
+    # buildifier: leave-alone
     deps = [
         "//sematic/config:config",
     ],
@@ -121,6 +135,7 @@ sematic_py_lib(
 sematic_py_lib(
     name = "examples_utils",
     srcs = ["examples_utils.py"],
+    # buildifier: leave-alone
     deps = [
         "//sematic/config:config",
     ],

--- a/sematic/cli/cli.py
+++ b/sematic/cli/cli.py
@@ -1,11 +1,6 @@
 # Third-party
 import click
 
-# Sematic
-from sematic.config.config import switch_env
-from sematic.db.migrate import migrate_up
-
-
 @click.group("sematic")
 def cli():
     """
@@ -17,8 +12,7 @@ def cli():
     Run an example:
         $ sematic run examples/mnist/pytorch
     """
-    switch_env("local")
-    migrate_up()
+    pass
 
 
 @cli.group("advanced")

--- a/sematic/cli/cli.py
+++ b/sematic/cli/cli.py
@@ -1,6 +1,7 @@
 # Third-party
 import click
 
+
 @click.group("sematic")
 def cli():
     """

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -1,13 +1,20 @@
 # Sematic
-import sematic.cli.cancel  # noqa: F401
-import sematic.cli.logs  # noqa: F401
-import sematic.cli.new  # noqa: F401
-import sematic.cli.run  # noqa: F401
-import sematic.cli.settings  # noqa: F401
-import sematic.cli.start  # noqa: F401
-import sematic.cli.stop  # noqa: F401
-import sematic.cli.version  # noqa: F401
-from sematic.cli.cli import cli
+from sematic.config.config import switch_env
+from sematic.db.migrate import migrate_up
+
+switch_env("local")
+migrate_up()
+
+import sematic.cli.cancel  # noqa: F401, E402
+import sematic.cli.logs  # noqa: F401, E402
+import sematic.cli.migrate  # noqa: F401, E402
+import sematic.cli.new  # noqa: F401, E402
+import sematic.cli.run  # noqa: F401, E402
+import sematic.cli.settings  # noqa: F401, E402
+import sematic.cli.start  # noqa: F401, E402
+import sematic.cli.stop  # noqa: F401, E402
+import sematic.cli.version  # noqa: F401, E402
+from sematic.cli.cli import cli  # noqa: E402
 
 if __name__ == "__main__":
     cli()

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -5,6 +5,7 @@ from sematic.db.migrate import migrate_up
 switch_env("local")
 migrate_up()
 
+# Sematic
 import sematic.cli.cancel  # noqa: F401, E402
 import sematic.cli.logs  # noqa: F401, E402
 import sematic.cli.migrate  # noqa: F401, E402

--- a/sematic/cli/migrate.py
+++ b/sematic/cli/migrate.py
@@ -1,0 +1,8 @@
+# Sematic
+from sematic.cli.cli import cli
+
+
+@cli.command("migrate")
+def migrate_cli() -> None:
+    # Migrations are already applied for every CLI call.
+    pass

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -33,7 +33,7 @@ def up():
             .get("dictitems", {})
         )
 
-    if "dictitems" in user_loaded_yaml:
+    if "dictitems" in server_loaded_yaml:
         server_loaded_yaml = dict(
             default=server_loaded_yaml["dictitems"]
             .get("default", {})

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -28,14 +28,17 @@ def up():
     # Recover from 0.21.1 corrupted settings files
     if "dictitems" in user_loaded_yaml:
         user_loaded_yaml = dict(
-            default=user_loaded_yaml["dictitems"].get(
-                "default", {}
-            ).get("dictitems", {}))
+            default=user_loaded_yaml["dictitems"]
+            .get("default", {})
+            .get("dictitems", {})
+        )
 
     if "dictitems" in user_loaded_yaml:
-        server_loaded_yaml = dict(default=server_loaded_yaml["dictitems"].get(
-            "default", {}
-            ).get("dictitems", {}))
+        server_loaded_yaml = dict(
+            default=server_loaded_yaml["dictitems"]
+            .get("default", {})
+            .get("dictitems", {})
+        )
 
     new_settings = {
         "version": THIS_MIGRATION_SCHEMA_VERSION,
@@ -111,11 +114,11 @@ def _load_settings_yaml(file_name: str) -> Dict[str, Any]:
     # Enables loading corrupted settings files from 0.21.1 release
     yaml.Loader.add_constructor(
         "tag:yaml.org,2002:python/object/new:sematic.config.settings.Settings",
-        _settings_constructor
+        _settings_constructor,
     )
     yaml.Loader.add_constructor(
         "tag:yaml.org,2002:python/object/new:sematic.config.settings.ProfileSettings",
-        _settings_constructor
+        _settings_constructor,
     )
 
     if os.path.isfile(settings_file_path):

--- a/sematic/resolver.py
+++ b/sematic/resolver.py
@@ -11,6 +11,7 @@ class Resolver(abc.ABC):
     """
     Abstract base class for all resolvers. Defines the `Resolver` interfaces.
     """
+
     @abc.abstractmethod
     def resolve(self, future: AbstractFuture) -> typing.Any:
         """


### PR DESCRIPTION
Release 0.21.1 corrupted settings files, adding serialized dataclasses tags to the yaml file.

This PR does the following things:

- Updates a settings file migration to catch corrupted files and fix them
- Adds a `migrate` command to the CLI. Is there a way to call this as a post-pip-install script?
- Moves automated migrations from the CLI to before anything else is imported. Some modules (e.g. `server`) import plugins which loads settings. This means settings must be migrated before anything else is imported.