### PR TITLE
Make _getitem importable on graph cloning

### DIFF
--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -86,18 +86,27 @@ EXTERNAL_RESOURCE_HELP = (
     "Whether to use an artificial external resource when executing some of "
     "the 'add' functions."
 )
+RAY_HELP = (
+    "Includes a function that is executed on the specified external Ray cluster. "
+    "If not provided, Ray will not be used. Defaults to None. "
+    "Example: 'ray://raycluster-complete-head-svc:10001'."
+)
 EXPAND_SHARED_MEMORY_HELP = (
     "Whether to include a function that runs on a Kubernetes pod which uses an expanded "
     "shared memory partition. This option is added to a shared function which uses one "
     "KubernetesResourceRequirements configuration containing all the relevant specified "
     "CLI parameters. Defaults to False."
 )
-RAY_HELP = (
-    "Includes a function that is executed on the specified external Ray cluster. "
-    "using a remote Ray cluster. If not provided, Ray will not be used. "
-    "Example: 'ray://raycluster-complete-head-svc:10001'."
+CACHE_HELP = (
+    "The cache namespace to use for funcs whose outputs will be cached. "
+    "Defaults to None, which deactivates caching."
 )
-CACHE_HELP = "The cache namespace to use for funcs whose outputs will be cached."
+VIRTUAL_FUNCS_HELP = (
+    "Whether to explicitly include the `_make_list`, `_make_tuple`, and `_getitem` "
+    "virtual functions. Defaults to False. Note: If this pipeline is invoked with any "
+    "parameters, `_make_list` is automatically included at the end of the execution "
+    "anyway, in order to collect all intermediate results."
+)
 EXIT_HELP = (
     "Includes a function which will exit with the specified code. "
     "If specified without a value, defaults to 0. Defaults to None."
@@ -209,6 +218,12 @@ def _parse_args() -> argparse.Namespace:
         type=str,
         default=None,
         help=CACHE_HELP,
+    )
+    parser.add_argument(
+        "--virtual-funcs",
+        action="store_true",
+        default=False,
+        help=VIRTUAL_FUNCS_HELP,
     )
     parser.add_argument(
         "--exit",

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -6,13 +6,14 @@ import logging
 import os
 import random
 import time
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # Third-party
 import ray
 
 # Sematic
 import sematic
+from sematic.calculator import _make_tuple
 from sematic.plugins.external_resource.timed_message import TimedMessage
 from sematic.resolvers.resource_requirements import ResourceRequirements
 
@@ -258,6 +259,17 @@ def do_retry(val: float, failure_probability: float = 0.5) -> float:
     return val
 
 
+@sematic.func(inline=False)
+def do_virtual_funcs(a: float, b: float, c: float) -> float:
+    """
+    Adds three numbers while explicitly including _make_tuple, _make_list, and _getitem.
+    """
+    logger.info("Executing: do_virtual_funcs(a=%s, b=%s, c=%s)", a, b, c)
+    time.sleep(5)
+    d, e, f = _make_tuple(Tuple[float, float, float], (a, b, c))
+    return add_all([d, e, f])
+
+
 @sematic.func(inline=True)
 def testing_pipeline(
     inline: bool = False,
@@ -271,6 +283,7 @@ def testing_pipeline(
     ray_cluster_address: Optional[str] = None,
     resource_requirements: Optional[ResourceRequirements] = None,
     cache: bool = False,
+    virtual_funcs: bool = False,
     exit_code: Optional[int] = None,
 ) -> float:
     """
@@ -300,20 +313,21 @@ def testing_pipeline(
         Defaults to False.
     external_resource: bool
         Whether to use an external resource. Defaults to False.
+    ray_cluster_address:
+        The address of a Ray cluster. `None` if Ray should not be used. If specified,
+        two numbers will be added using a Ray task that executes on the remote cluster.
     resource_requirements: Optional[ResourceRequirements]
         If not None, includes a function that runs with the specified requirements.
         Defaults to False.
     cache: bool
         Whether to include nested functions which will have the `cache` flag activated.
         Defaults to False.
+    virtual_funcs: bool
+        Whether to include the `_make_list`, `_make_tuple`, and `_getitem` virtual
+        functions. Defaults to False.
     exit_code: Optional[int]
         If not None, includes a function which will exit with the specified code.
         Defaults to None.
-    external_resource: bool
-        Whether to use an external resource. Defaults to False.
-    ray_cluster_address:
-        The address of a Ray cluster. `None` if Ray should not be used. If specified,
-        two numbers will be added using a Ray task that executes on the remote cluster.
     """
     # have an initial function whose output is used as inputs by all other functions
     # this staggers the rest of the functions and allows the user a chance to monitor and
@@ -347,6 +361,9 @@ def testing_pipeline(
         futures.append(add_using_resource(initial_future, 1.0))
         futures.append(add_inline_using_resource(initial_future, 1.0))
 
+    if ray_cluster_address is not None:
+        futures.append(add_with_ray(initial_future, 1.0, ray_cluster_address))
+
     if resource_requirements is not None:
         function = add_with_resource_requirements(initial_future, 3)
         function.set(resource_requirements=resource_requirements)
@@ -355,11 +372,11 @@ def testing_pipeline(
     if cache:
         futures.append(add4_nested_cached(initial_future, 1, 2, 3))
 
+    if virtual_funcs:
+        futures.append(do_virtual_funcs(initial_future, 2, 3))
+
     if exit_code is not None:
         futures.append(do_exit(initial_future, exit_code))
-
-    if ray_cluster_address is not None:
-        futures.append(add_with_ray(initial_future, 1.0, ray_cluster_address))
 
     # collect all values
     result = add_all(futures) if len(futures) > 1 else futures[0]

--- a/sematic/future_operators/getitem.py
+++ b/sematic/future_operators/getitem.py
@@ -59,4 +59,10 @@ def __getitem__(self: Future, key: Any):
     return _getitem(self, key)
 
 
+# the func is externally-referred to as `_get_item`,
+# and needs to be importable under this name when cloning the graph
+def _getitem(container: Future, key: Any):
+    return __getitem__(self=container, key=key)  # type: ignore
+
+
 Future.__getitem__ = __getitem__  # type: ignore

--- a/sematic/ui/src/constants.ts
+++ b/sematic/ui/src/constants.ts
@@ -1,1 +1,1 @@
-export const HIDDEN_RUN_NAME_LIST = ["_make_list", "_make_tuple"];
+export const HIDDEN_RUN_NAME_LIST = ["_make_list", "_make_tuple", "_getitem"];


### PR DESCRIPTION
Fixes #494.

When re-running a pipeline that included `_getitem`, during the cloning process the func would be imported. As `_getitem` is declared inside another plain Python function, it is not available for import.

This does not reproduce for `_make_list` or for `_make_tuple` because their enclosing functions have the same respective names. `_getitem` is declared inside a function called `__getitem__`, which is then set as the homonymous utility function on the `Future` class.

This PR introduces a `_getitem` function which wraps `__getitem__`, which can be imported in its stead.

The testing pipeline is also updated to provide the ability to explicitly include the `_make_list`, `_make_tuple`, and `_getitem` virtual funcs.

Also, `_getitem` is added to the list of "hidden" funcs in the Dashboard, alongside the other two. This had been an oversight.

Reproduced locally using the testing pipeline enhancement, and validated locally and in the cloud that the re-run feature works with this fix:

```bash
$ bazel run sematic/examples/testing_pipeline -- --virtual-funcs
$ bazel run sematic/examples/testing_pipeline -- --virtual-funcs --rerun-from=XXX
```

![image](https://user-images.githubusercontent.com/1894533/214453598-718b6b4c-3f4d-4343-b057-d00fe5fac95b.png)
