### PR TITLE
More robust fix for old settings files

### DIFF
--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -103,27 +103,22 @@ def down():
         f.write(yaml.dump(old_server_settings, Dumper=yaml.Dumper))
 
 
-def _settings_constructor(loader: yaml.Loader, node: yaml.MappingNode):
-    return loader.construct_mapping(node)
-
-
 def _load_settings_yaml(file_name: str) -> Dict[str, Any]:
     config_dir_path = _get_config_dir()
     settings_file_path = os.path.join(config_dir_path, file_name)
 
-    # Enables loading corrupted settings files from 0.21.1 release
-    yaml.Loader.add_constructor(
-        "tag:yaml.org,2002:python/object/new:sematic.config.settings.Settings",
-        _settings_constructor,
-    )
-    yaml.Loader.add_constructor(
-        "tag:yaml.org,2002:python/object/new:sematic.config.settings.ProfileSettings",
-        _settings_constructor,
-    )
-
     if os.path.isfile(settings_file_path):
         with open(settings_file_path, "r") as f:
-            return yaml.load(f, yaml.Loader) or {}
+            contents = (
+                f.read()
+                .replace("!!python/object/new:sematic.config.settings.Settings", "")
+                .replace(
+                    "!!python/object/new:sematic.config.settings.ProfileSettings", ""
+                )
+                .replace("!!python/object:sematic.config.settings.ProfileSettings", "")
+                .replace("!!python/object:sematic.config.settings.Settings", "")
+            )
+            return yaml.load(contents, yaml.Loader) or {}
 
     return {}
 


### PR DESCRIPTION
The old fix for migrating from old settings files missed a case for in-yaml tags; this PR covers it.