### PR TITLE
Fix Helm socketio service address

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
 {{ if .Values.deployment.socket_io.dedicated }}
-  SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "%s-socketio" .Release.Name }}
+  SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}
 {{ end }}
 {{ if .Values.ingress.sematic_dashboard_url }}
   SEMATIC_DASHBOARD_URL: {{ .Values.ingress.sematic_dashboard_url | quote }}


### PR DESCRIPTION
Fixes the incorrectly-generated socketio service address in the Helm charts.