### PR TITLE
Dismiss loading indicator

### DIFF
--- a/sematic/ui/src/pipelines/ScrollingLogView.tsx
+++ b/sematic/ui/src/pipelines/ScrollingLogView.tsx
@@ -155,6 +155,9 @@ export default function ScrollingLogView(props: {
 
   useEffect(() => {
     setIsLoading(isLoading);
+    return () => {
+      setIsLoading(false);
+    }
   }, [setIsLoading, isLoading]);
 
   return (


### PR DESCRIPTION
This PR dismisses the full page loading indicator when the component is unloaded. So we leave no lingering loading indicator after switching tabs.