### PR TITLE
Add retry for data 'put'

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -88,6 +88,7 @@ def _get_artifact(artifact_id: str) -> Artifact:
     return Artifact.from_json_encodable(response["content"])
 
 
+@retry(tries=3, delay=10, jitter=1)
 def store_artifact_bytes(artifact_id: str, bytes_: bytes) -> None:
     response = _get(f"/artifacts/{artifact_id}/location")
 


### PR DESCRIPTION
With the new way of writing data to S3, we aren't using the boto lib anymore for the actual write. This means that we are no longer doing the retries it did. This adds retries to our own write logic.