### PR TITLE
Show cloned run state

### DIFF
--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -78,7 +78,7 @@ export default function Home() {
       component="span"
       sx={{ display: "flex", alignItems: "center" }}
     >
-      Your latest run:&nbsp; <RunStateChip state={run.future_state} />
+      Your latest run:&nbsp; <RunStateChip run={run} />
       <Link href={"/pipelines/" + run.calculator_path}>{run.name}</Link>
     </Typography>;
   }, [isLoaded, runs]);

--- a/sematic/ui/src/components/CopyButton.tsx
+++ b/sematic/ui/src/components/CopyButton.tsx
@@ -7,8 +7,9 @@ export function CopyButton(props: {
   text: string;
   message?: string;
   children?: any;
+  color?: string;
 }) {
-  const { text, message = "Copied", children } = props;
+  const { text, message = "Copied", children, color = undefined } = props;
 
   const { setSnackMessage } = useContext(SnackBarContext);
 
@@ -20,7 +21,7 @@ export function CopyButton(props: {
     <Tooltip title={"Copy " + text}>
       <ButtonBase onClick={copy}>
         {children}
-        <ContentCopy fontSize="inherit" sx={{ ml: 1 }} />
+        <ContentCopy htmlColor={color} fontSize="inherit" sx={{ ml: 1 }} />
       </ButtonBase>
     </Tooltip>
   );

--- a/sematic/ui/src/components/Notes.tsx
+++ b/sematic/ui/src/components/Notes.tsx
@@ -1,8 +1,6 @@
 import { Box, Typography, useTheme } from "@mui/material";
-import { Link, useParams } from "react-router-dom";
-import { getPipelineUrlPattern } from "../hooks/pipelineHooks";
 import { Note, User } from "../Models";
-import { CopyButton } from "./CopyButton";
+import RunId from "./RunId";
 import TimeAgo from "./TimeAgo";
 import UserAvatar from "./UserAvatar";
 
@@ -65,22 +63,3 @@ export function NoteView(props: {
   );
 }
 
-function RunId(props: {
-  runId: string;
-  trim?: boolean;
-}) {
-  const { runId, trim = true } = props;
-
-  const { calculatorPath } = useParams();
-
-  return (
-    <>
-      <Link to={getPipelineUrlPattern(calculatorPath!, runId)} style={
-        {fontSize: '12px'}
-      }>
-          {trim ? runId.substring(0, 6) : runId}
-      </Link>
-      <CopyButton text={runId} message="Copied run ID" />
-    </>
-  );
-}

--- a/sematic/ui/src/components/RunId.tsx
+++ b/sematic/ui/src/components/RunId.tsx
@@ -1,0 +1,25 @@
+import { useParams, Link } from "react-router-dom";
+import { getPipelineUrlPattern } from "../hooks/pipelineHooks";
+import { CopyButton } from "./CopyButton";
+
+export default function RunId(props: {
+    runId: string;
+    trim?: boolean;
+    copy?: boolean;
+  }) {
+    const { runId, trim = true, copy = true } = props;
+  
+    const { pipelinePath } = useParams();
+  
+    return (
+      <>
+        <Link to={getPipelineUrlPattern(pipelinePath!, runId)} style={
+          {fontSize: '12px'}
+        }>
+            <code>{trim ? runId.substring(0, 6) : runId}</code>
+        </Link>
+        {copy && <CopyButton text={runId} message="Copied run ID" />}
+      </>
+    );
+  }
+  

--- a/sematic/ui/src/components/RunStateChip.tsx
+++ b/sematic/ui/src/components/RunStateChip.tsx
@@ -1,5 +1,6 @@
 import { Box, Tooltip, Typography, useTheme } from "@mui/material";
 import React from "react";
+import { Run } from "../Models";
 
 const Pin = React.forwardRef<HTMLDivElement, { color: any; hollow?: boolean }>(
   (props, ref) => {
@@ -24,16 +25,39 @@ const Pin = React.forwardRef<HTMLDivElement, { color: any; hollow?: boolean }>(
   }
 );
 
-function RunStateChip(props: { state?: string; variant?: string }) {
-  const state = props.state || "undefined";
-  const variant = props.variant || "mini";
+function RunStateChipCommonPresentation({
+  toolTipMessage, color, variant, hollow
+}: {
+  toolTipMessage: string,
+  color: string,
+  variant?: string,
+  hollow: boolean
+}) {
+  return <Tooltip title={toolTipMessage}>
+    <Typography
+      component="span"
+      sx={{ display: "flex", alignItems: "center" }}
+    >
+      <Pin color={color} hollow={hollow} />
+      {variant === "full" && <Box>{toolTipMessage}</Box>}
+    </Typography>
+  </Tooltip>
+}
+
+function RunStateChip({run, variant = "mini"}: { run: Run; variant?: string }) {
+  const state = run.future_state || "undefined";
   let toolTipMessage = state ? state : "UNKNOWN";
   const theme = useTheme();
   let color = theme.palette.grey[300];
   let hollow = false;
 
   if (state === "RESOLVED") {
-    toolTipMessage = "Succeeded";
+    if (run.original_run_id !== null) {
+      toolTipMessage = "Cloned";
+      hollow = true;
+    } else {
+      toolTipMessage = "Succeeded";
+    }
     color = theme.palette.success.light;
   }
 
@@ -69,15 +93,18 @@ function RunStateChip(props: { state?: string; variant?: string }) {
   }
 
   return (
-    <Tooltip title={toolTipMessage}>
-      <Typography
-        component="span"
-        sx={{ display: "flex", alignItems: "center" }}
-      >
-        <Pin color={color} hollow={hollow} />
-        {variant === "full" && <Box>{toolTipMessage}</Box>}
-      </Typography>
-    </Tooltip>
+    <RunStateChipCommonPresentation {...{
+      toolTipMessage, color, hollow, variant
+    }} />
+  );
+}
+
+export function RunStateChipUndefinedStyle() {
+  const theme = useTheme();
+
+  return (
+    <RunStateChipCommonPresentation toolTipMessage={"UNKNOWN"} 
+    color={theme.palette.grey[300]} hollow={false} variant={undefined} />
   );
 }
 

--- a/sematic/ui/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/src/pipelines/PipelineBar.tsx
@@ -255,13 +255,14 @@ export default function PipelineBar() {
               label="Latest runs"
               onChange={onSelect}
             >
-              {latestRuns.map(({id, future_state, created_at}) => (
-                <MenuItem value={id} key={id}>
+              {latestRuns.map((run) => {
+                const {id, created_at} = run;
+                return <MenuItem value={id} key={id}>
                   <Typography
                     component="span"
                     sx={{ display: "flex", alignItems: "center" }}
                   >
-                    <RunStateChip state={future_state} />
+                    <RunStateChip run={run} />
                     <Box>
                       <Typography sx={{ fontSize: "small", color: "GrayText" }}>
                         <code>{id.substring(0, 6)}</code>
@@ -272,7 +273,7 @@ export default function PipelineBar() {
                     </Box>
                   </Typography>
                 </MenuItem>
-              ))}
+              })}
             </Select>
           </FormControl>
         </Box>

--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -7,7 +7,7 @@ import { RunList } from "../components/RunList";
 import Tags from "../components/Tags";
 import { Run } from "../Models";
 import Link from "@mui/material/Link";
-import RunStateChip from "../components/RunStateChip";
+import RunStateChip, { RunStateChipUndefinedStyle } from "../components/RunStateChip";
 import { Alert, AlertTitle, Container } from "@mui/material";
 import { InfoOutlined } from "@mui/icons-material";
 import { RunTime } from "../components/RunTime";
@@ -16,9 +16,14 @@ import CalculatorPath from "../components/CalculatorPath";
 import TimeAgo from "../components/TimeAgo";
 import { useFetchRuns } from "../hooks/pipelineHooks";
 import Loading from "../components/Loading";
+import { styled } from "@mui/system";
+
+const RecentStatusesWithStyles = styled('span')`
+  flex-direction: row;
+  display: flex;
+`;
 
 function RecentStatuses(props: { calculatorPath: string }) {
-  let state: string | undefined = undefined;
   const { calculatorPath } = props;
 
   const runFilters = useMemo(() => ({
@@ -33,16 +38,17 @@ function RecentStatuses(props: { calculatorPath: string }) {
 
   function statusChip(index: number) {
     if (runs && runs.length > index) {
-      state = runs[index].future_state;
+      return <RunStateChip run={runs[index]} key={index} />;
     } else {
-      state = "undefined";
+      return <RunStateChipUndefinedStyle key={index} />;
     }
-    return <RunStateChip state={state} key={index} />;
   }
   if (isLoading) {
     return <Loading isLoaded={false} /> 
   }
-  return <>{[...Array(5)].map((e, i) => statusChip(i))}</>;
+  return <RecentStatusesWithStyles>
+    {[...Array(5)].map((e, i) => statusChip(i))}
+    </RecentStatusesWithStyles>;
 }
 
 function PipelineRow(props: { run: Run }) {

--- a/sematic/ui/src/pipelines/RunDetailsPanel.tsx
+++ b/sematic/ui/src/pipelines/RunDetailsPanel.tsx
@@ -1,9 +1,12 @@
 import { Box, Typography } from "@mui/material";
+import { styled } from "@mui/system";
 import { useCallback, useContext, useMemo } from "react";
 import { UserContext } from "..";
 import { ActionMenu, ActionMenuItem } from "../components/ActionMenu";
 import CalculatorPath from "../components/CalculatorPath";
+import { CopyButton } from "../components/CopyButton";
 import Docstring from "../components/Docstring";
+import RunId from "../components/RunId";
 import RunStateChip from "../components/RunStateChip";
 import { RunTime } from "../components/RunTime";
 import { SnackBarContext } from "../components/SnackBarProvider";
@@ -16,6 +19,12 @@ import { fetchJSON } from "../utils";
 import PipelinePanelsContext from "./PipelinePanelsContext";
 import PipelineRunViewContext from "./PipelineRunViewContext";
 import RunTabs, { IOArtifacts } from "./RunTabs";
+
+const StyledText = styled('span')`
+  font-size: small;
+  margin-left: 1em;
+  color: grey;
+`;
 
 export function RunDetailsPanel() {
     const { selectedRun } = usePipelinePanelsContext() as ExtractContextType<typeof PipelinePanelsContext> & {
@@ -73,18 +82,16 @@ export function RunDetailsPanel() {
               <Box marginBottom={3}>
                 <Typography variant="h6">{selectedRun.name}</Typography>
                 <Typography fontSize="small" color="GrayText" component="span">
-                  <code style={{ fontSize: 12 }}>
-                  ID: {selectedRun.id}
-                  {
-                    selectedRun.original_run_id &&
-                    /*
-                      TODO #278: replace full id with a 6-character trimmed
-                      link using "./Notes/RunId"
-                    */
-                    <> (cloned from {selectedRun.original_run_id})</>
-                  }
-                  </code>
+                  {'ID: '}
+                  <code style={{ fontSize: 12 }}>{selectedRun.id}</code>
                 </Typography>
+                <CopyButton text={selectedRun.id} message="Copied run ID" color={"grey"} />
+                {
+                    selectedRun.original_run_id &&
+                    <StyledText>
+                      cloned from <RunId runId={selectedRun.original_run_id} copy={false} />
+                    </StyledText>
+                }
                 <br />
                 <CalculatorPath calculatorPath={selectedRun.calculator_path} />
               </Box>
@@ -97,7 +104,7 @@ export function RunDetailsPanel() {
               />
             </Box>
             <Box sx={{ gridColumn: 3, pt: 3, pr: 5 }}>
-              <RunStateChip state={selectedRun.future_state} variant="full" />
+              <RunStateChip run={selectedRun} variant="full" />
               <RunTime run={selectedRun} prefix="in " />
             </Box>
           </Box>

--- a/sematic/ui/src/pipelines/RunTree.tsx
+++ b/sematic/ui/src/pipelines/RunTree.tsx
@@ -52,7 +52,7 @@ export default function RunTree(props: {
             selected={selectedRun.id === run!.id}
           >
             <ListItemIcon sx={{ minWidth: "20px" }}>
-              <RunStateChip state={run!.future_state} />
+              <RunStateChip run={run!} />
             </ListItemIcon>
             <ListItemText primary={run!.name} />
           </ListItemButton>

--- a/sematic/ui/src/pipelines/graph/RunNode.tsx
+++ b/sematic/ui/src/pipelines/graph/RunNode.tsx
@@ -72,7 +72,7 @@ export default function RunNode(props: NodeProps) {
         }}
       >
         <AlertTitle>
-          <RunStateChip state={run.future_state} />
+          <RunStateChip run={run} />
           {run.name}
         </AlertTitle>
       </Alert>

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -62,7 +62,7 @@ export function RunRow(props: RunRowProps) {
         {createdAt}
       </TableCell>
       <TableCell onClick={props.onClick}>
-        <RunStateChip state={run.future_state} />
+        <RunStateChip run={run} />
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
- On the run details page, render full run ID with copy button + original run ID shortened into six characters with deep-link. 

- Updated State chip and changes it to a hollow green circle for cloned runs. The label will be changed to `cloned` instead of `success`. The update should reflect on the DAG view and the run tree.

- Refactored the interface of `<RunStateChip />`.

![capture1](https://user-images.githubusercontent.com/1046489/213318747-b68ed35e-b303-4205-9add-caa31c5d7e68.gif)

Update: the visual style for the header part is updated to the following style:

<img width="793" alt="image" src="https://user-images.githubusercontent.com/1046489/213768191-99eb024b-0d14-438b-bdcd-6703fc4e1d7d.png">

(Screencast above is not re-recorded)
