### PR TITLE
Support -p for configuring settings

### DIFF
--- a/sematic/cli/settings.py
+++ b/sematic/cli/settings.py
@@ -1,12 +1,12 @@
 # Standard Library
 import sys
-from typing import Type
+from typing import Optional, Type
 
 # Third-party
 import click
 
 # Sematic
-from sematic.abstract_plugin import AbstractPlugin
+from sematic.abstract_plugin import AbstractPlugin, import_plugin
 from sematic.cli.cli import cli
 from sematic.config.server_settings import ServerSettings
 from sematic.config.settings import (
@@ -35,11 +35,22 @@ def show_settings_cli() -> None:
 @settings.command("set", short_help="Set a user settings value")
 @click.argument("var", type=click.STRING)
 @click.argument("value", type=click.STRING)
-def set_settings_cli(var: str, value: str) -> None:
+@click.option(
+    "-p",
+    "--plugin",
+    "plugin",
+    type=click.STRING,
+    help="Import path to a plugin to configure a setting for.",
+    default=None,
+)
+def set_settings_cli(var: str, value: str, plugin: Optional[str]) -> None:
     """
     Set a setting value.
     """
-    _set_plugin_settings_cli(var, value, UserSettings)
+    plugin_class: Type[AbstractPlugin] = UserSettings
+    if plugin is not None:
+        plugin_class = import_plugin(plugin)
+    _set_plugin_settings_cli(var, value, plugin_class)
 
 
 def _set_plugin_settings_cli(

--- a/sematic/cli/tests/BUILD
+++ b/sematic/cli/tests/BUILD
@@ -50,3 +50,16 @@ pytest_test(
         "//sematic/tests:fixtures",
     ],
 )
+
+pytest_test(
+    name = "test_settings",
+    srcs = ["test_settings.py"],
+    pip_deps = [
+        "click",
+    ],
+    deps = [
+        "//sematic/cli:settings",
+        "//sematic/config:user_settings",
+        "//sematic/plugins/storage:s3_storage",
+    ],
+)

--- a/sematic/cli/tests/test_settings.py
+++ b/sematic/cli/tests/test_settings.py
@@ -1,0 +1,46 @@
+# Standard Library
+from unittest.mock import patch
+
+# Third-party
+from click.testing import CliRunner
+
+# Sematic
+from sematic.cli.settings import set_settings_cli
+from sematic.config.user_settings import UserSettings, UserSettingsVar
+from sematic.plugins.storage.s3_storage import S3Storage, S3StorageSettingsVar
+
+
+@patch("sematic.cli.settings.set_plugin_setting")
+def test_set_settings_cli(mock_set_plugin_setting):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        fake_address = "foo.com"
+        result = runner.invoke(
+            set_settings_cli, [UserSettingsVar.SEMATIC_API_ADDRESS.value, fake_address]
+        )
+        assert result.exception is None
+
+        mock_set_plugin_setting.assert_called_with(
+            UserSettings,
+            UserSettingsVar.SEMATIC_API_ADDRESS,
+            fake_address,
+        )
+
+        fake_bucket = "fake_bucket"
+        result = runner.invoke(
+            set_settings_cli,
+            [
+                S3StorageSettingsVar.AWS_S3_BUCKET.value,
+                fake_bucket,
+                "-p",
+                f"{S3Storage.__module__}.{S3Storage.__name__}",
+            ],
+        )
+        assert result.exception is None
+
+        mock_set_plugin_setting.assert_called_with(
+            S3Storage,
+            S3StorageSettingsVar.AWS_S3_BUCKET,
+            fake_bucket,
+        )


### PR DESCRIPTION
Users may sometimes have to configure settings for plugins besides `UserSettings` and `ServerSettings`. Indeed, we have error messages that assume this is possible. This PR adds support via:
```
sematic settings set VAR_NAME VALIE -p PLUGIN_IMPORT_PATH
```

Testing
-------
```
bazel run //sematic/cli:main -- settings set AWS_S3_BUCKET sematic-dev -p sematic.plugins.storage.s3_storage.S3Storage
bazel run //sematic/cli:main -- advanced dump-log-storage logs/v2/run_id/027010013add4641a0accecf80ecd3c9/worker
```

Also added a unit test