### PR TITLE
Improve run/resolution cleanup (clearer root cause, resolver restarts)

### DIFF
--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -7,7 +7,7 @@ import abc
 import enum
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple, Union
 
 # Sematic
 from sematic.abstract_calculator import AbstractCalculator
@@ -57,13 +57,19 @@ class FutureState(enum.Enum):
         """Return True if & only if the state represents one that can't be moved from."""
         return self in _TERMINAL_STATES
 
+    @classmethod
+    def terminal_states(cls) -> FrozenSet["FutureState"]:
+        return _TERMINAL_STATES
 
-_TERMINAL_STATES = {
-    FutureState.NESTED_FAILED,
-    FutureState.FAILED,
-    FutureState.RESOLVED,
-    FutureState.CANCELED,
-}
+
+_TERMINAL_STATES = frozenset(
+    {
+        FutureState.NESTED_FAILED,
+        FutureState.FAILED,
+        FutureState.RESOLVED,
+        FutureState.CANCELED,
+    }
+)
 
 
 @dataclass

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -61,6 +61,10 @@ class FutureState(enum.Enum):
     def terminal_states(cls) -> FrozenSet["FutureState"]:
         return _TERMINAL_STATES
 
+    @classmethod
+    def terminal_state_strings(cls) -> FrozenSet[str]:
+        return _TERMINAL_STATE_STRINGS
+
 
 _TERMINAL_STATES = frozenset(
     {
@@ -70,6 +74,8 @@ _TERMINAL_STATES = frozenset(
         FutureState.CANCELED,
     }
 )
+
+_TERMINAL_STATE_STRINGS = frozenset(state.value for state in _TERMINAL_STATES)
 
 
 @dataclass

--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -18,6 +18,7 @@ sematic_py_lib(
         "//sematic/db/models:run",
         "//sematic/db/models:user",
         "//sematic/scheduling:job_scheduler",
+        "//sematic/scheduling:kubernetes",
     ],
 )
 

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -283,9 +283,7 @@ def _publish_resolution_event(resolution: Resolution) -> None:
 
 
 def _cancel_non_terminal_runs(root_id):
-    terminal_states = (
-        future_state.value for future_state in FutureState if future_state.is_terminal()
-    )
+    terminal_states = list(FutureState.terminal_states())
 
     unfinished_runs, _, __ = get_graph(
         sqlalchemy.and_(

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -130,6 +130,9 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
     except InvalidResolution as e:
         logger.warning("Could not update resolution: %s", e)
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
+    
+    if existing_resolution is not None and existing_resolution.status.is_terminal():
+        _cancel_non_terminal_runs(resolution.root_id)
 
     save_resolution(resolution)
     _publish_resolution_event(resolution)
@@ -231,32 +234,15 @@ def cancel_resolution_endpoint(
 
     root_run = get_run(resolution.root_id)
 
-    terminal_states = (
-        future_state.value for future_state in FutureState if future_state.is_terminal()
-    )
-
-    unfinished_runs, _, __ = get_graph(
-        sqlalchemy.and_(
-            Run.root_id == resolution.root_id,
-            sqlalchemy.not_(Run.future_state.in_(terminal_states)),  # type: ignore
-        ),
-        include_edges=False,
-        include_artifacts=False,
-    )
-
+    jobs = []
     for external_job in resolution.external_jobs:
-        cancel_job(external_job)
+        jobs.append(cancel_job(external_job))
+    resolution.external_jobs = jobs
 
     resolution.status = ResolutionStatus.CANCELED
     save_resolution(resolution)
 
-    for run in unfinished_runs:
-        for external_job in run.external_jobs:
-            cancel_job(external_job)
-
-        run.future_state = FutureState.CANCELED
-
-    save_graph(unfinished_runs, [], [])
+    _cancel_non_terminal_runs(resolution.root_id)
 
     broadcast_graph_update(root_id=resolution.root_id, user=user)
     broadcast_resolution_cancel(
@@ -291,3 +277,28 @@ def _publish_resolution_event(resolution: Resolution) -> None:
         # TODO: components such as these should be instantiated once at startup and made
         #  available as a server-internal first-class citizen component API
         publisher_class().publish(resolution)
+
+
+def _cancel_non_terminal_runs(root_id):
+    terminal_states = (
+        future_state.value for future_state in FutureState if future_state.is_terminal()
+    )
+
+    unfinished_runs, _, __ = get_graph(
+        sqlalchemy.and_(
+            Run.root_id == root_id,
+            sqlalchemy.not_(Run.future_state.in_(terminal_states)),  # type: ignore
+        ),
+        include_edges=False,
+        include_artifacts=False,
+    )
+
+    for run in unfinished_runs:
+        jobs = []
+        for external_job in run.external_jobs:
+            jobs.append(cancel_job(external_job))
+        run.external_jobs = jobs
+
+        run.future_state = FutureState.CANCELED
+
+    save_graph(unfinished_runs, [], [])

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -130,9 +130,12 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
     except InvalidResolution as e:
         logger.warning("Could not update resolution: %s", e)
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
-    
-    if existing_resolution is not None and existing_resolution.status.is_terminal():
-        _cancel_non_terminal_runs(resolution.root_id)
+
+    if ResolutionStatus[resolution.status].is_terminal():
+        try:
+            _cancel_non_terminal_runs(resolution.root_id)
+        except Exception as e:
+            logger.exception("Error when trying to cancel runs in resolution: %s", e)
 
     save_resolution(resolution)
     _publish_resolution_event(resolution)
@@ -237,7 +240,7 @@ def cancel_resolution_endpoint(
     jobs = []
     for external_job in resolution.external_jobs:
         jobs.append(cancel_job(external_job))
-    resolution.external_jobs = jobs
+    resolution.external_jobs = jobs  # type: ignore
 
     resolution.status = ResolutionStatus.CANCELED
     save_resolution(resolution)

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -283,7 +283,7 @@ def _publish_resolution_event(resolution: Resolution) -> None:
 
 
 def _cancel_non_terminal_runs(root_id):
-    terminal_states = list(FutureState.terminal_states())
+    terminal_states = FutureState.terminal_state_strings()
 
     unfinished_runs, _, __ = get_graph(
         sqlalchemy.and_(

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -45,6 +45,7 @@ from sematic.log_reader import load_log_lines
 from sematic.scheduling.external_job import ExternalJob
 from sematic.scheduling.job_scheduler import schedule_run, update_run_status
 from sematic.utils.retry import retry
+from sematic.scheduling.kubernetes import cancel_job
 
 logger = logging.getLogger(__name__)
 
@@ -415,6 +416,12 @@ def save_graph_endpoint(user: Optional[User]):
     runs = [Run.from_json_encodable(run) for run in graph["runs"]]
     for run in runs:
         logger.info("Graph update, run %s is in state %s", run.id, run.future_state)
+        if FutureState[run.future_state].is_terminal():
+            logger.info("Ensuring jobs for %s are stopped %s", run.id, run.future_state)
+            jobs = []
+            for external_job in run.external_jobs:
+                jobs.append(cancel_job(external_job))
+            run.external_jobs = jobs
     artifacts = [
         Artifact.from_json_encodable(artifact) for artifact in graph["artifacts"]
     ]

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -44,8 +44,8 @@ from sematic.db.queries import (
 from sematic.log_reader import load_log_lines
 from sematic.scheduling.external_job import ExternalJob
 from sematic.scheduling.job_scheduler import schedule_run, update_run_status
-from sematic.utils.retry import retry
 from sematic.scheduling.kubernetes import cancel_job
+from sematic.utils.retry import retry
 
 logger = logging.getLogger(__name__)
 

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -1,5 +1,6 @@
 # Standard Library
 import typing
+from dataclasses import replace
 from http import HTTPStatus
 from unittest import mock
 
@@ -217,14 +218,23 @@ def test_schedule_resolution_endpoint(
     )
 
 
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_resolution_cancel")
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_graph_update")
 @mock.patch("sematic.api.endpoints.resolutions.cancel_job")
 def test_cancel_resolution(
     mock_cancel_job: mock.MagicMock,
+    mock_broadcast_update: mock.MagicMock,
+    mock_broadcast_cancel: mock.MagicMock,
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
     test_db,  # noqa: F811
     mock_auth,  # noqa: F811
 ):
+    def fake_cancel(job):
+        return replace(job, still_exists=False, has_started=True)
+
+    mock_cancel_job.side_effect = fake_cancel
+
     persisted_resolution.external_jobs = (
         KubernetesExternalJob.new(
             try_number=0,
@@ -253,10 +263,14 @@ def test_cancel_resolution(
     response = test_client.put(
         f"/api/v1/resolutions/{persisted_resolution.root_id}/cancel"
     )
+    mock_broadcast_update.assert_called()
+    mock_broadcast_cancel.assert_called()
 
     assert response.status_code == HTTPStatus.OK
 
     canceled_resolution = get_resolution(persisted_resolution.root_id)
+    for job in canceled_resolution.external_jobs:
+        assert not job.is_active()
 
     assert canceled_resolution.status == ResolutionStatus.CANCELED.value
 
@@ -272,7 +286,9 @@ def test_cancel_resolution(
     assert mock_cancel_job.call_count == 2
 
 
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
 def test_rerun_resolution_endpoint(
+    mock_broadcast_update: mock.MagicMock,
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
     test_db,  # noqa: F811
@@ -283,6 +299,7 @@ def test_rerun_resolution_endpoint(
         f"/api/v1/resolutions/{persisted_resolution.root_id}/rerun",
         json={"rerun_from": persisted_resolution.root_id},
     )
+    mock_broadcast_update.assert_called()
 
     assert response.status_code == HTTPStatus.OK
 

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -95,6 +95,10 @@ class ResolutionStatus(Enum):
         if not isinstance(to_status, ResolutionStatus):
             to_status = ResolutionStatus[to_status]
         return to_status in _ALLOWED_TRANSITIONS[from_status]
+    
+    @classmethod
+    def is_terminal(self) -> bool:
+        return len(_ALLOWED_TRANSITIONS[self]) == 0
 
 
 _ALLOWED_TRANSITIONS = {

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -95,8 +95,7 @@ class ResolutionStatus(Enum):
         if not isinstance(to_status, ResolutionStatus):
             to_status = ResolutionStatus[to_status]
         return to_status in _ALLOWED_TRANSITIONS[from_status]
-    
-    @classmethod
+
     def is_terminal(self) -> bool:
         return len(_ALLOWED_TRANSITIONS[self]) == 0
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -295,6 +295,7 @@ class CloudResolver(LocalResolver):
             and run.exception_metadata is None
         ):
             run.exception_metadata = format_exception_for_run()
+        run.future_state = failed_future.state
         self._add_run(run)
         self._save_graph()
         if failed_future.state == FutureState.NESTED_FAILED:

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -237,14 +237,20 @@ class LocalResolver(SilentResolver):
             # If we are here, the cancelation was applied successfully server-side
             # so it is safe to mark non-terminal futures as CANCELED
             # This will precipitate the termination of the resolution loop.
-            self._cancel_non_terminal_futures()
-            self._sio_client.disconnect()
+            self._clean_up_resolution(save_graph=False)
 
         self._populate_run_and_artifacts(self._root_future)
         self._save_graph()
         self._cache_namespace_str = self._make_cache_namespace()
         self._create_resolution(self._root_future)
         self._update_resolution_status(ResolutionStatus.RUNNING)
+    
+    def _clean_up_resolution(self, save_graph: bool) -> None:
+        self._cancel_non_terminal_futures()
+        self._deactivate_all_resources()
+        self._sio_client.disconnect()
+        if save_graph:
+            self._save_graph()
 
     def _make_cache_namespace(self) -> Optional[str]:
         """
@@ -537,7 +543,7 @@ class LocalResolver(SilentResolver):
             if state.is_terminal():
                 continue
 
-            run.future_state = FutureState.FAILED
+            run.future_state = FutureState.CANCELED
 
             if run.exception_metadata is None:
                 run.exception_metadata = ExceptionMetadata(

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -526,6 +526,9 @@ class LocalResolver(SilentResolver):
         if isinstance(error, CalculatorError):
             reason = "Marked as failed because another run in the graph failed."
             resolution_status = ResolutionStatus.COMPLETE
+        elif isinstance(error, _ResolverRestartError):
+            reason = "Marked as failed because the resolver restarted mid-execution."
+            resolution_status = ResolutionStatus.FAILED
         else:
             reason = "Marked as failed because the rest of the graph failed to resolve."
             resolution_status = ResolutionStatus.FAILED
@@ -563,7 +566,7 @@ class LocalResolver(SilentResolver):
             status == ResolutionStatus.RUNNING
             and current_status != ResolutionStatus.SCHEDULED
         ):
-            raise RuntimeError(
+            raise _ResolverRestartError(
                 "It appears that the resolver has restarted mid-execution. "
                 "The cluster may be under pressure."
             )
@@ -820,3 +823,7 @@ def make_edge_key(edge: Edge) -> str:
         edge.destination_run_id,
         edge.destination_name,
     )
+
+
+class _ResolverRestartError(RuntimeError):
+    pass

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -244,7 +244,7 @@ class LocalResolver(SilentResolver):
         self._cache_namespace_str = self._make_cache_namespace()
         self._create_resolution(self._root_future)
         self._update_resolution_status(ResolutionStatus.RUNNING)
-    
+
     def _clean_up_resolution(self, save_graph: bool) -> None:
         self._cancel_non_terminal_futures()
         self._deactivate_all_resources()

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -231,14 +231,14 @@ def test_resolver_error(
 
     assert get_resolution(future.id).status == ResolutionStatus.FAILED.value
     assert get_run(future.id).future_state == FutureState.NESTED_FAILED.value
-    assert get_run(future.nested_future.id).future_state == FutureState.FAILED.value
+    assert get_run(future.nested_future.id).future_state == FutureState.CANCELED.value
     assert (
         get_run(future.nested_future.kwargs["x"].id).future_state
         == FutureState.FAILED.value
     )
     assert (
         get_run(future.nested_future.kwargs["y"].id).future_state
-        == FutureState.FAILED.value
+        == FutureState.CANCELED.value
     )
 
 

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -453,7 +453,7 @@ def cancel_job(job: KubernetesExternalJob) -> KubernetesExternalJob:
     if not job.still_exists:
         logger.info(
             "No need to cancel Kubernetes job %s, as it no longer exists",
-            job.external_job_id
+            job.external_job_id,
         )
         return job
 

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -450,6 +450,12 @@ def cancel_job(job: KubernetesExternalJob) -> KubernetesExternalJob:
         raise ValueError(
             f"Expected a {KubernetesExternalJob.__name__}, got a {type(job).__name__}"
         )
+    if not job.still_exists:
+        logger.info(
+            "No need to cancel Kubernetes job %s, as it no longer exists",
+            job.external_job_id
+        )
+        return job
 
     try:
         kubernetes.client.BatchV1Api().delete_namespaced_job(


### PR DESCRIPTION
Addresses #518, #417

Make some improvements to the way run/resolution cleanup is performed. In particular:
- Make it so that when one run fails and others are running/pending, it is clear which have failed and which were just canceled
- Make it so when the resolver restarts, all runs are stopped (instead of left running). We also add an appropriate error visible in the UI when this occurs.

The first of these is achieved simply by changing the existing logic that marks remaining runs as "failed" to mark them as "canceled" instead. The latter is achieved by adjusting the logic such that when a resolution reaches a terminal state, we always cancel any remaining associated runs on the server side. This works because when a resolver pod restarted, we were already failing the resolution. The only reason the existing cleanup logic didn't cancel the existing runs was that after a restart, the resolver no longer has in-memory representations of the remote runs it had generated on its previous execution.

Testing
--------
In addition to the unit tests shown here, I also emulated the two cases being addressed.

For emulating a resolver pod restart, I eliminated the SIGTERM handler in my resolver code, then deleted the resolver pod with `kubectl` while the resolution was in-progress. K8s automatically re-creates the pod in this case, since there is still an associated k8s job. A resolution created in this way is [here](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/4b3fd510027f45fe969eeb43d13aa9cf)
<img width="1138" alt="Screen Shot 2023-02-06 at 6 48 03 AM" src="https://user-images.githubusercontent.com/7181589/217003187-a61c116b-019d-402d-a7c9-6ebeb0ba0272.png">

For emulating a run failure mid-pipeline, I simply used the testing pipeline with fan-out and forced one of the fanned-out runs to fail with an intentional exception. An example created in this way is [here](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/bc3450afe64341e4aff952c3a0569678)

<img width="1157" alt="Screen Shot 2023-02-06 at 6 49 36 AM" src="https://user-images.githubusercontent.com/7181589/217003548-ed987172-a7a2-4403-9657-bcae0a9fbcdc.png">
