### PR TITLE
Implements UI for external resource

### DIFF
--- a/sematic/ui/src/Models.tsx
+++ b/sematic/ui/src/Models.tsx
@@ -82,3 +82,48 @@ export type User = {
   // only returned if user is self
   api_key: string | null;
 };
+
+export type ExternalResourceState = 
+"CREATED" |
+"ACTIVATING" |
+"ACTIVE" |
+"DEACTIVATING" |
+"DEACTIVATED";
+
+export type ExternalResource = {
+  id: string,
+  resource_state: ExternalResourceState,
+  managed_by: string,
+  status_message: string,
+  last_updated_epoch_seconds: Date,
+  type_serialization: TypeSerialization,
+  value_serialization: any,
+  history_serializations: any,
+  created_at: Date
+  updated_at: Date
+};
+
+export type ExternalResourceHistorySerialization = {
+  root_type: TypeSerialization,
+  types: unknown,
+  values: {
+    allocation_seconds: number,
+    deallocation_seconds: number,
+    epoch_time_activation_began: any,
+    epoch_time_deactivation_began: any,
+    id: string,
+    max_active_seconds: number,
+    message: string,
+    status: {
+      root_type: TypeSerialization,
+      values: {
+        last_update_epoch_time: number,
+        managed_by: string,
+        message: string,
+        state: ExternalResourceState
+      }
+    }
+  }
+};
+
+

--- a/sematic/ui/src/hooks/externalResourceHooks.ts
+++ b/sematic/ui/src/hooks/externalResourceHooks.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import useAsyncRetry from "react-use/lib/useAsyncRetry";
+import { ExternalResource, ExternalResourceState, Run } from "../Models";
+import { useHttpClient } from "./httpHooks";
+
+export const TERMINATE_STATE: ExternalResourceState = 'DEACTIVATED';
+const PULL_EXTERNAL_RESOURCE_INTERVAL = 1000;
+
+export function useExternalResource(run: Run) {
+    const {fetch} = useHttpClient();
+
+    const {value, loading, retry, error} = useAsyncRetry(async ()=> {
+        const response = await fetch({
+            url: `/api/v1/runs/${run.id}/external_resources`
+        });
+
+        if (!response['content']) {
+            throw Error('external_resources response is not in the correct format.')
+        }
+
+        return response['content'] as Array<ExternalResource>
+    }, [fetch, run]);
+
+    const timerHandler = useRef<number>();
+    useEffect(() => {
+        if (!loading && !!value) {
+            if (value.length === 0 || value[0].resource_state !== TERMINATE_STATE) {
+                timerHandler.current = window.setTimeout(retry, PULL_EXTERNAL_RESOURCE_INTERVAL);
+            }
+        }
+
+        return () => {
+            // clean up
+            if (timerHandler.current) {
+                clearTimeout(timerHandler.current);
+            }
+        }
+    }, [timerHandler, loading, value, retry]);
+
+    return {value, loading, error};
+}

--- a/sematic/ui/src/hooks/externalResourceHooks.ts
+++ b/sematic/ui/src/hooks/externalResourceHooks.ts
@@ -4,7 +4,7 @@ import { ExternalResource, ExternalResourceState, Run } from "../Models";
 import { useHttpClient } from "./httpHooks";
 
 export const TERMINATE_STATE: ExternalResourceState = 'DEACTIVATED';
-const PULL_EXTERNAL_RESOURCE_INTERVAL = 1000;
+const POLL_EXTERNAL_RESOURCE_INTERVAL = 1000;
 
 export function useExternalResource(run: Run) {
     const {fetch} = useHttpClient();
@@ -25,7 +25,7 @@ export function useExternalResource(run: Run) {
     useEffect(() => {
         if (!loading && !!value) {
             if (value.length === 0 || value[0].resource_state !== TERMINATE_STATE) {
-                timerHandler.current = window.setTimeout(retry, PULL_EXTERNAL_RESOURCE_INTERVAL);
+                timerHandler.current = window.setTimeout(retry, POLL_EXTERNAL_RESOURCE_INTERVAL);
             }
         }
 

--- a/sematic/ui/src/hooks/externalResourceHooks.ts
+++ b/sematic/ui/src/hooks/externalResourceHooks.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import useAsyncRetry from "react-use/lib/useAsyncRetry";
+import usePreviousDistinct from "react-use/lib/usePreviousDistinct";
 import { ExternalResource, ExternalResourceState, Run } from "../Models";
 import { useHttpClient } from "./httpHooks";
 
@@ -19,12 +20,14 @@ export function useExternalResource(run: Run) {
         }
 
         return response['content'] as Array<ExternalResource>
-    }, [fetch, run]);
+    }, [fetch, run.id]);
 
     const timerHandler = useRef<number>();
+    const prevLoading = usePreviousDistinct(loading);
     useEffect(() => {
-        if (!loading && !!value) {
-            if (value.length === 0 || value[0].resource_state !== TERMINATE_STATE) {
+        // monitors when loading changes from `true` to `false`
+        if (prevLoading && !loading) {
+            if (!!value && (value.length === 0 || value[0].resource_state !== TERMINATE_STATE)) {
                 timerHandler.current = window.setTimeout(retry, POLL_EXTERNAL_RESOURCE_INTERVAL);
             }
         }
@@ -35,7 +38,7 @@ export function useExternalResource(run: Run) {
                 clearTimeout(timerHandler.current);
             }
         }
-    }, [timerHandler, loading, value, retry]);
+    }, [timerHandler, prevLoading, loading, value, retry]);
 
     return {value, loading, error};
 }

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -78,3 +78,30 @@ export function useHttpClient(): HttpClient {
         cancel
     };
 }
+
+/**
+ * Mock series of server side responses
+ * 
+ * @param data The series of HTTP Response JOSN
+ * @param interval delay before a request is fulfilled.
+ * @returns 
+ */
+export function useMockHttpClient<T>(data: Array<T> = [], interval: number) {
+    let n = 0;
+
+    const fetchCallback = useCallback(async (args: any) => {
+        if (n >= data.length) {
+            return;
+        }
+        await new Promise((resolve) => {
+            setTimeout(resolve, interval);
+        });
+
+        return data[n++];
+    }, [data, interval, n]);
+
+    return {
+        fetch: fetchCallback,
+        cancel: () => {}
+    };
+}

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -80,13 +80,13 @@ export function useHttpClient(): HttpClient {
 }
 
 /**
- * Mock series of server side responses
+ * Simulate series of server side responses
  * 
  * @param data The series of HTTP Response JOSN
  * @param interval delay before a request is fulfilled.
  * @returns 
  */
-export function useMockHttpClient<T>(data: Array<T> = [], interval: number) {
+export function useDebuggingHttpClient<T>(data: Array<T> = [], interval: number) {
     let n = 0;
 
     const fetchCallback = useCallback(async (args: any) => {

--- a/sematic/ui/src/hooks/runDetailsHooks.ts
+++ b/sematic/ui/src/hooks/runDetailsHooks.ts
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import RunPanelContext from "../pipelines/RunDetailsContext";
 
 export function useRunPanelContext() {
@@ -9,4 +9,15 @@ export function useRunPanelContext() {
     }
 
     return contextValue;
+}
+
+export function useRunPanelLoadingIndicator(isLoading: boolean) {
+    const { setIsLoading } = useRunPanelContext();
+
+    useEffect(() => {
+        setIsLoading(isLoading);
+        return () => {
+            setIsLoading(false);
+        }
+    }, [setIsLoading, isLoading]);
 }

--- a/sematic/ui/src/pipelines/DocumentationPanel.tsx
+++ b/sematic/ui/src/pipelines/DocumentationPanel.tsx
@@ -1,7 +1,0 @@
-import Docstring from "../components/Docstring";
-import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
-
-export default function DocumentationPanel() {
-    const { selectedRun } = usePipelinePanelsContext();
-    return <Docstring docstring={selectedRun?.description} />
-} 

--- a/sematic/ui/src/pipelines/RunTabs.tsx
+++ b/sematic/ui/src/pipelines/RunTabs.tsx
@@ -12,8 +12,8 @@ import { Artifact } from "../Models";
 import { ArtifactList } from "./Artifacts";
 import LogPanel from "./LogPanel";
 import SourceCode from "../components/SourceCode";
-import DocumentationPanel from "./DocumentationPanel";
 import OutputPanel from "./OutputPanel";
+import ExternalResourcePanel from "./external_resource/ExternalResource";
 
 const StickyHeader = styled(Box)`
   position: sticky;
@@ -55,6 +55,7 @@ export default function RunTabs(props: {
             <Tab label="Source" value="source" />
             <Tab label="Logs" value="logs" />
             {grafanaTab}
+            <Tab label="Resources" value="ext_res" />
           </TabList>
         </StickyHeader>
         <TabPanel value="input">
@@ -62,9 +63,6 @@ export default function RunTabs(props: {
         </TabPanel>
         <TabPanel value="output" sx={{ pt: 5 }}>
           <OutputPanel outputArtifacts={artifacts.output} />
-        </TabPanel>
-        <TabPanel value="documentation">
-          <DocumentationPanel />
         </TabPanel>
         <TabPanel hidden={selectedRunTab !== "logs"} value="logs">
           <LogPanel />
@@ -74,6 +72,9 @@ export default function RunTabs(props: {
         </TabPanel>
         <TabPanel value="grafana">
           <GrafanaPanel />
+        </TabPanel>
+        <TabPanel hidden={selectedRunTab !== "ext_res"} value="ext_res">
+            <ExternalResourcePanel />
         </TabPanel>
       </TabContext>
     </>

--- a/sematic/ui/src/pipelines/ScrollingLogView.tsx
+++ b/sematic/ui/src/pipelines/ScrollingLogView.tsx
@@ -7,7 +7,7 @@ import { usePulldownTrigger, useScrollTracker } from "../hooks/scrollingHooks";
 import { ExceptionMetadata } from "../Models";
 import { Exception, ExternalException } from "../components/Exception";
 import usePrevious from "react-use/lib/usePrevious";
-import { useRunPanelContext } from "../hooks/runDetailsHooks";
+import { useRunPanelContext, useRunPanelLoadingIndicator } from "../hooks/runDetailsHooks";
 import { styled } from "@mui/system";
 
 const DEFAULT_LOG_INFO_MESSAGE = "No more matching lines";
@@ -34,7 +34,7 @@ export default function ScrollingLogView(props: {
   const { accumulateLogsUntilEnd, isLoading: isAccumulatorLoading,
     isAccumulating, accumulatedLines } = useAccumulateLogsUntilEnd(hasMore, getNext);
 
-  const { setFooterRenderProp, scrollerId, scrollContainerRef, setIsLoading } = useRunPanelContext();
+  const { setFooterRenderProp, scrollerId, scrollContainerRef } = useRunPanelContext();
 
   
   const pullDownCallback = useCallback(async () => {
@@ -153,12 +153,7 @@ export default function ScrollingLogView(props: {
     }
   }, [getNext, hasPulledData, scrollContainerRef]);
 
-  useEffect(() => {
-    setIsLoading(isLoading);
-    return () => {
-      setIsLoading(false);
-    }
-  }, [setIsLoading, isLoading]);
+  useRunPanelLoadingIndicator(isLoading);
 
   return (
     <>

--- a/sematic/ui/src/pipelines/external_resource/ExternalResource.tsx
+++ b/sematic/ui/src/pipelines/external_resource/ExternalResource.tsx
@@ -1,0 +1,61 @@
+import Timeline from '@mui/lab/Timeline';
+import Alert from "@mui/material/Alert";
+import { useMemo } from "react";
+import { useExternalResource } from "../../hooks/externalResourceHooks";
+import { usePipelinePanelsContext } from "../../hooks/pipelineHooks";
+import { styled } from '@mui/system';
+import ExternalResourceState from './ExternalResourceState';
+import timelineItemClasses from '@mui/lab/TimelineItem/timelineItemClasses';
+import { ExternalResourceHistorySerialization } from '../../Models';
+import { useRunPanelLoadingIndicator } from '../../hooks/runDetailsHooks';
+
+const ThinTimetime = styled(Timeline)`
+    margin: 0;
+    flex: 0;
+    & .${timelineItemClasses.root}:before {
+        flex: 0;
+        padding: 0;
+    }
+`;
+
+export default function ExternalResourcePanel() {
+
+    const { selectedRun } = usePipelinePanelsContext();
+
+    const { value: externalResources, loading, error } = useExternalResource(selectedRun!);
+
+    const historyRecords = useMemo<Array<ExternalResourceHistorySerialization> | null>(
+        () => {
+            if (!externalResources) {
+                return null;
+            }
+            if (externalResources.length === 0) {
+                return [];
+            }
+            const externalResource = externalResources[0];
+            const history 
+                = externalResource.history_serializations as 
+                Array<ExternalResourceHistorySerialization> || [];
+            return history.reverse();
+        }, [externalResources]);
+
+    useRunPanelLoadingIndicator(loading);
+
+    if (!externalResources || externalResources.length === 0) {
+        return <Alert severity="info" sx={{ mt: 3 }}>
+            The run does not use any external resource or the external resource state has not been reported yet.
+        </Alert>
+    }
+
+    if (!!error) {
+        return <Alert severity="error" sx={{ mt: 3 }}> {error.message} </Alert>
+    }
+
+    return <ThinTimetime key={selectedRun?.id}>
+            {historyRecords?.map(
+                (state, index) => 
+                <ExternalResourceState 
+                    historyRecord={state} key={index} isLast={historyRecords.length - 1 === index}/>
+            )}
+        </ThinTimetime>
+}

--- a/sematic/ui/src/pipelines/external_resource/ExternalResource.tsx
+++ b/sematic/ui/src/pipelines/external_resource/ExternalResource.tsx
@@ -38,6 +38,16 @@ export default function ExternalResourcePanel() {
                 Array<ExternalResourceHistorySerialization> || [];
             return history.reverse();
         }, [externalResources]);
+    
+    const extraResourcesInfoSection = useMemo(() => {
+        if ((externalResources?.length || 0) > 1) {
+            return <Alert severity="info">
+                The run uses more than 1 external resources. Here is only the first one.
+            </Alert>
+        }
+        return <></>;
+
+    }, [externalResources]);
 
     useRunPanelLoadingIndicator(loading);
 
@@ -51,11 +61,14 @@ export default function ExternalResourcePanel() {
         return <Alert severity="error" sx={{ mt: 3 }}> {error.message} </Alert>
     }
 
-    return <ThinTimetime key={selectedRun?.id}>
+    return <>
+        {extraResourcesInfoSection}
+        <ThinTimetime key={selectedRun?.id}>
             {historyRecords?.map(
                 (state, index) => 
                 <ExternalResourceState 
                     historyRecord={state} key={index} isLast={historyRecords.length - 1 === index}/>
             )}
         </ThinTimetime>
+    </>
 }

--- a/sematic/ui/src/pipelines/external_resource/ExternalResourceState.tsx
+++ b/sematic/ui/src/pipelines/external_resource/ExternalResourceState.tsx
@@ -1,0 +1,86 @@
+import TimelineConnector from "@mui/lab/TimelineConnector/TimelineConnector";
+import TimelineContent from "@mui/lab/TimelineContent/TimelineContent";
+import TimelineDot from "@mui/lab/TimelineDot/TimelineDot";
+import TimelineItem from "@mui/lab/TimelineItem/TimelineItem";
+import TimelineSeparator from "@mui/lab/TimelineSeparator/TimelineSeparator";
+import { TERMINATE_STATE } from "../../hooks/externalResourceHooks";
+import { format } from 'date-fns'
+import { useMemo } from "react";
+import Typography from "@mui/material/Typography/Typography";
+import { ExternalResourceHistorySerialization, ExternalResourceState as ExternalResourceStateType } from "../../Models";
+import { styled } from "@mui/system";
+import Chip from "@mui/material/Chip/Chip";
+
+const HighLightenedText = styled(Typography)`
+    font-weight: bold;
+    display: inline;
+`;
+
+const SpacedText = styled(Typography)`
+    margin: 4px 0;
+`;
+
+const StyledChip = styled(Chip)`
+    margin-right: 4px;
+`
+
+function StyledChipWithColor(props:
+    React.ComponentProps<typeof StyledChip> & {
+        resourceState: ExternalResourceStateType
+    }) {
+    const {resourceState, ...restProps } = props;
+
+    const color = useMemo(() => getColorByState(resourceState), [resourceState]);
+
+    return <StyledChip {...restProps} color={color} label={resourceState} />
+}
+
+interface ExternalResourceStateProps {
+    historyRecord: ExternalResourceHistorySerialization;
+    isLast: boolean;
+}
+
+function getColorByState(resourceState: ExternalResourceStateType) {
+    if (["ACTIVATING", "DEACTIVATING"].includes(resourceState)) {
+        return 'primary';
+    }
+    if ('ACTIVE' === resourceState) {
+        return 'success';
+    }
+    if (["CREATED", "DEACTIVATED"].includes(resourceState)) {
+        return undefined;
+    }
+    return undefined;
+}
+
+function TimelineDotWithColor({ resourceState }: { resourceState: ExternalResourceStateType }) {
+    const color = useMemo(() => getColorByState(resourceState) || 'grey', [resourceState]);
+    return <TimelineDot color={color} />;
+};
+
+export default function ExternalResourceState({ historyRecord, isLast }: ExternalResourceStateProps) {
+    const { root_type, values: { id, status: { values: { state, last_update_epoch_time, message } } } } = historyRecord;
+    const timeString = useMemo(
+        () => format(
+            new Date(last_update_epoch_time * 1000),
+            'LLL\xa0d,\xa0yyyy\xa0h:mm:ss\xa0a'), [last_update_epoch_time]);
+
+    const resourceName = root_type.type[1];
+
+    return <TimelineItem key={id}>
+        <TimelineSeparator>
+            {isLast ?
+                <TimelineDotWithColor resourceState={state} />
+                : <TimelineDot />}
+            {state !== TERMINATE_STATE && <TimelineConnector />}
+        </TimelineSeparator>
+        <TimelineContent>
+            {isLast ?
+                <StyledChipWithColor size={"small"} resourceState={state}/>
+                : <StyledChip size={"small"} label={state} />}
+            <HighLightenedText>{resourceName}</HighLightenedText>
+            <SpacedText>{message}</SpacedText>
+            <SpacedText>{timeString}</SpacedText>
+        </TimelineContent>
+    </TimelineItem>
+}

--- a/sematic/ui/src/pipelines/external_resource/ExternalResourceState.tsx
+++ b/sematic/ui/src/pipelines/external_resource/ExternalResourceState.tsx
@@ -20,9 +20,9 @@ const SpacedText = styled(Typography)`
     margin: 4px 0;
 `;
 
-const StyledChip = styled(Chip)`
-    margin-right: 4px;
-`
+function StyledChip(props: React.ComponentProps<typeof Chip>) {
+    return <Chip {...props} sx={{mr: 1}}/>
+};
 
 function StyledChipWithColor(props:
     React.ComponentProps<typeof StyledChip> & {


### PR DESCRIPTION
This PR works to display the external resources tab. 

Currently, after the tab is switched to, the code will constantly poll the server with an interval of 1 second until it sees the external resource with `DEACTIVATED` state. Navigating away from the external resources tab will cancel polling.

Despite the server returning a list of resources, we assume the server will return a list of 1. 

![capture1](https://user-images.githubusercontent.com/1046489/214685119-735bb26a-73ed-4090-86bc-4a701c3b5f59.gif)

Update:
After suggestions from code review, it now looks like this:

<img width="1457" alt="image" src="https://user-images.githubusercontent.com/1046489/214732868-77720600-18e9-4382-8554-576e463879dc.png">
