### PR TITLE
Add a link in output panel pointing to logs panel in case of error

### DIFF
--- a/sematic/ui/src/pipelines/OutputPanel.tsx
+++ b/sematic/ui/src/pipelines/OutputPanel.tsx
@@ -1,5 +1,7 @@
 import { Alert } from "@mui/material";
-import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { getPipelineUrlPattern, usePipelinePanelsContext } from "../hooks/pipelineHooks";
 import { Artifact } from "../Models";
 import { ArtifactList } from "./Artifacts";
 
@@ -10,12 +12,25 @@ export default function OutputPanel(props: {
     const { selectedRun } = usePipelinePanelsContext();
     const { future_state } = selectedRun!;
 
+    const logsLinkPath = useMemo(
+        () => {
+            const { calculator_path, id} = selectedRun!;
+            return {
+                pathname: getPipelineUrlPattern(calculator_path, id),
+                hash: 'tab=logs'
+            }
+        }, [selectedRun]);
+
     return <>
         {["CREATED", "SCHEDULED", "RAN"].includes(future_state) && (
             <Alert severity="info">No output yet. Run has not completed.</Alert>
         )}
         {["FAILED", "NESTED_FAILED"].includes(future_state) && (
-            <Alert severity="error">Run has failed. See Logs tab for details.</Alert>
+            <Alert severity="error">
+                Run has failed. See&nbsp;
+                <Link to={logsLinkPath} reloadDocument>Logs</Link>
+                &nbsp;tab for details.
+            </Alert>
         )}
         {future_state === "RESOLVED" && (<ArtifactList artifacts={outputArtifacts} />
         )}


### PR DESCRIPTION
Show a link pointing to logs tab in case the run failed, and no output is yielded.

Implementation-wise, it is implemented as a native HTML link instead of JS navigation functions. So we take advantage of copying/pasting, travel state, "open in new tabs" etc. 

![capture1](https://user-images.githubusercontent.com/1046489/213535885-515f379f-7620-45d7-9245-8cb6d97492e2.gif)
