### PR TITLE
Add support for Bazel 6.0.0

### DIFF
--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "sematic")


### PR DESCRIPTION
Bazel 6.0.0 gives the following error when running any Sematic target:
```bash
~/work/sematic$ bazel test sematic/api/...
ERROR: Failed to load .bzl file '//bazel:pipeline.bzl': possible dependency cycle detected.
ERROR: Error computing the main repository mapping: cycles detected during computation of main repo mapping
```

This seems to be caused by the inclusion in the `WORKSPACE` file of a Bazel file this resides inside a nested `WORKSPACE`. The error message itself seems to be incorrect, as a cycle is not actually present. Changing the name of the nested `WORKSPACE` or commenting out the entirety of the imported `pipeline.bzl` file incorrectly yields the same error, which would suggest that this is a regression in the Bazel release.

None of the [Bazel 6.0.0 release notes](https://github.com/bazelbuild/bazel/releases/tag/6.0.0) or any of its pre-release notes mention any changes regarding the behavior of loading `WORKSPACE`s (except deprecating a parameter).

Simply removing the nested `WORKSPACE` definition resolves the issue. This does not seem to have any consequences in the build itself.

