### PR TITLE
Function output caching unit tests

### DIFF
--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -8,6 +8,7 @@ pytest_test(
         "//sematic:calculator",
         "//sematic:retry_settings",
         "//sematic/api/tests:fixtures",
+        "//sematic/db:db",
         "//sematic/db/models:edge",
         "//sematic/db/models:resolution",
         "//sematic/db/tests:fixtures",

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -1,6 +1,6 @@
 # Standard Library
 from collections import defaultdict
-from typing import List
+from typing import Any, List, Tuple, Type
 
 # Third-party
 import pytest
@@ -15,14 +15,20 @@ from sematic.api.tests.fixtures import (  # noqa: F401
     test_client,
 )
 from sematic.calculator import func
+from sematic.db.db import DB
+from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import ResolutionKind, ResolutionStatus
+from sematic.db.models.run import Run
 from sematic.db.queries import get_resolution, get_root_graph, get_run
 from sematic.db.tests.fixtures import pg_mock, test_db  # noqa: F401
 from sematic.resolvers.local_resolver import LocalResolver
 from sematic.retry_settings import RetrySettings
-from sematic.tests.fixtures import valid_client_version  # noqa: F401
+from sematic.tests.fixtures import (  # noqa: F401
+    DIVERSE_VALUES_WITH_TYPES,
+    valid_client_version,
+)
 from sematic.utils.exceptions import ExceptionMetadata, ResolutionError
 
 
@@ -641,9 +647,185 @@ def test_cancel_non_terminal_futures(
     assert middle_func_states == [
         FutureState.SCHEDULED,
         FutureState.CANCELED,
-        # see comment in callback assetions above about why this is here
+        # see comment in callback assertions above about why this is here
         FutureState.RESOLVED,
     ]
     assert last_func_states == [
         FutureState.CANCELED,
     ]
+
+
+def _get_runs_and_artifacts(db: DB) -> List[Tuple[Run, Artifact]]:
+    with db.get_session() as session:
+        return (
+            session.query(Run, Artifact)
+            .join(Edge, Edge.source_run_id == Run.id)
+            .filter(Edge.artifact_id == Artifact.id)
+            .order_by(Run.created_at)
+            .all()
+        )
+
+
+@pytest.mark.parametrize("value_and_type", DIVERSE_VALUES_WITH_TYPES)
+def test_cached_output_happy(
+    value_and_type: Tuple[Any, Type],
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    value, T = value_and_type
+
+    @func(cache=True)
+    def cache_func(param: T) -> T:  # type: ignore
+        return param
+
+    # original run:
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    original_future = cache_func(param=value)
+    output = original_future.resolve(resolver)
+
+    assert output == value
+
+    # second run, which should be cached:
+    # resolvers are single-use, so we instantiate a new one
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    cache_future = cache_func(param=value)
+    output = cache_future.resolve(resolver)
+
+    assert output == value
+
+    # get the saved runs and artifacts from the test db
+    db_values = _get_runs_and_artifacts(test_db)
+
+    assert len(db_values) == 2
+    original_run, original_artifact = db_values[0]
+    cache_run, cache_artifact = db_values[1]
+
+    assert original_run.cache_key == cache_run.cache_key
+    assert original_run.id == original_future.id
+    assert cache_run.id == cache_future.id
+    assert original_artifact == cache_artifact
+
+
+def test_cached_output_different_namespaces(
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    @func(cache=True)
+    def cache_func(param: int) -> int:  # type: ignore
+        return param
+
+    # original run:
+    resolver = LocalResolver(cache_namespace="test_namespace1")
+    future1 = cache_func(param=42)
+    output1 = future1.resolve(resolver)
+
+    assert output1 == 42
+
+    # second run, which should be cached:
+    # resolvers are single-use, so we instantiate a new one
+    resolver = LocalResolver(cache_namespace="test_namespace2")
+    future2 = cache_func(param=42)
+    output2 = future2.resolve(resolver)
+
+    assert output2 == 42
+
+    # get the saved runs and artifacts from the test db
+    db_values = _get_runs_and_artifacts(test_db)
+
+    assert len(db_values) == 2
+    run1, artifact1 = db_values[0]
+    run2, artifact2 = db_values[1]
+
+    assert run1.cache_key != run2.cache_key
+    assert run1.id == future1.id
+    assert run2.id == future2.id
+    # we currently address artifacts by content
+    # if this ever changes, this must be updated to `!=`,
+    # and this added: with pytest.raises(ValueError): artifact1.assert_matches(artifact2)
+    assert artifact1 == artifact2
+
+
+def test_cached_output_different_funcs(
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    @func(cache=True)
+    def cache_func1(param: int) -> int:  # type: ignore
+        return param
+
+    @func(cache=True)
+    def cache_func2(param: int) -> int:  # type: ignore
+        return param
+
+    # original run:
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    future1 = cache_func1(param=42)
+    output1 = future1.resolve(resolver)
+
+    assert output1 == 42
+
+    # second run, which should be cached:
+    # resolvers are single-use, so we instantiate a new one
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    future2 = cache_func2(param=42)
+    output2 = future2.resolve(resolver)
+
+    assert output2 == 42
+
+    # get the saved runs and artifacts from the test db
+    db_values = _get_runs_and_artifacts(test_db)
+
+    assert len(db_values) == 2
+    run1, artifact1 = db_values[0]
+    run2, artifact2 = db_values[1]
+
+    assert run1.cache_key != run2.cache_key
+    assert run1.id == future1.id
+    assert run2.id == future2.id
+    # we currently address artifacts by content
+    # if this ever changes, this must be updated to `!=`,
+    # and this added: with pytest.raises(ValueError): artifact1.assert_matches(artifact2)
+    assert artifact1 == artifact2
+
+
+def test_cached_output_different_inputs(
+    mock_socketio,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+):
+    @func(cache=True)
+    def cache_func(param: int) -> int:  # type: ignore
+        return param
+
+    # original run:
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    future1 = cache_func(param=42)
+    output1 = future1.resolve(resolver)
+
+    assert output1 == 42
+
+    # second run, which should be cached:
+    # resolvers are single-use, so we instantiate a new one
+    resolver = LocalResolver(cache_namespace="test_namespace")
+    future2 = cache_func(param=43)
+    output2 = future2.resolve(resolver)
+
+    assert output2 == 43
+
+    # get the saved runs and artifacts from the test db
+    db_values = _get_runs_and_artifacts(test_db)
+
+    assert len(db_values) == 2
+    run1, artifact1 = db_values[0]
+    run2, artifact2 = db_values[1]
+
+    assert run1.cache_key != run2.cache_key
+    assert run1.id == future1.id
+    assert run2.id == future2.id
+    assert artifact1 != artifact2
+
+    with pytest.raises(ValueError):
+        artifact1.assert_matches(artifact2)

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -1,7 +1,9 @@
 # Standard Library
 import contextlib
+import enum
 import os
-from typing import Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 # Third-party
 import pytest
@@ -76,3 +78,62 @@ def environment_variables(to_set: Dict[str, Optional[str]]):
         yield
     finally:
         update_environ_with(backup_of_changed_keys)
+
+
+class MyEnum(enum.Enum):
+    A = "a"
+    B = "b"
+
+
+@dataclass
+class MyDataclass:
+    a: int
+    b: str
+
+    def __hash__(self):
+        return self.a + len(self.b)
+
+
+DIVERSE_VALUES_WITH_TYPES: List[Tuple[Optional[Any], Type[Any]]] = [
+    (None, object),
+    (None, Optional[int]),  # type: ignore
+    (1, int),
+    ("a", str),
+    (MyEnum.A, type(MyEnum.A)),
+    (MyDataclass(a=1, b="b"), MyDataclass),
+    ([], List[object]),
+    ([None], List[object]),
+    ([None], List[Optional[int]]),
+    ([1, 2, 3], List[int]),
+    (["a", "b", "c"], List[str]),
+    ([MyEnum.A, MyEnum.B], List[type(MyEnum.A)]),  # type: ignore
+    ([MyDataclass(a=1, b="b"), MyDataclass(a=0, b="")], List[MyDataclass]),
+    ([None, 1, "a", MyEnum.A, MyDataclass(a=1, b="b")], List[object]),
+    (  # type: ignore
+        (None, None, 1, "a", MyEnum.A, MyDataclass(a=1, b="b")),
+        Tuple[object, Optional[int], int, str, type(MyEnum.A), MyDataclass],
+    ),
+    (dict(), Dict[int, int]),
+    ({None: None}, Dict[object, object]),
+    ({None: None}, Dict[Optional[int], Optional[int]]),
+    ({"a": 1, "b": 2}, Dict[str, int]),
+    ({1: "a", 2: "b"}, Dict[int, str]),
+    (
+        {MyEnum.A: MyEnum.A, MyEnum.B: MyEnum.B},
+        Dict[type(MyEnum.A), type(MyEnum.A)],  # type: ignore
+    ),
+    (
+        {MyDataclass(a=1, b="b"): MyDataclass(a=1, b="b")},
+        Dict[MyDataclass, MyDataclass],
+    ),
+    (
+        {
+            None: None,
+            1: 1,
+            "a": "a",
+            MyEnum.A: MyEnum.A,
+            MyDataclass(a=1, b="b"): MyDataclass(a=1, b="b"),
+        },
+        Dict[object, object],
+    ),
+]

--- a/sematic/types/types/dict.py
+++ b/sematic/types/types/dict.py
@@ -62,7 +62,10 @@ def _dict_to_json_encodable(
     key_type, element_type = type_.__args__
 
     # Sorting keys for determinism
-    sorted_keys = sorted(value.keys())
+    # not using the values of the keys directly because the '<' operation is not
+    # guaranteed to be implemented for all types, but the hash is guaranteed to be
+    # implemented, since the keys must be hashable in order to be used as keys
+    sorted_keys = sorted(value.keys(), key=hash)
 
     return {
         "items": [
@@ -103,7 +106,10 @@ def _dict_to_json_encodable_summary(value: Dict, type_: Type) -> List[Tuple[Any,
     key_type, element_type = type_.__args__
 
     # Sorting keys for determinism
-    sorted_keys = sorted(value.keys())
+    # not using the values of the keys directly because the '<' operation is not
+    # guaranteed to be implemented for all types, but the hash is guaranteed to be
+    # implemented, since the keys must be hashable in order to be used as keys
+    sorted_keys = sorted(value.keys(), key=hash)
 
     return [
         (


### PR DESCRIPTION
This is the fourth in a series of PRs that implement #338. The previous one is #414.

This introduces unit tests that validate the integration between the Resolver and the output caching module. Unit tests for the caching module had already existed.

```bash
$ bazel test --test_output=all sematic/resolvers/tests:test_local_resolver
```