### PR TITLE
Endpoint for external resources used by a run

### DIFF
--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -31,6 +31,7 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.run import Run
 from sematic.db.models.user import User
 from sematic.db.queries import (
+    get_external_resources_by_run_id,
     get_resolution,
     get_root_graph,
     get_run,
@@ -425,6 +426,21 @@ def save_graph_endpoint(user: Optional[User]):
     #    return jsonify_error(str(e), HTTPStatus.INTERNAL_SERVER_ERROR)
 
     return flask.jsonify({})
+
+
+@sematic_api.route("/api/v1/runs/<run_id>/external_resources", methods=["GET"])
+@authenticate
+def get_run_external_resources(user: Optional[User], run_id):
+    external_resources = get_external_resources_by_run_id(run_id)
+
+    return flask.jsonify(
+        dict(
+            content=[
+                external_resource.to_json_encodable()
+                for external_resource in external_resources
+            ],
+        )
+    )
 
 
 @sematic_api.route("/api/v1/runs/<run_id>/external_resources", methods=["POST"])

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -22,13 +22,17 @@ from sematic.api.tests.fixtures import (  # noqa: F401
 from sematic.calculator import func
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
-from sematic.db.queries import get_run, save_resolution, save_run,\
-     save_run_external_resource_links
+from sematic.db.queries import (
+    get_run,
+    save_resolution,
+    save_run,
+    save_run_external_resource_links,
+)
 from sematic.db.tests.fixtures import (  # noqa: F401
     make_run,
+    persisted_external_resource,
     persisted_resolution,
     persisted_run,
-    persisted_external_resource,
     pg_mock,
     run,
     test_db,
@@ -630,12 +634,12 @@ def test_get_run_external_resources(
 ):
     save_run_external_resource_links([persisted_external_resource.id], persisted_run.id)
 
-    response = test_client.get(
-        f"/api/v1/runs/{persisted_run.id}/external_resources"
-    )
+    response = test_client.get(f"/api/v1/runs/{persisted_run.id}/external_resources")
     assert response.status_code == 200
 
-    payload = response.json["content"]
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+    payload = payload["content"]
 
     assert len(payload) == 1
-    assert payload[0]['id'] == persisted_external_resource.id
+    assert payload[0]["id"] == persisted_external_resource.id

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -22,11 +22,13 @@ from sematic.api.tests.fixtures import (  # noqa: F401
 from sematic.calculator import func
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
-from sematic.db.queries import get_run, save_resolution, save_run
+from sematic.db.queries import get_run, save_resolution, save_run,\
+     save_run_external_resource_links
 from sematic.db.tests.fixtures import (  # noqa: F401
     make_run,
     persisted_resolution,
     persisted_run,
+    persisted_external_resource,
     pg_mock,
     run,
     test_db,
@@ -45,6 +47,9 @@ test_put_run_graph_auth = make_auth_test("/api/v1/graph", method="PUT")
 test_post_events_auth = make_auth_test("/api/v1/events/namespace/event", method="POST")
 test_schedule_run_auth = make_auth_test("/api/v1/runs/123/schedule", method="POST")
 test_future_states_auth = make_auth_test("/api/v1/runs/future_states", method="POST")
+test_get_run_external_resource_auth = make_auth_test(
+    "/api/v1/runs/abc123/external_resources", method="GET"
+)
 
 
 @pytest.fixture
@@ -616,3 +621,21 @@ def test_get_run_graph_endpoint(
     assert payload["runs"][0]["id"] == future.id
     assert len(payload["artifacts"]) == artifact_count
     assert len(payload["edges"]) == edge_count
+
+
+def test_get_run_external_resources(
+    persisted_run,  # noqa: F811
+    persisted_external_resource,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    save_run_external_resource_links([persisted_external_resource.id], persisted_run.id)
+
+    response = test_client.get(
+        f"/api/v1/runs/{persisted_run.id}/external_resources"
+    )
+    assert response.status_code == 200
+
+    payload = response.json["content"]
+
+    assert len(payload) == 1
+    assert payload[0]['id'] == persisted_external_resource.id

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -205,15 +205,18 @@ def get_external_resources_by_run_id(run_id: str) -> List[ExternalResource]:
     Get the external resources used by a run.
     """
     with db().get_session() as session:
-        result = (
-            session.query(RunExternalResource, ExternalResource)
-            .filter(RunExternalResource.run_id == run_id)
+        external_resources = (
+            session.query(ExternalResource)
             .join(
-                ExternalResource, ExternalResource.id == RunExternalResource.resource_id
+                RunExternalResource,
+                sqlalchemy.and_(
+                    run_id == RunExternalResource.run_id,
+                    ExternalResource.id == RunExternalResource.resource_id,
+                ),
             )
             .all()
         )
-    return [row[ExternalResource] for row in result]
+    return external_resources
 
 
 def get_resolution(resolution_id: str) -> Resolution:

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -202,7 +202,7 @@ def get_resources_by_root_id(root_run_id: str) -> List[ExternalResource]:
 
 def get_external_resources_by_run_id(run_id: str) -> List[ExternalResource]:
     """
-    Get the external resources used by a run
+    Get the external resources used by a run.
     """
     with db().get_session() as session:
         result = (

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -200,6 +200,22 @@ def get_resources_by_root_id(root_run_id: str) -> List[ExternalResource]:
         return list(set(r[0] for r in results))
 
 
+def get_external_resources_by_run_id(run_id: str) -> List[ExternalResource]:
+    """
+    Get the external resources used by a run
+    """
+    with db().get_session() as session:
+        result = (
+            session.query(RunExternalResource, ExternalResource)
+            .filter(RunExternalResource.run_id == run_id)
+            .join(
+                ExternalResource, ExternalResource.id == RunExternalResource.resource_id
+            )
+            .all()
+        )
+    return [row[ExternalResource] for row in result]
+
+
 def get_resolution(resolution_id: str) -> Resolution:
     """Get a resolution from the database.
 


### PR DESCRIPTION
Support an API like the one below, which enumerates the external resources associated with a run

http://127.0.0.1:5001/api/v1/runs/df97c16293e6453485895811319ee643/external_resources