### PR TITLE
Enable dataclass compatibility

### DIFF
--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -131,7 +131,12 @@ def _dataclass_from_json_encodable(value: Any, type_: Any) -> Any:
         if name in types:
             field_type = type_from_json_encodable(types[name])
 
-        kwargs[name] = value_from_json_encodable(values[name], field_type)
+        if name in values:
+            # if the values were written with an older version of
+            # the dataclass, there may not be a value for certain
+            # fields. In such cases, we will rely on the defaults
+            # in the dataclass constructor.
+            kwargs[name] = value_from_json_encodable(values[name], field_type)
 
     return root_type(**kwargs)
 


### PR DESCRIPTION
Sometimes dataclasses change over time, and it would be helpful if values deserialized using an old version of a class could be deserialized using a new version of the class. One would think that if you add a new field to a dataclass, it should be able to deserialize something written when the class did *not* have that field--provided that the new class has a default value for the field. This is how protobuf compatibility works, for example. However, our code did not support this use case until this PR.

One place where these kind of incongruences can show up is between clients on an old version of Sematic and servers on a new version of Sematic. Clients and servers share some dataclasses, like resource requirements. This makes it safe to add new fields to dataclasses, provided that you specify a default for the new fields.