### PR TITLE
Parallelizing CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             - .pyenv
             - project
 
-  build-and-lint:
+  lint:
     docker:
       - image: sematicai/sematic-ci:latest
     steps:
@@ -96,13 +96,19 @@ jobs:
           at: /home/circleci
       - non-coverage-tests
 
-  integration-test:
+  installation:
     docker:
       - image: sematicai/sematic-ci:latest
     steps:
       - attach_workspace:
           at: /home/circleci
       - installation-tests
+  
+  integration-test:
+    docker:
+      - image: sematicai/sematic-ci:latest
+    steps:
+      - run: echo "no op for now"
       
   finalize:
     docker:
@@ -118,17 +124,20 @@ workflows:
   sematic-test:
     jobs:
       - init
-      - build-and-lint:
+      - lint:
           requires:
             - init
       - unit-tests:
           requires:
             - init
-      - integration-test:
+      - installation:
           requires:
             - init
+      - integration-test:
+          requires:
+            - installation
       - finalize:
           requires:
-            - build-and-lint
+            - lint
             - unit-tests
             - integration-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,20 +68,67 @@ commands:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build-and-test:
+  init:
     docker:
       - image: sematicai/sematic-ci:latest
     steps:
       - checkout
       - install-ci-pip-deps
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - .pyenv
+            - project
+
+  build-and-lint:
+    docker:
+      - image: sematicai/sematic-ci:latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
       - do-static-analysis
+      
+  unit-tests:
+    docker:
+      - image: sematicai/sematic-ci:latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
       - non-coverage-tests
+
+  integration-test:
+    docker:
+      - image: sematicai/sematic-ci:latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
       - installation-tests
+      
+  finalize:
+    docker:
+      - image: cimg/base:2023.01
+    steps:
       - notify-completion
+
+
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   sematic-test:
     jobs:
-      - build-and-test
+      - init
+      - build-and-lint:
+          requires:
+            - init
+      - unit-tests:
+          requires:
+            - init
+      - integration-test:
+          requires:
+            - init
+      - finalize:
+          requires:
+            - build-and-lint
+            - unit-tests
+            - integration-test


### PR DESCRIPTION
Parallelizing CI runs by dividing the workflow into several jobs.

This is to pave the way for the works of integration test later.

In the implementation, I adopted workspace storage (persist_to_workspace + attach_workspace) to preserve the work of `pip install` and code checkout. So the successive jobs can directly use the result when run in parallel.

Example: https://app.circleci.com/pipelines/github/sematic-ai/sematic/2078/workflows/0b83172b-0aa5-46d1-aea5-24534bdc8e4d

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/1046489/216422270-05d756e2-7082-4104-9465-bdb0222ecb02.png">

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/1046489/216125078-f23c49c9-6c05-4c95-9912-29831f8ce2dc.png">

