### PR TITLE
Fixes a race condition issue

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
+    * [feature] Support the `debug` query parameter which can be added to any URL to enforce the front-end application to emit logs.
 * [0.22.2](https://pypi.org/project/sematic/0.22.2/)
     * [feature] Add the ability to cache the output of a function and avoid its re-execution in
       the future

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import io from "socket.io-client";
 import { atomWithHash } from 'jotai-location'
+import { useLocation } from "react-router-dom";
 
 interface IFetchJSON {
   url: string;
@@ -59,9 +60,23 @@ export function fetchJSON({
 }
 
 export function useLogger() {
-  const devLogger = useMemo(() => process.env.NODE_ENV === "development" ?
-    (...args: any[]) => console.log("DEV DEBUG: ", ...args) :
-    () => { }, []);
+  const { search } = useLocation();
+
+  const isLoggingExplicitlyTurnedOn = useMemo(
+    () => (new URLSearchParams(search)).has('debug'), [search]);
+
+  const devLogger = useMemo(
+    () => {
+      if (process.env.NODE_ENV === "development" || isLoggingExplicitlyTurnedOn) {
+        return (...args: any[]) => {
+          console.log(
+            `${(new Date()).toString().replace(/\sGMT.+$/, '')}  DEV DEBUG: `,
+            ...args
+          );
+        }
+      }
+      return () => { };
+    }, [isLoggingExplicitlyTurnedOn]);
 
   return {
     devLogger


### PR DESCRIPTION
This is a second attempt to fix the issue mentioned in https://github.com/sematic-ai/sematic/pull/440

### Symptom
The WebSocket packets to update the graph are emitted at random moments. If the client receives a packet when there is an ongoing request to get the updated graph payload, a successive such request will be discarded due to the logic in  [useAsyncRetry](https://github.com/streamich/react-use/blob/325f5bd69904346788ea981ec18bfc7397c611df/src/useAsyncRetry.ts#L13
), when we see the log message `You are calling useAsyncRetry hook retry() method while loading in progress, this is a no-op.' `, it is an indication of such mechanism underplay. 

### Previous fix in https://github.com/sematic-ai/sematic/pull/440
In the previous PR, I attempted to wait for the async loading using a promise. That part succeeded. However, following the promise resolution, the loading state variable `loading` does not instantly flip from `true` to `false`. Due to complexities in the React state update mechanism, the state update might take a while. In [PR 440](https://github.com/sematic-ai/sematic/pull/440), I attempted to work around this issue using `setTimeout`, hoping to relieve the code flow from the rendering cycle and trigger the reload (retry) callback as a side-effect. That approach didn't work, probably due to the following reasons:

1. the `retry` callback could be associated with `loading` state as `true` in its clousure.  So when it's called, it always sees the `loading` state as `true`. Hence, the request will be discarded.
2. We will remove listeners from the graph socket and reattach them as long as `retry` callback changes. This might be too frequent and cause us to lose frames from the socket transmission. It is a recipe for failure due to race conditions.
3. The time it takes the React framework to flip the state of `loading` is unpredictable. 

### New fix in the PR
1. If there is an ongoing request, do not wait for the promise. Instead, we simply bookmark an intention to call reload after the ongoing request completes. In the meantime, the code look for when the `loading` state has been flipped from `true` to `false`. When that happens, see if there was any reload attempt requested. If so, call reload when the `loading` state is `false`. So we guarantee that the `loading` state must be `false` when we call `retry`.

2. Use a delegate wrapper as the graph update callback. This wrapper links to the actual callback logic and is constantly updated to ensure it always points to the latest. This way, we only need to call `graph.on()` once, instead of constantly detaching/re-attaching the listeners. 

Other helpful changes in this PR include:
1. Add timestamp for logging statements.
2. For a production build, one can add a `debug` query parameter to enforce turning on logging. Specifying a value for this query parameter is not necessary. 