### PR TITLE
Make untyped dict error message is clearer, ensure propagation in dataclasses

### DIFF
--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -61,7 +61,9 @@ def _safe_cast_dataclass(value: Any, type_: Any) -> Tuple[Any, Optional[str]]:
 
         cast_field, error = safe_cast(field_value, field.type)
         if error is not None:
-            return None, "Cannot cast {} to {}: {}".format(repr(value), type_, error)
+            return None, "Cannot cast field '{}' of {} to {}: {}".format(
+                name, repr(value), type_, error
+            )
 
         if create_instance_from_scratch:
             cast_value[name] = cast_field

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -26,7 +26,14 @@ def _dict_safe_cast(value: Dict, type_: Type) -> Tuple[Optional[Dict], Optional[
             repr(value), type_
         )
 
-    key_type, element_type = get_args(type_)
+    type_args = get_args(type_)
+    if type_args is None or type_args == ():
+        return None, (
+            "Dictionary doesn't have key/value types specified. Please use "
+            "'Dict[KType, VType]' instead of 'Dict' or 'dict'. Dict[object, object] "
+            "can be used for arbitrary dictionaries."
+        )
+    key_type, element_type = type_args
 
     cast_value = dict()
 

--- a/sematic/types/types/tests/test_dataclass.py
+++ b/sematic/types/types/tests/test_dataclass.py
@@ -110,7 +110,9 @@ def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
             A,
             None,
             None,
-            "Cannot cast C(a='abc') to <class 'sematic.types.types.tests.test_dataclass.A'>: Cannot cast 'abc' to <class 'int'>",  # noqa: E501
+            "Cannot cast field 'a' of C(a='abc') to "
+            "<class 'sematic.types.types.tests.test_dataclass.A'>: "
+            "Cannot cast 'abc' to <class 'int'>",  # noqa: E501
         ),
         (
             MyFrozenDataclass("some value"),
@@ -129,7 +131,7 @@ def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
             "<class 'sematic.types.types.tests.test_dataclass.BadDictField'>:"
             " Dictionary doesn't have key/value types specified. Please use "
             "'Dict[KType, VType]' instead of 'Dict' or 'dict'. "
-            "Dict[object, object] can be used for arbitrary dictionaries",
+            "Dict[object, object] can be used for arbitrary dictionaries.",
         ),
     ),
 )

--- a/sematic/types/types/tests/test_dataclass.py
+++ b/sematic/types/types/tests/test_dataclass.py
@@ -1,6 +1,5 @@
 # Standard Library
 from dataclasses import dataclass
-from typing import Dict
 
 # Third-party
 import pytest

--- a/sematic/types/types/tests/test_dataclass.py
+++ b/sematic/types/types/tests/test_dataclass.py
@@ -124,7 +124,8 @@ def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
             BadDictField,
             BadDictField,
             None,
-            "Cannot cast BadDictField(bad_dict_field={'foo': 'bar'}) to "
+            "Cannot cast field 'bad_dict_field' of "
+            "BadDictField(bad_dict_field={'foo': 'bar'}) to "
             "<class 'sematic.types.types.tests.test_dataclass.BadDictField'>:"
             " Dictionary doesn't have key/value types specified. Please use "
             "'Dict[KType, VType]' instead of 'Dict' or 'dict'. "

--- a/sematic/types/types/tests/test_dataclass.py
+++ b/sematic/types/types/tests/test_dataclass.py
@@ -1,5 +1,6 @@
 # Standard Library
 from dataclasses import dataclass
+from typing import Dict
 
 # Third-party
 import pytest
@@ -43,6 +44,11 @@ class E:
 @dataclass
 class MyFrozenDataclass:
     field: str
+
+
+@dataclass
+class BadDictField:
+    bad_dict_field: dict
 
 
 @pytest.mark.parametrize(
@@ -113,6 +119,17 @@ def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
             MyFrozenDataclass,
             MyFrozenDataclass("some value"),
             None,
+        ),
+        (
+            BadDictField({"foo": "bar"}),
+            BadDictField,
+            BadDictField,
+            None,
+            "Cannot cast BadDictField(bad_dict_field={'foo': 'bar'}) to "
+            "<class 'sematic.types.types.tests.test_dataclass.BadDictField'>:"
+            " Dictionary doesn't have key/value types specified. Please use "
+            "'Dict[KType, VType]' instead of 'Dict' or 'dict'. "
+            "Dict[object, object] can be used for arbitrary dictionaries",
         ),
     ),
 )


### PR DESCRIPTION
Prior to this PR, instead of getting a casting error, there was an exception raised when the tuple unpacking failed. This made it hard to identify where in a dataclass a bad dict annotation was coming from. This makes it more clear.