### PR TITLE
Don't specify an image tag by default in Helm chart

### DIFF
--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -71,7 +71,7 @@ deployment:
 
 image:
   repository: sematicai/sematic-server
-  tag: vX.XX.X # REPLACE ME
+  #tag: vX.XX.X # REPLACE ME
   pull_policy: IfNotPresent
   #pull_secrets: []
 


### PR DESCRIPTION
If the tag is commented out, the image tag specified in `Chart.yaml` is used instead, which is the correct result.