### PR TITLE
Add more log messages to worker.py

### DIFF
--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -129,6 +129,7 @@ sematic_py_lib(
         "//sematic/resolvers:cloud_resolver",
         "//sematic/scheduling:external_job",
         "//sematic/utils:exceptions",
+        "//sematic:versions",
     ],
 )
 

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -16,6 +16,7 @@ import cloudpickle
 import sematic.api_client as api_client
 from sematic.abstract_future import FutureState
 from sematic.calculator import Calculator
+from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import make_artifact
@@ -31,6 +32,7 @@ from sematic.resolvers.log_streamer import ingested_logs
 from sematic.scheduling.external_job import JobType
 from sematic.storage import S3Storage
 from sematic.utils.exceptions import format_exception_for_run
+from sematic.versions import CURRENT_VERSION_STR
 
 # Argument to cause worker.py to emulate a normal python interpreter.
 # If used, all other args will be passed to the emulated interpreter.
@@ -257,6 +259,9 @@ def wrap_main_with_logging():
             level=logging.INFO,
             format="%(asctime)s - %(levelname)s - %(name)s: %(message)s",
         )
+        pod_name = os.getenv(KUBERNETES_POD_NAME_ENV_VAR)
+        logger.info("Worker pod: %s", pod_name)
+        logger.info("Worker Sematic Version: %s", CURRENT_VERSION_STR)
         logger.info("Worker CLI args: run_id=%s", args.run_id)
         logger.info("Worker CLI args: resolve=%s", args.resolve)
         logger.info("Worker CLI args: max-parallelism=%s", args.max_parallelism)


### PR DESCRIPTION
It can sometimes be helpful to determine what version of Sematic a particular pipeline was running with when looking in the logs. This PR adds that info. Also, to diagnose whether there were new pods created, or help with k8s debugging, it can be helpful to view the pod name. This PR also adds that to the logs.

Testing
-------
Executed testing pipeline. View logs [here](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/982287fea62d49f09670e7673c4524e3#run=027010013add4641a0accecf80ecd3c9&tab=logs)