### PR TITLE
"Tee" logs to pod stdout as well as Sematic ingestion

### DIFF
--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -68,7 +68,12 @@ def log_ingestion_enabled() -> bool:
 
 
 def _flush_to_file(
-    file_path, read_handle, uploader, remote_prefix, timeout_seconds=None
+    file_path,
+    read_handle,
+    tee_write_handle,
+    uploader,
+    remote_prefix,
+    timeout_seconds=None,
 ):
     """Read from the read_handle dump to file_path and then remote.
 
@@ -84,6 +89,8 @@ def _flush_to_file(
     read_handle:
         A readable object that can be streamed from. It should be configured such that
         reads are non-blocking.
+    tee_write_handle:
+        A writable object to "tee" the read_handle contents to.
     uploader:
         The function to call for performing the remote upload
     remote_prefix:
@@ -125,6 +132,8 @@ def _flush_to_file(
                 continue
 
             fp.write(line)
+            tee_write_handle.write(line)
+            tee_write_handle.flush()
             fp.flush()
             if received_stream_termination:
                 break
@@ -136,6 +145,7 @@ def _flush_to_file(
 def _stream_logs_to_remote_from_file_descriptor(
     file_path: str,
     read_from_file_descriptor: int,
+    original_stdout_fd: int,
     upload_interval_seconds: int,
     remote_prefix: str,
     uploader: Callable[[str, str], None],
@@ -150,6 +160,8 @@ def _stream_logs_to_remote_from_file_descriptor(
         The path to the local file that's being uploaded
     read_from_file_descriptor:
         The file descriptor that's being read from.
+    original_stdout_fd:
+        The file descriptor for the original stdout (likely a TTY)
     upload_interval_seconds:
         The amount of time between the end of one upload and the start of the next
     remote_prefix:
@@ -161,12 +173,14 @@ def _stream_logs_to_remote_from_file_descriptor(
         the remote prefix as arguments.
     """
     read_handle = os.fdopen(read_from_file_descriptor)
+    tee_write_handle = os.fdopen(original_stdout_fd, "w")
     while True:
         received_termination = _flush_to_file(
-            file_path,
-            read_handle,
-            uploader,
-            remote_prefix,
+            file_path=file_path,
+            read_handle=read_handle,
+            tee_write_handle=tee_write_handle,
+            uploader=uploader,
+            remote_prefix=remote_prefix,
             timeout_seconds=upload_interval_seconds,
         )
         if received_termination:
@@ -199,6 +213,7 @@ def _do_upload(file_path: str, remote_prefix: str):
 def _start_log_streamer_out_of_process(
     file_path: str,
     read_from_file_descriptor: int,
+    original_stdout_fd: int,
     upload_interval_seconds: int,
     remote_prefix: str,
     uploader: Callable[[str, str], None],
@@ -214,6 +229,8 @@ def _start_log_streamer_out_of_process(
         The path to the local log file
     read_from_file_descriptor:
         The file descriptor to read from; likely the "read" end of a pipe
+    original_stdout_fd:
+        The file descriptor for the original stdout before redirection (likely a TTY)
     upload_interval_seconds:
         The interval between uploads.
     uploader:
@@ -232,6 +249,7 @@ def _start_log_streamer_out_of_process(
     _stream_logs_to_remote_from_file_descriptor(
         file_path=file_path,
         read_from_file_descriptor=read_from_file_descriptor,
+        original_stdout_fd=original_stdout_fd,
         upload_interval_seconds=upload_interval_seconds,
         remote_prefix=remote_prefix,
         uploader=uploader,
@@ -316,10 +334,14 @@ def ingested_logs(
         # for ingestion
         os.set_inheritable(write_file_descriptor, True)
 
-        with redirect_to_file_descriptor(write_file_descriptor):
+        with redirect_to_file_descriptor(write_file_descriptor) as (
+            original_stdout_fd,
+            _,
+        ):
             streamer_pid = _start_log_streamer_out_of_process(
                 file_path,
                 read_file_descriptor,
+                original_stdout_fd,
                 upload_interval_seconds=upload_interval_seconds,
                 remote_prefix=remote_prefix,
                 uploader=uploader,

--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -11,7 +11,6 @@ from curses import ascii
 from typing import Callable, Optional
 
 # Sematic
-from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR
 from sematic.config.user_settings import UserSettingsVar, get_user_setting
 from sematic.plugins.storage.s3_storage import S3Storage
 from sematic.utils.retry import retry
@@ -283,18 +282,6 @@ def ingested_logs(
         An optional override for uploading the log file.
     """
     uploader = uploader if uploader is not None else _do_upload
-
-    pod_name = os.getenv(KUBERNETES_POD_NAME_ENV_VAR)
-    if pod_name is not None:
-        # print is appropriate here because we want to write to actual stdout,
-        # with no logging machinary in between. This is *about* the logs. It
-        # will be shown when somebody does `kubectl logs <pod name>` because
-        # it will go to stdout before stdout gets redirected.
-        print(
-            f"To follow these logs, try:\n\t"
-            f"kubectl exec -i {pod_name} -- tail {file_path}"
-        )
-
     original_signal_handler = None
     streamer_pid = None
     read_file_descriptor = None

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -30,6 +30,16 @@ sematic_py_lib(
     deps = [],
 )
 
+sematic_py_binary(
+    name = "stdout_bin",
+    srcs = ["stdout.py"],
+    main = "stdout.py",
+    deps = [
+        ":stdout",
+    ],
+)
+
+
 sematic_py_lib(
     name = "git",
     srcs = ["git.py"],

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -30,16 +30,6 @@ sematic_py_lib(
     deps = [],
 )
 
-sematic_py_binary(
-    name = "stdout_bin",
-    srcs = ["stdout.py"],
-    main = "stdout.py",
-    deps = [
-        ":stdout",
-    ],
-)
-
-
 sematic_py_lib(
     name = "git",
     srcs = ["git.py"],

--- a/sematic/utils/stdout.py
+++ b/sematic/utils/stdout.py
@@ -83,16 +83,3 @@ def redirect_to_file_descriptor(file_descriptor: int):
                 stderr.flush()
                 os.dup2(stdout_copied.fileno(), stdout_fd)
                 os.dup2(stderr_copied.fileno(), stderr_fd)
-
-
-#######################################
-def main():
-    with redirect_to_file("/tmp/testee") as (stdout_fd, stderr_fd):
-        stdout = os.fdopen(stdout_fd, "wb")
-        stdout.write(b"Wow!")
-        stdout.flush()
-        print("Hi")
-
-
-if __name__ == "__main__":
-    main()

--- a/sematic/utils/stdout.py
+++ b/sematic/utils/stdout.py
@@ -29,8 +29,11 @@ def redirect_to_file(file_path: str):
         The file path to put stdout and stderr into
     """
     with open(file_path, "wb") as to_file:
-        with redirect_to_file_descriptor(to_file.fileno()):
-            yield
+        with redirect_to_file_descriptor(to_file.fileno()) as (
+            original_stdout,
+            original_stderr,
+        ):
+            yield (original_stdout, original_stderr)
 
 
 @contextmanager
@@ -70,7 +73,9 @@ def redirect_to_file_descriptor(file_descriptor: int):
             os.dup2(file_descriptor, stderr_fd)
             os.set_inheritable(file_descriptor, True)
             try:
-                yield  # allow code to be run with the redirected stdout
+                yield _fileno(stdout_copied), _fileno(  # type: ignore
+                    stderr_copied  # type: ignore
+                )  # allow code to be run with the redirected stdout
             finally:
                 # restore stdout & stderr to previous values
                 # NOTE: dup2 makes stdout_fd inheritable unconditionally
@@ -78,3 +83,16 @@ def redirect_to_file_descriptor(file_descriptor: int):
                 stderr.flush()
                 os.dup2(stdout_copied.fileno(), stdout_fd)
                 os.dup2(stderr_copied.fileno(), stderr_fd)
+
+
+#######################################
+def main():
+    with redirect_to_file("/tmp/testee") as (stdout_fd, stderr_fd):
+        stdout = os.fdopen(stdout_fd, "wb")
+        stdout.write(b"Wow!")
+        stdout.flush()
+        print("Hi")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Addresses #459 

Prior to this PR, we ingested logs to Sematic for display in the UI--but at the cost of the logs not being available on the pod's original stdout/stderr. This has the downside that if people are using other logging systems, and want job logs available there, they can't access them. This PR changes this so that we push logs *both* to Sematic *and* to the original stdout. This effectively emulates the behavior of ["tee"](https://linuxize.com/post/linux-tee-command/). Why not use *actual* `tee`?

1. We want to support people bringing their own base images, and not all will have `tee` (ex: slim base images like alpine)
2. Currently the worker image is created by using bazel [`py3_image`](https://github.com/bazelbuild/rules_docker/blob/4c1eaabcb6f52500373cf550e11982463d37a7a4/README.md#py3_image). If we wanted to have a script like `python3 -m sematic.resolvers.worker | tee log_file.log & python3 -m sematic.upload_from_log_file`, we would need to stop using `py3_image`. This would require ensuring we used the proper bazel bootstrap python env in the image to execute worker.py (since bazel doesn't use the built-in python env)
3. We would lose the ability to use log deltas, since we would have to read from a file being written to by `tee`. See the description of [this PR](https://github.com/sematic-ai/sematic/pull/306) for why that would be necessary
4. It's actually fairly simple/straightforward to accomplish this using existing code

Testing
-------
In addition to unit tests, executed the testing pipeline with a `do_sleep` modified as:
```python
@sematic.func(inline=False)
def do_sleep(val: float, sleep_time: int) -> float:
    """
    Raises a ValueError, without retries.
    """
    logger.info("Executing: do_sleep(val=%s, sleep=%s)", val, sleep_time)
    curr_time = time.time()
    stop_time = curr_time + sleep_time
    subprocess1 = subprocess.Popen(args=[
        "python3",
        "-c",
        "print('From subprocess1')"
    ])
    subprocess2 = subprocess.Popen(args=[
        "python3",
        "-c",
        "import sys; print('From subprocess2', file=sys.stderr)"
    ])

    while curr_time < stop_time:
        logger.info("do_sleep has %s more seconds to sleep", stop_time - curr_time)
        print(f"Using print to stdout with {stop_time - curr_time}s remaining")
        print(f"Using print to stderr with {stop_time - curr_time}s remaining", file=sys.stderr)
        time.sleep(1)
        curr_time = time.time()

    logger.info("do_sleep is done sleeping!")
    return val
```

[Resulting run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/bd6412d597d549b0b8f5bd64b6fb0237#tab=logs&run=cb61cdc4e3ce4418aae1de41a442686b)

Confirmed that the expected logs were all ingested, including that they were being ingested live. Also used `kubectl` to follow the logs directly from the pod, and confirmed that the logs were in fact being shown live on the pod's stdout.