### PR TITLE
Provide default plugin settings

### DIFF
--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -23,12 +23,20 @@ from sematic.versions import SETTINGS_SCHEMA_VERSION
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_PROFILE = "default"
 _SETTINGS_FILE_NAME = "settings.yaml"
 _PLUGIN_VERSION_KEY: Literal["__version__"] = "__version__"
 
 PluginScopes = Dict[PluginScope, List[str]]
 PluginSettings = Dict[Union[AbstractPluginSettingsVar, Literal["__version__"]], str]
 PluginsSettings = Dict[str, PluginSettings]
+
+# providing textual path instead of importing in order to avoid a dependency cycle
+# these plugins are "known" and will always be part of the server deployment
+_MANDATORY_SYSTEM_PLUGIN_PATHS = [
+    "sematic.config.server_settings.ServerSettings",
+    "sematic.config.user_settings.UserSettings",
+]
 
 
 @dataclass
@@ -41,18 +49,6 @@ class ProfileSettings:
     settings: PluginsSettings = field(default_factory=dict)
 
 
-_DEFAULT_PROFILE = "default"
-_DEFAULT_PROFILE_SETTINGS = ProfileSettings(
-    scopes={},
-    settings={
-        # providing textual path instead of importing in order to avoid a dependency cycle
-        # these plugins are "known" and will always be part of the server deployment
-        "sematic.config.server_settings.ServerSettings": {},
-        "sematic.config.user_settings.UserSettings": {},
-    },
-)
-
-
 @dataclass
 class Settings:
     """
@@ -61,7 +57,7 @@ class Settings:
 
     version: int = field(default_factory=lambda: SETTINGS_SCHEMA_VERSION)
     profiles: Dict[str, ProfileSettings] = field(
-        default_factory=lambda: {_DEFAULT_PROFILE: _DEFAULT_PROFILE_SETTINGS}
+        default_factory=lambda: {_DEFAULT_PROFILE: ProfileSettings()}
     )
 
 
@@ -131,6 +127,7 @@ def get_active_settings() -> ProfileSettings:
         profile_settings = settings.profiles[_DEFAULT_PROFILE]
 
         _apply_scopes_overrides(profile_settings.scopes)
+        _ensure_mandatory_plugins(profile_settings.settings)
 
         for plugin_path, plugin_settings in profile_settings.settings.items():
             plugin_settings_vars = _get_plugin_settings_vars(plugin_path)
@@ -437,12 +434,24 @@ def _apply_env_var_overrides(
             settings[var] = new_value
 
 
-def _apply_scopes_overrides(plugin_scopes: PluginScopes):
+def _apply_scopes_overrides(plugin_scopes: PluginScopes) -> None:
+    """
+    Adds system plugins that are declared in env variables, but not in the settings file.
+    """
     for scope in PluginScope:
         if scope.value in os.environ:
             logger.debug("Overriding scope %s from environment variables", scope.value)
 
             plugin_scopes[scope] = os.environ[scope.value].split(",")
+
+
+def _ensure_mandatory_plugins(plugin_settings: PluginsSettings) -> None:
+    """
+    Adds the mandatory system plugins to the parameter, if not present.
+    """
+    for plugin_path in _MANDATORY_SYSTEM_PLUGIN_PATHS:
+        if plugin_path not in plugin_settings:
+            plugin_settings[plugin_path] = {}
 
 
 def dump_settings(settings: ProfileSettings) -> str:

--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -23,7 +23,6 @@ from sematic.versions import SETTINGS_SCHEMA_VERSION
 logger = logging.getLogger(__name__)
 
 
-_DEFAULT_PROFILE = "default"
 _SETTINGS_FILE_NAME = "settings.yaml"
 _PLUGIN_VERSION_KEY: Literal["__version__"] = "__version__"
 
@@ -42,6 +41,18 @@ class ProfileSettings:
     settings: PluginsSettings = field(default_factory=dict)
 
 
+_DEFAULT_PROFILE = "default"
+_DEFAULT_PROFILE_SETTINGS = ProfileSettings(
+    scopes={},
+    settings={
+        # providing textual path instead of importing in order to avoid a dependency cycle
+        # these plugins are "known" and will always be part of the server deployment
+        "sematic.config.server_settings.ServerSettings": {},
+        "sematic.config.user_settings.UserSettings": {},
+    },
+)
+
+
 @dataclass
 class Settings:
     """
@@ -50,7 +61,7 @@ class Settings:
 
     version: int = field(default_factory=lambda: SETTINGS_SCHEMA_VERSION)
     profiles: Dict[str, ProfileSettings] = field(
-        default_factory=lambda: {_DEFAULT_PROFILE: ProfileSettings()}
+        default_factory=lambda: {_DEFAULT_PROFILE: _DEFAULT_PROFILE_SETTINGS}
     )
 
 

--- a/sematic/config/tests/BUILD
+++ b/sematic/config/tests/BUILD
@@ -44,6 +44,8 @@ sematic_py_lib(
         "pyyaml",
     ],
     deps = [
+        "//sematic/config:server_settings",
         "//sematic/config:settings",
+        "//sematic/config:user_settings",
     ],
 )

--- a/sematic/config/tests/fixtures.py
+++ b/sematic/config/tests/fixtures.py
@@ -9,7 +9,17 @@ from unittest.mock import patch
 import yaml
 
 # Sematic
+import sematic.config.server_settings as server_settings_module
 import sematic.config.settings as settings_module
+import sematic.config.user_settings as user_settings_module
+
+EXPECTED_DEFAULT_ACTIVE_SETTINGS = settings_module.ProfileSettings(
+    scopes={},
+    settings={
+        server_settings_module.ServerSettings.get_path(): {},
+        user_settings_module.UserSettings.get_path(): {},
+    },
+)
 
 
 @contextmanager

--- a/sematic/config/tests/fixtures.py
+++ b/sematic/config/tests/fixtures.py
@@ -2,6 +2,7 @@
 import os
 import tempfile
 from contextlib import contextmanager
+from typing import Any, Dict, Optional
 from unittest.mock import patch
 
 # Third-party
@@ -12,7 +13,13 @@ import sematic.config.settings as settings_module
 
 
 @contextmanager
-def mock_settings(settings_dict):
+def mock_settings(settings_dict: Optional[Dict[str, Any]]):
+    """
+    Returns the path to a mock settings file.
+
+    If the `settings_dict` parameter is empty, the settings file will be initialized with
+    an empty structure. If it is None, the file will not exist.
+    """
     with tempfile.TemporaryDirectory() as td:
         with patch(
             "sematic.config.settings.get_config_dir",

--- a/sematic/config/tests/test_server_settings.py
+++ b/sematic/config/tests/test_server_settings.py
@@ -8,8 +8,13 @@ from sematic.config.server_settings import (
 from sematic.config.tests.fixtures import mock_settings
 
 
-def test_get_empty_settings():
-    with mock_settings(None):
+def test_get_empty_settings_file():
+    with mock_settings({}):
+        assert get_active_server_settings() == {}
+
+
+def test_get_no_settings_file():
+    with mock_settings({}):
         assert get_active_server_settings() == {}
 
 

--- a/sematic/config/tests/test_settings.py
+++ b/sematic/config/tests/test_settings.py
@@ -9,6 +9,7 @@ from sematic.abstract_plugin import (
 )
 from sematic.config.settings import (
     _DEFAULT_PROFILE,
+    _DEFAULT_PROFILE_SETTINGS,
     _PLUGIN_VERSION_KEY,
     MissingSettingsError,
     get_active_plugins,
@@ -109,31 +110,77 @@ def test_get_settings(plugin_settings):
 
 
 @pytest.fixture
-def no_settings_file():
-    with mock_settings(None):
+def empty_settings_file():
+    with mock_settings({}):
         yield
 
 
-def test_from_scratch(no_settings_file):
+def test_get_empty_file(empty_settings_file):
     settings = get_settings()
-
     assert settings.version == 1
 
     settings_profile = settings.profiles[_DEFAULT_PROFILE]
+    assert settings_profile == _DEFAULT_PROFILE_SETTINGS
 
-    assert settings_profile.scopes == {}
 
-    assert settings_profile.settings == {}
+def test_get_specific_plugin_empty_file(empty_settings_file):
+    get_settings()
 
     assert get_active_plugins(scope=PluginScope.STORAGE, default=[TestPlugin]) == [
         TestPlugin
     ]
-
     assert (
         get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING, "default") == "default"
     )
 
 
-def test_env_override(no_settings_file):
+def test_env_override_specific_plugin_empty_file(empty_settings_file):
     with environment_variables({"SOME_SETTING": "override"}):
         assert get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING) == "override"
+
+
+def test_env_override_absent_plugin_empty_file(empty_settings_file):
+    with environment_variables({"SOME_SETTING": "override"}):
+        active_settings = get_active_settings()
+
+        # the plugin is not present in the scope, so its variables won't be even loaded
+        assert active_settings == _DEFAULT_PROFILE_SETTINGS
+
+
+@pytest.fixture
+def no_settings_file():
+    with mock_settings(None):
+        yield
+
+
+def test_get_no_file(no_settings_file):
+    settings = get_settings()
+    assert settings.version == 1
+
+    settings_profile = settings.profiles[_DEFAULT_PROFILE]
+    assert settings_profile == _DEFAULT_PROFILE_SETTINGS
+
+
+def test_get_specific_plugin_no_file(no_settings_file):
+    get_settings()
+
+    assert get_active_plugins(scope=PluginScope.STORAGE, default=[TestPlugin]) == [
+        TestPlugin
+    ]
+    assert (
+        get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING, "default") == "default"
+    )
+
+
+def test_env_override_specific_plugin_no_file(no_settings_file):
+    with environment_variables({"SOME_SETTING": "override"}):
+        # the plugin is not present in the scope, so its variables won't be even loaded
+        assert get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING) == "override"
+
+
+def test_env_override_absent_plugin_no_file(no_settings_file):
+    with environment_variables({"SOME_SETTING": "override"}):
+        active_settings = get_active_settings()
+
+        # the plugin is not present in the scope, so its variables won't be even loaded
+        assert active_settings == _DEFAULT_PROFILE_SETTINGS

--- a/sematic/config/tests/test_settings.py
+++ b/sematic/config/tests/test_settings.py
@@ -7,9 +7,9 @@ from sematic.abstract_plugin import (
     AbstractPluginSettingsVar,
     PluginScope,
 )
+from sematic.config.server_settings import ServerSettings, ServerSettingsVar
 from sematic.config.settings import (
     _DEFAULT_PROFILE,
-    _DEFAULT_PROFILE_SETTINGS,
     _PLUGIN_VERSION_KEY,
     MissingSettingsError,
     get_active_plugins,
@@ -18,7 +18,11 @@ from sematic.config.settings import (
     get_plugin_settings,
     get_settings,
 )
-from sematic.config.tests.fixtures import mock_settings
+from sematic.config.tests.fixtures import (
+    EXPECTED_DEFAULT_ACTIVE_SETTINGS,
+    mock_settings,
+)
+from sematic.config.user_settings import UserSettings, UserSettingsVar
 from sematic.tests.fixtures import environment_variables
 
 
@@ -34,7 +38,7 @@ class TestPlugin(AbstractPlugin):
 
     @staticmethod
     def get_version():
-        return (0, 1, 0)
+        return 0, 1, 0
 
     @classmethod
     def get_settings_vars(cls):
@@ -59,24 +63,6 @@ def plugin_settings():
     }
     with mock_settings(test_settings) as settings_file_name:
         yield settings_file_name
-
-
-def test_get_active_plugins(plugin_settings):
-    assert get_active_plugins(scope=PluginScope.STORAGE, default=[]) == [TestPlugin]
-    assert get_active_plugins(scope=PluginScope.AUTH, default=[]) == []
-
-
-def test_get_active_settings(plugin_settings):
-    active_settings = get_active_settings()
-
-    assert active_settings.scopes == {PluginScope.STORAGE: [TestPlugin.get_path()]}
-
-    assert active_settings.settings == {
-        TestPlugin.get_path(): {
-            SettingsVar.SOME_SETTING: "bar",
-            _PLUGIN_VERSION_KEY: "0.1.0",
-        }
-    }
 
 
 def test_get_plugin_setting(plugin_settings):
@@ -109,6 +95,76 @@ def test_get_settings(plugin_settings):
     }
 
 
+def test_get_active_plugins(plugin_settings):
+    assert get_active_plugins(scope=PluginScope.STORAGE, default=[]) == [TestPlugin]
+    assert get_active_plugins(scope=PluginScope.AUTH, default=[]) == []
+
+
+def test_get_active_settings(plugin_settings):
+    active_settings = get_active_settings()
+
+    assert active_settings.scopes == {PluginScope.STORAGE: [TestPlugin.get_path()]}
+
+    assert active_settings.settings == {
+        TestPlugin.get_path(): {
+            SettingsVar.SOME_SETTING: "bar",
+            _PLUGIN_VERSION_KEY: "0.1.0",
+        },
+        ServerSettings.get_path(): {},
+        UserSettings.get_path(): {},
+    }
+
+
+def test_get_active_settings_user_missing(plugin_settings):
+    with mock_settings(
+        {
+            "version": 0,
+            "profiles": {
+                "default": {
+                    "settings": {
+                        ServerSettings.get_path(): {
+                            ServerSettingsVar.KUBERNETES_NAMESPACE.value: "foobar"
+                        }
+                    }
+                }
+            },
+        }
+    ):
+        active_settings = get_active_settings()
+
+        assert active_settings.scopes == {}
+        assert active_settings.settings == {
+            ServerSettings.get_path(): {
+                ServerSettingsVar.KUBERNETES_NAMESPACE: "foobar"
+            },
+            UserSettings.get_path(): {},
+        }
+
+
+def test_get_active_settings_server_missing(plugin_settings):
+    with mock_settings(
+        {
+            "version": 0,
+            "profiles": {
+                "default": {
+                    "settings": {
+                        UserSettings.get_path(): {
+                            UserSettingsVar.SNOWFLAKE_USER.value: "foobar"
+                        }
+                    }
+                }
+            },
+        }
+    ):
+        active_settings = get_active_settings()
+
+        assert active_settings.scopes == {}
+        assert active_settings.settings == {
+            ServerSettings.get_path(): {},
+            UserSettings.get_path(): {UserSettingsVar.SNOWFLAKE_USER: "foobar"},
+        }
+
+
 @pytest.fixture
 def empty_settings_file():
     with mock_settings({}):
@@ -120,7 +176,8 @@ def test_get_empty_file(empty_settings_file):
     assert settings.version == 1
 
     settings_profile = settings.profiles[_DEFAULT_PROFILE]
-    assert settings_profile == _DEFAULT_PROFILE_SETTINGS
+    assert settings_profile.scopes == {}
+    assert settings_profile.settings == {}
 
 
 def test_get_specific_plugin_empty_file(empty_settings_file):
@@ -144,7 +201,12 @@ def test_env_override_absent_plugin_empty_file(empty_settings_file):
         active_settings = get_active_settings()
 
         # the plugin is not present in the scope, so its variables won't be even loaded
-        assert active_settings == _DEFAULT_PROFILE_SETTINGS
+        assert active_settings == EXPECTED_DEFAULT_ACTIVE_SETTINGS
+
+
+def test_get_active_settings_empty_file(empty_settings_file):
+    active_settings = get_active_settings()
+    assert active_settings == EXPECTED_DEFAULT_ACTIVE_SETTINGS
 
 
 @pytest.fixture
@@ -158,7 +220,8 @@ def test_get_no_file(no_settings_file):
     assert settings.version == 1
 
     settings_profile = settings.profiles[_DEFAULT_PROFILE]
-    assert settings_profile == _DEFAULT_PROFILE_SETTINGS
+    assert settings_profile.scopes == {}
+    assert settings_profile.settings == {}
 
 
 def test_get_specific_plugin_no_file(no_settings_file):
@@ -183,4 +246,9 @@ def test_env_override_absent_plugin_no_file(no_settings_file):
         active_settings = get_active_settings()
 
         # the plugin is not present in the scope, so its variables won't be even loaded
-        assert active_settings == _DEFAULT_PROFILE_SETTINGS
+        assert active_settings == EXPECTED_DEFAULT_ACTIVE_SETTINGS
+
+
+def test_get_active_settings_no_file(no_settings_file):
+    active_settings = get_active_settings()
+    assert active_settings == EXPECTED_DEFAULT_ACTIVE_SETTINGS

--- a/sematic/config/tests/test_user_settings.py
+++ b/sematic/config/tests/test_user_settings.py
@@ -8,7 +8,12 @@ from sematic.config.user_settings import (
 )
 
 
-def test_get_empty_settings():
+def test_get_empty_settings_file():
+    with mock_settings({}):
+        assert get_active_user_settings() == {}
+
+
+def test_get_no_settings_file():
     with mock_settings(None):
         assert get_active_user_settings() == {}
 


### PR DESCRIPTION
Currently, if the settings file is empty or missing, the Server and User plugins' settings are not loaded at all. The consequence is that env overrides for those plugins won't take effect.

This fixes the default profile settings to always include the Server and User plugins, and extends the unit tests.

Before:
```bash
~/work/sematic$ bazel run sematic/cli:main -- settings show
[...]
Active profile settings:

scopes: {}
settings:
  sematic.config.server_settings.ServerSettings: {}
  sematic.config.user_settings.UserSettings:
    AWS_S3_BUCKET: my_bucket
    SEMATIC_API_ADDRESS: my_server
    SEMATIC_API_KEY: my_api_key

~/work/sematic$ AWS_S3_BUCKET=test_bucket_override bazel run sematic/cli:main -- settings show
Active profile settings:

scopes: {}
settings:
  sematic.config.server_settings.ServerSettings: {}
  sematic.config.user_settings.UserSettings:
    AWS_S3_BUCKET: test_bucket_override       # <-- overridden
    SEMATIC_API_ADDRESS: my_server
    SEMATIC_API_KEY: my_api_key

~/work/sematic$ # remove the settings file completely
~/work/sematic$ rm ~/.sematic/settings.yaml
~/work/sematic$
~/work/sematic$ AWS_S3_BUCKET=test_bucket_override bazel run sematic/cli:main -- settings show
[...]
Active profile settings:

scopes: {}
settings: {}       # <-- not overridden

~/work/sematic$
```


After:
```bash
~/work/sematic$ # remove the settings file completely
~/work/sematic$ rm ~/.sematic/settings.yaml
~/work/sematic$
~/work/sematic$ AWS_S3_BUCKET=test_bucket_override bazel run sematic/cli:main -- settings show
[...]
Active profile settings:

scopes: {}
settings:
  sematic.config.server_settings.ServerSettings: {}
  sematic.config.user_settings.UserSettings:
    AWS_S3_BUCKET: test_bucket_override       # <-- overridden

~/work/sematic$
```
