### PR TITLE
Full-text run search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,5 +167,6 @@ node_modules
 # Python wheels
 *.whl
 
-# Cypress Captured Video
+# Cypress related
 sematic/ui/tests/cypress_video
+sematic/ui/tests/cypress_results

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -46,6 +46,7 @@ from sematic.scheduling.external_job import ExternalJob
 from sematic.scheduling.job_scheduler import schedule_run, update_run_status
 from sematic.scheduling.kubernetes import cancel_job
 from sematic.utils.retry import retry
+from sqlalchemy.sql.elements import BooleanClauseList
 
 logger = logging.getLogger(__name__)
 
@@ -101,17 +102,6 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
-    search_string, search_predicates = flask.request.args.get("search"), None
-    if search_string is not None:
-        search_predicates = sqlalchemy.or_(
-            Run.name.ilike(f"%{search_string}%"),
-            Run.calculator_path.ilike(f"%{search_string}%"),
-            Run.description.ilike(f"%{search_string}%"),
-            Run.source_code.ilike(f"%{search_string}%"),
-            Run.id.ilike(f"%{search_string}%"),
-            Run.tags.ilike(f"%{search_string}%"),
-        )
-
     decoded_cursor: Optional[str] = None
     if cursor is not None:
         try:
@@ -148,6 +138,7 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         if sql_predicates is not None:
             query = query.filter(sql_predicates)
 
+        search_predicates = _generateSearchPredicate()
         if search_predicates is not None:
             query = query.filter(search_predicates)
 
@@ -203,6 +194,21 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
 
 def _make_cursor(key: str) -> str:
     return base64.urlsafe_b64encode(bytes(key, "utf-8")).decode("utf-8")
+
+
+def _generateSearchPredicate() -> Optional[BooleanClauseList]:
+    search_string, search_predicates = flask.request.args.get("search"), None
+    if search_string is not None:
+        search_predicates = sqlalchemy.or_(
+            Run.name.ilike(f"%{search_string}%"),
+            Run.calculator_path.ilike(f"%{search_string}%"),
+            Run.description.ilike(f"%{search_string}%"),
+            Run.source_code.ilike(f"%{search_string}%"),
+            Run.id.ilike(f"%{search_string}%"),
+            Run.tags.ilike(f"%{search_string}%"),
+        )
+
+    return search_predicates
 
 
 @sematic_api.route("/api/v1/runs/<run_id>", methods=["GET"])
@@ -354,7 +360,6 @@ def update_run_status_endpoint(user: Optional[User]) -> flask.Response:
 
     result_list = []
     for run_id, (future_state, jobs) in db_status_dict.items():
-
         new_future_state_value = future_state.value
         run = _get_run_if_modified(run_id, future_state, jobs)
         if run is not None:

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -101,6 +101,17 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
+    search_string, search_predicates = flask.request.args.get("search"), None
+    if search_string is not None:
+        search_predicates = sqlalchemy.or_(
+            Run.name.ilike(f"%{search_string}%"),
+            Run.calculator_path.ilike(f"%{search_string}%"),
+            Run.description.ilike(f"%{search_string}%"),
+            Run.source_code.ilike(f"%{search_string}%"),
+            Run.id.ilike(f"%{search_string}%"),
+            Run.tags.ilike(f"%{search_string}%"),
+        )
+
     decoded_cursor: Optional[str] = None
     if cursor is not None:
         try:
@@ -136,6 +147,9 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
 
         if sql_predicates is not None:
             query = query.filter(sql_predicates)
+
+        if search_predicates is not None:
+            query = query.filter(search_predicates)
 
         if decoded_cursor is not None:
             query = query.filter(

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -138,8 +138,9 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         if sql_predicates is not None:
             query = query.filter(sql_predicates)
 
-        search_predicates = _generateSearchPredicate()
-        if search_predicates is not None:
+        search_string = flask.request.args.get("search")
+        if search_string is not None:
+            search_predicates = _generate_search_predicate(search_string)
             query = query.filter(search_predicates)
 
         if decoded_cursor is not None:
@@ -196,19 +197,16 @@ def _make_cursor(key: str) -> str:
     return base64.urlsafe_b64encode(bytes(key, "utf-8")).decode("utf-8")
 
 
-def _generateSearchPredicate() -> Optional[BooleanClauseList]:
-    search_string, search_predicates = flask.request.args.get("search"), None
-    if search_string is not None:
-        search_predicates = sqlalchemy.or_(
-            Run.name.ilike(f"%{search_string}%"),
-            Run.calculator_path.ilike(f"%{search_string}%"),
-            Run.description.ilike(f"%{search_string}%"),
-            Run.source_code.ilike(f"%{search_string}%"),
-            Run.id.ilike(f"%{search_string}%"),
-            Run.tags.ilike(f"%{search_string}%"),
-        )
-
-    return search_predicates
+def _generate_search_predicate(
+    search_string: str,
+) -> BooleanClauseList:
+    return sqlalchemy.or_(
+        Run.name.ilike(f"%{search_string}%"),
+        Run.calculator_path.ilike(f"%{search_string}%"),
+        Run.description.ilike(f"%{search_string}%"),
+        Run.id.ilike(f"%{search_string}%"),
+        Run.tags.ilike(f"%{search_string}%"),
+    )
 
 
 @sematic_api.route("/api/v1/runs/<run_id>", methods=["GET"])

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -340,12 +340,11 @@ def test_list_runs_search_fields(
         make_run(name="photon"),
         make_run(calculator_path="neutralino.to.dark.matter"),
         make_run(description="the neutralino is a hypothetical particle"),
-        make_run(source_code="def neutrino():\npass"),
     )
 
     for run_ in runs:
         save_run(run_)
-    run1, run2, run3, run4, run5, run6 = runs
+    run1, run2, run3, run4, run5 = runs
 
     response = test_client.get("/api/v1/runs?search=neutr")
 
@@ -354,14 +353,13 @@ def test_list_runs_search_fields(
     payload = response.json
     payload = typing.cast(typing.Dict[str, typing.Any], payload)
 
-    assert len(payload["content"]) == 5
+    assert len(payload["content"]) == 4
     ids = [result["id"] for result in payload["content"]]
     assert run1.id in ids
     assert run2.id in ids
     assert run3.id not in ids
     assert run4.id in ids
     assert run5.id in ids
-    assert run6.id in ids
 
 
 def test_list_runs_search_tags(

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -310,6 +310,87 @@ def test_list_runs_cursor_400(
     assert payload == dict(error="invalid value for 'cursor'")
 
 
+def test_list_runs_search_id(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
+    runs = make_run(), make_run(), make_run()
+
+    for run_ in runs:
+        save_run(run_)
+
+    run1 = runs[0]
+
+    response = test_client.get(f"/api/v1/runs?search={run1.id}")
+
+    assert response.status_code == 200
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert len(payload["content"]) == 1
+    assert payload["content"][0]["id"] == run1.id
+
+
+def test_list_runs_search_fields(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
+    runs = (
+        make_run(name="neutrino"),
+        make_run(name="neutralino"),
+        make_run(name="photon"),
+        make_run(calculator_path="neutralino.to.dark.matter"),
+        make_run(description="the neutralino is a hypothetical particle"),
+        make_run(source_code="def neutrino():\npass"),
+    )
+
+    for run_ in runs:
+        save_run(run_)
+    run1, run2, run3, run4, run5, run6 = runs
+
+    response = test_client.get("/api/v1/runs?search=neutr")
+
+    assert response.status_code == 200
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert len(payload["content"]) == 5
+    ids = [result["id"] for result in payload["content"]]
+    assert run1.id in ids
+    assert run2.id in ids
+    assert run3.id not in ids
+    assert run4.id in ids
+    assert run5.id in ids
+    assert run6.id in ids
+
+
+def test_list_runs_search_tags(
+    mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
+):
+    runs = (
+        make_run(tags=["Donald", "Fauntleroy"]),
+        make_run(tags=["Pineapple", "apple", "pie"]),
+        make_run(tags=["MacDonald"]),
+    )
+
+    for run_ in runs:
+        save_run(run_)
+    run1, run2, run3 = runs
+
+    response = test_client.get("/api/v1/runs?search=donald")
+
+    assert response.status_code == 200
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert len(payload["content"]) == 2
+    ids = [result["id"] for result in payload["content"]]
+    assert run1.id in ids
+    assert run2.id not in ids
+    assert run3.id in ids
+
+
 def test_get_run_endpoint(
     mock_auth, persisted_run: Run, test_client: flask.testing.FlaskClient  # noqa: F811
 ):

--- a/sematic/ui/src/components/RunList.tsx
+++ b/sematic/ui/src/components/RunList.tsx
@@ -19,6 +19,7 @@ type RunListProps = {
   columns: Array<string>;
   children: Function;
   groupBy?: string;
+  search?: string;
   filters?: Filter;
   pageSize?: number;
   size?: "small" | "medium" | undefined;
@@ -28,7 +29,7 @@ type RunListProps = {
 };
 
 export function RunList(props: RunListProps) {
-  let { triggerRefresh, filters, groupBy, onRunsLoaded } = props;
+  let { triggerRefresh, filters, groupBy, onRunsLoaded, search } = props;
   const [pages, setPages] = useState<Array<RunListPayload>>([]);
   const [currentPage, setPage] = useState(0);
 
@@ -51,6 +52,9 @@ export function RunList(props: RunListProps) {
     }
     if (!!groupBy) {
       queryParams['group_by'] = groupBy;
+    }
+    if (!!search && search.length > 0) {
+      queryParams['search'] = search;
     }
     return queryParams;
   }, [pageSize, groupBy]);

--- a/sematic/ui/src/components/RunList.tsx
+++ b/sematic/ui/src/components/RunList.tsx
@@ -57,7 +57,7 @@ export function RunList(props: RunListProps) {
       queryParams['search'] = search;
     }
     return queryParams;
-  }, [pageSize, groupBy]);
+  }, [pageSize, groupBy, search]);
 
   const {isLoaded, error, load} = useFetchRunsFn(filters, queryParams);
 
@@ -79,7 +79,7 @@ export function RunList(props: RunListProps) {
       setPages(pages.concat(payload));
       onRunsLoaded?.(payload.content);
     })().catch(console.error);
-  }, [currentPage, pages, load, onRunsLoaded]);
+  }, [currentPage, pages, load, onRunsLoaded, search]);
 
   let tableBody;
   let currentPayload = pages[currentPage];

--- a/sematic/ui/src/components/RunList.tsx
+++ b/sematic/ui/src/components/RunList.tsx
@@ -14,13 +14,17 @@ import { useFetchRunsFn } from "../hooks/pipelineHooks";
 import useLatest from "react-use/lib/useLatest";
 import usePreviousDistinct from "react-use/lib/usePreviousDistinct";
 import { styled } from "@mui/system";
-import { spacing } from "../utils";
-import toolbarClasses from "@mui/material/Toolbar/toolbarClasses";
+import { useSynchornizedTables } from "../hooks/domHooks";
 
 const defaultPageSize = 10;
 
+interface RunListColumn {
+  name: string;
+  width: string;
+}
+
 type RunListProps = {
-  columns: Array<string>;
+  columns: Array<RunListColumn>;
   children: Function;
   groupBy?: string;
   search?: string;
@@ -31,16 +35,19 @@ type RunListProps = {
   triggerRefresh?: (refreshCallback: () => void) => void;
 };
 
-const StyledFooter = styled('div')`
-  & .${toolbarClasses.root} {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    background-color: ${({theme}) => theme.palette.background.paper};
-    box-sizing: border-box;
-    margin-right: ${spacing(5)};
-    width: 100%;
+const StyledTableContainer = styled(TableContainer)`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  & table {
+    flex-shrink: 1;
   }
+`;
+
+const TBodyScroller = styled('div')`
+  flex-grow: 1;
+  overflow-y: auto;
 `;
 
 export function RunList(props: RunListProps) {
@@ -116,6 +123,8 @@ export function RunList(props: RunListProps) {
 
   let tableBody;
   let currentPayload = pages[currentPage];
+  
+  const {sourceTableRef, targetTableRef} = useSynchornizedTables()
 
   if (error || !isLoaded) {
     tableBody = (
@@ -151,32 +160,34 @@ export function RunList(props: RunListProps) {
   }
 
   return (
-    <>
-      <TableContainer>
-        <Table size={props.size} data-cy={"RunList"}>
-          <TableHead>
-            <TableRow>
-              {props.columns.map((column) => (
-                <TableCell key={column}>{column}</TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
+    <StyledTableContainer data-cy={"RunList"}>
+      <Table ref={sourceTableRef} size={props.size} >
+        <TableHead>
+          <TableRow>
+            {props.columns.map(({name, width}) => (
+              <TableCell key={name} style={{width}}>{name}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+      </Table>
+      <TBodyScroller>
+        <Table ref={targetTableRef}>
           {tableBody}
-          <TableFooter>
-            <TableRow>
-              <StyledFooter>
-                <TablePagination
-                  count={totalCount}
-                  page={page}
-                  onPageChange={(event, page) => setPage(page)}
-                  rowsPerPage={pageSize}
-                  rowsPerPageOptions={[pageSize]}
-                />
-              </StyledFooter>
-            </TableRow>
-          </TableFooter>
         </Table>
-      </TableContainer>
-    </>
+      </TBodyScroller>
+      <Table>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              count={totalCount}
+              page={page}
+              onPageChange={(event, page) => setPage(page)}
+              rowsPerPage={pageSize}
+              rowsPerPageOptions={[pageSize]}
+            />
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </StyledTableContainer>
   );
 }

--- a/sematic/ui/src/components/RunList.tsx
+++ b/sematic/ui/src/components/RunList.tsx
@@ -10,8 +10,12 @@ import TablePagination from "@mui/material/TablePagination";
 import TableFooter from "@mui/material/TableFooter";
 import { Filter, RunListPayload } from "../Payloads";
 import Loading from "./Loading";
-import { Run } from "../Models";
 import { useFetchRunsFn } from "../hooks/pipelineHooks";
+import useLatest from "react-use/lib/useLatest";
+import usePreviousDistinct from "react-use/lib/usePreviousDistinct";
+import { styled } from "@mui/system";
+import { spacing } from "../utils";
+import toolbarClasses from "@mui/material/Toolbar/toolbarClasses";
 
 const defaultPageSize = 10;
 
@@ -24,12 +28,23 @@ type RunListProps = {
   pageSize?: number;
   size?: "small" | "medium" | undefined;
   emptyAlert?: string;
-  onRunsLoaded?: (runs: Run[]) => void;
   triggerRefresh?: (refreshCallback: () => void) => void;
 };
 
+const StyledFooter = styled('div')`
+  & .${toolbarClasses.root} {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background-color: ${({theme}) => theme.palette.background.paper};
+    box-sizing: border-box;
+    margin-right: ${spacing(5)};
+    width: 100%;
+  }
+`;
+
 export function RunList(props: RunListProps) {
-  let { triggerRefresh, filters, groupBy, onRunsLoaded, search } = props;
+  let { triggerRefresh, filters, groupBy, search } = props;
   const [pages, setPages] = useState<Array<RunListPayload>>([]);
   const [currentPage, setPage] = useState(0);
 
@@ -59,9 +74,12 @@ export function RunList(props: RunListProps) {
     return queryParams;
   }, [pageSize, groupBy, search]);
 
-  const {isLoaded, error, load} = useFetchRunsFn(filters, queryParams);
+  const { isLoaded, error, load } = useFetchRunsFn(filters, queryParams);
+
+  const loadCurrent = useLatest(load);
 
   useEffect(() => {
+    // logic for turning to the next page which has not been seen
     if (currentPage <= pages.length - 1) {
       return;
     }
@@ -74,12 +92,27 @@ export function RunList(props: RunListProps) {
         params = { cursor };
       }
 
-      const payload = await load(params);
+      const payload = await loadCurrent.current(params);
 
       setPages(pages.concat(payload));
-      onRunsLoaded?.(payload.content);
     })().catch(console.error);
-  }, [currentPage, pages, load, onRunsLoaded, search]);
+  }, [currentPage, pages, loadCurrent]);
+
+  const prevSearch = usePreviousDistinct(search);
+
+  useEffect(() => {
+    // logic for updating search terms
+    if (search === prevSearch) {
+      return;
+    }
+
+    (async () => {
+      const payload = await loadCurrent.current();
+
+      setPages([payload]);
+      setPage(0);
+    })().catch(console.error);
+  }, [search, prevSearch, loadCurrent]);
 
   let tableBody;
   let currentPayload = pages[currentPage];
@@ -131,13 +164,15 @@ export function RunList(props: RunListProps) {
           {tableBody}
           <TableFooter>
             <TableRow>
-              <TablePagination
-                count={totalCount}
-                page={page}
-                onPageChange={(event, page) => setPage(page)}
-                rowsPerPage={pageSize}
-                rowsPerPageOptions={[pageSize]}
-              />
+              <StyledFooter>
+                <TablePagination
+                  count={totalCount}
+                  page={page}
+                  onPageChange={(event, page) => setPage(page)}
+                  rowsPerPage={pageSize}
+                  rowsPerPageOptions={[pageSize]}
+                />
+              </StyledFooter>
             </TableRow>
           </TableFooter>
         </Table>

--- a/sematic/ui/src/components/SideBar.tsx
+++ b/sematic/ui/src/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import { BatchPrediction, Logout } from "@mui/icons-material";
+import { BatchPrediction, Logout, ManageSearch, PlayCircle, Timeline } from "@mui/icons-material";
 import {
   Box,
   Typography,
@@ -47,8 +47,18 @@ export default function SideBar() {
             sx={{ color: "rgba(255, 255, 255, 0.5)" }}
             underline="none"
           >
-            <BatchPrediction fontSize="large" />
+            <Timeline fontSize="large" />
             <Typography fontSize={10}>Pipelines</Typography>
+          </Link>
+        </Box>
+        <Box mt={5}>
+          <Link
+            href="/runs"
+            sx={{ color: "rgba(255, 255, 255, 0.5)" }}
+            underline="none"
+          >
+            <PlayCircle fontSize="large" />
+            <Typography fontSize={10}>Runs</Typography>
           </Link>
         </Box>
       </Stack>

--- a/sematic/ui/src/components/SideBar.tsx
+++ b/sematic/ui/src/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import { BatchPrediction, Logout, ManageSearch, PlayCircle, Timeline } from "@mui/icons-material";
+import { Logout, PlayCircle, Timeline } from "@mui/icons-material";
 import {
   Box,
   Typography,

--- a/sematic/ui/src/hooks/domHooks.ts
+++ b/sematic/ui/src/hooks/domHooks.ts
@@ -1,0 +1,72 @@
+import { useRef, useEffect } from "react";
+import useCounter from "react-use/lib/useCounter";
+
+/**
+ * When two separate tables are used, automatically synchronize the column widths
+ * of the first row of the source table to the column widths of the first row of the 
+ * target table, so their columns appear fully aligned.
+ * 
+ * User is responsible for ensuring that the column count of the source table is the
+ * same as target, or this will become a no op.
+ * @returns {
+ *  sourceTableRef: React reference to assign to the `ref` prop of the source table
+ *  targetTableRef: React reference to assign to the `ref` prop of the target table
+ * }
+ */
+export function useSynchornizedTables() {
+  let sourceRef = useRef<HTMLTableElement>(null);
+  let targetRef = useRef<HTMLTableElement>(null);
+
+  const observerRef = useRef<MutationObserver>();
+
+  const [counter, {inc}] = useCounter(0);
+
+  useEffect(() => {
+    if (!targetRef.current) {
+        return;
+    }
+
+    if (observerRef.current) {
+        observerRef.current.disconnect();
+    }
+
+    observerRef.current = new MutationObserver((mutationList) => {
+        if (mutationList.length > 0) {
+            inc();
+        }
+    });
+
+    observerRef.current.observe(targetRef.current!, {
+        childList: true, subtree: true
+    });
+
+    return () => {
+        observerRef.current?.disconnect();
+    };
+
+  }, [inc]);
+
+  useEffect(() => {
+    if (!sourceRef.current || !targetRef.current) {
+      return;
+    }
+    const sourceTableCells = Array.from<HTMLTableCellElement>(
+        sourceRef.current.querySelectorAll("tr:first-child td,th")!);
+    const targetTableCells = Array.from<HTMLTableCellElement>(
+        targetRef.current.querySelectorAll("tr:first-child td,th")!);
+
+    if (targetTableCells.length !== sourceTableCells.length) {
+      // no op for mismatched column count
+      return;
+    }
+    targetTableCells.forEach((td, index) => {
+      td.style.width = sourceTableCells[index].style.width;
+    });
+
+  }, [counter, sourceRef, targetRef]);
+
+  return {
+    sourceTableRef: sourceRef,
+    targetTableRef: targetRef
+  }
+}

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -27,6 +27,7 @@ import logo from "./Fox.png";
 import { fetchJSON } from "./utils";
 import { SnackBarProvider } from "./components/SnackBarProvider";
 import PipelineView from "./pipelines/PipelineView";
+import { RunIndex } from "./runs/RunIndex";
 
 export const UserContext = React.createContext<{
   user: User | null;
@@ -114,6 +115,7 @@ function App() {
             <Route path="/" element={<Shell />}>
               <Route path="" element={<Home />} />
               <Route path="pipelines" element={<PipelineIndex />} />
+              <Route path="runs" element={<RunIndex />} />
               <Route
                 path="pipelines/:pipelinePath/:rootId" element={<PipelineRunView />}
               />

--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -23,6 +23,12 @@ const RecentStatusesWithStyles = styled('span')`
   display: flex;
 `;
 
+const TableColumns = [
+  {name: "Name", width: "65%"},
+  {name: "Last run", width: "20%"},
+  {name: "Status", width: "15%"}
+]
+
 function RecentStatuses(props: { calculatorPath: string }) {
   const { calculatorPath } = props;
 
@@ -98,7 +104,7 @@ function PipelineIndex() {
               </Typography>
             </Box>
             <RunList
-              columns={["Name", "Last run", "Status"]}
+              columns={TableColumns}
               groupBy="calculator_path"
               filters={{ AND: [{ parent_id: { eq: null } }] }}
               emptyAlert="No pipelines."

--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -91,7 +91,7 @@ function PipelineIndex() {
     <Box sx={{ display: "grid", gridTemplateColumns: "1fr 300px" }}>
       <Box sx={{ gridColumn: 1 }}>
         <Container sx={{ pt: 15 }}>
-          <Box sx={{ mx: 5 }}>
+          <Box sx={{ mx: 5, transform: 'translate(0)', pb: 15}}>
             <Box sx={{ mb: 10 }}>
               <Typography variant="h2" component="h2">
                 Your pipelines

--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -97,7 +97,7 @@ function PipelineIndex() {
     <Box sx={{ display: "grid", gridTemplateColumns: "1fr 300px" }}>
       <Box sx={{ gridColumn: 1 }}>
         <Container sx={{ pt: 15 }}>
-          <Box sx={{ mx: 5, transform: 'translate(0)', pb: 15}}>
+          <Box sx={{ mx: 5 }}>
             <Box sx={{ mb: 10 }}>
               <Typography variant="h2" component="h2">
                 Your pipelines

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -5,11 +5,12 @@ import Link from "@mui/material/Link";
 import { Run } from "../Models";
 import { RunList } from "../components/RunList";
 import RunStateChip from "../components/RunStateChip";
-import React from "react";
+import React, { useCallback, useState } from "react";
 import Tags from "../components/Tags";
 import CalculatorPath from "../components/CalculatorPath";
 import Id from "../components/Id";
 import TimeAgo from "../components/TimeAgo";
+import { Box, Container, TextField } from "@mui/material";
 
 type RunRowProps = {
   run: Run;
@@ -69,14 +70,31 @@ export function RunRow(props: RunRowProps) {
 }
 
 export function RunIndex() {
+
+  const [searchString, setSearchString] = useState<string | undefined>(undefined);
+  
+  const onChange = useCallback((value: string) => {
+    console.log(value);
+    setSearchString(value);
+  }, []);
+
   return (
-    <>
+    <Container sx={{ pt: 10, height: "100vh", overflowY: "scroll" }}>
       <Typography variant="h4" component="h2">
         Run list
       </Typography>
-      <RunList columns={["ID", "Name", "Tags", "Time", "Status"]}>
+      <Box sx={{py: 10}}>
+      <TextField 
+        id="outlined-basic"
+        label="Search"
+        variant="outlined"
+        sx={{width: "100%"}}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      </Box>
+      <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} search={searchString}>
         {(run: Run) => <RunRow run={run} key={run.id} />}
       </RunList>
-    </>
+    </Container>
   );
 }

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -5,12 +5,14 @@ import Link from "@mui/material/Link";
 import { Run } from "../Models";
 import { RunList } from "../components/RunList";
 import RunStateChip from "../components/RunStateChip";
-import React, { useCallback, useState } from "react";
+import React, { ChangeEvent, FormEvent, FormEventHandler, useCallback, useState } from "react";
 import Tags from "../components/Tags";
 import CalculatorPath from "../components/CalculatorPath";
 import Id from "../components/Id";
 import TimeAgo from "../components/TimeAgo";
-import { Box, Container, TextField } from "@mui/material";
+import { Box, Button, Container, TextField } from "@mui/material";
+import { RunTime } from "../components/RunTime";
+import { SearchOutlined } from "@mui/icons-material";
 
 type RunRowProps = {
   run: Run;
@@ -27,7 +29,7 @@ export function RunRow(props: RunRowProps) {
   let createdAt: React.ReactElement | undefined;
 
   if (props.variant !== "skinny") {
-    calculatorPath = <CalculatorPath calculatorPath={run.calculator_path} />;
+    calculatorPath = <Box><CalculatorPath calculatorPath={run.calculator_path}/></Box>;
 
     createdAt = (
       <Typography fontSize="small" color="GrayText">
@@ -47,23 +49,24 @@ export function RunRow(props: RunRowProps) {
         <Id id={run.id} trimTo={8} />
       </TableCell>
       <TableCell onClick={props.onClick}>
+      <Typography variant="h6">
         {props.noRunLink && run.name}
         {!props.noRunLink && (
           <Link href={"/runs/" + run.id} underline="hover">
             {run.name}
           </Link>
         )}
+        </Typography>
         {calculatorPath}
       </TableCell>
       <TableCell>
         <Tags tags={run.tags || []} />
       </TableCell>
       <TableCell onClick={props.onClick}>
-        <TimeAgo date={run.created_at} />
-        {createdAt}
+        <TimeAgo date={run.created_at} /><RunTime run={run} prefix="in" />
       </TableCell>
       <TableCell onClick={props.onClick}>
-        <RunStateChip run={run} />
+        <RunStateChip run={run} variant="full"/>
       </TableCell>
     </TableRow>
   );
@@ -72,29 +75,48 @@ export function RunRow(props: RunRowProps) {
 export function RunIndex() {
 
   const [searchString, setSearchString] = useState<string | undefined>(undefined);
-  
-  const onChange = useCallback((value: string) => {
-    console.log(value);
-    setSearchString(value);
+  const [submitedSearchString, setSubmitedSearchString] = useState<string | undefined>(undefined);
+
+  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setSearchString(event.target.value);
   }, []);
 
+  const onSubmit = useCallback((event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    console.log(searchString);
+    setSubmitedSearchString(searchString);
+  }, [searchString]);
+
   return (
-    <Container sx={{ pt: 10, height: "100vh", overflowY: "scroll" }}>
+    <Container sx={{ pt: 10, height: "100vh", overflowY: "scroll", display: "grid", gridTemplateRows: "auto 1fr" }}>
+
+      <Box sx={{gridRow: 1}}>
+
       <Typography variant="h4" component="h2">
-        Run list
+        Runs
       </Typography>
-      <Box sx={{py: 10}}>
-      <TextField 
+      <form onSubmit={onSubmit}>
+      <Box sx={{py: 10, display: "grid", gridTemplateColumns: "1fr auto"}}>
+        <Box sx={{gridColumn: 1, pr: 10}}>
+        <TextField 
         id="outlined-basic"
         label="Search"
         variant="outlined"
         sx={{width: "100%"}}
-        onChange={(event) => onChange(event.target.value)}
-      />
+        onChange={onChange}
+        />
+        </Box>
+        <Box sx={{gridColumn: 2}}>
+          <Button variant="contained" size="large" startIcon={<SearchOutlined/>} sx={{height: "100%"}} type="submit">SEARCH</Button>
+        </Box>
       </Box>
-      <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} search={searchString}>
-        {(run: Run) => <RunRow run={run} key={run.id} />}
+      </form>
+        </Box>
+        <Box sx={{gridRow: 2}}>
+      <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} search={submitedSearchString}>
+        {(run: Run) => <RunRow run={run} key={run.id} onClick={() => null}/>}
       </RunList>
+        </Box>
     </Container>
   );
 }

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -67,30 +67,25 @@ export function RunRow(props: RunRowProps) {
   );
 }
 
-const StyledContainer = styled('div')`
-  height: 100%;
-  transform: translate(0);
-  width: fit-content;
-  margin: auto;
-`;
-
 const StyledScroller = styled(Container)`
   padding-top: ${spacing(10)};
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: hidden;
   display: flex;
   flex-direction: column;
 
   @media (min-width: 1280px) {
-    min-width: 800px;
+    min-width: 1020px;
   }
 
-  & .${buttonClasses.root} {
-    height: 100%;
+  & > * {
+    flex-shrink: 1;
   }
 
-  & .${textFieldClasses.root} {
-    width: 100%;
+  & > *.RunListBox {
+    flex-grow: 1;
+    flex-shrink: unset;
+    height: 0;
   }
 
   & .search-bar {
@@ -103,26 +98,24 @@ const StyledScroller = styled(Container)`
       padding-right: ${spacing(10)};
       flex-grow: 1
     }
-  }
 
-  & form {
-    position: sticky;
-    top: -${spacing(15)};
-    background-color: ${({theme}) => theme.palette.background.paper};
-    z-index: 200;
-  }
-
-  & table {
-    position: sticky;
-    bottom: 0;
-    background-color: ${({theme}) => theme.palette.background.paper};
-  }
-
-  & > :last-child {
-    margin-bottom: ${spacing(15)};
+    & .${buttonClasses.root} {
+      height: 100%;
+    }
+  
+    & .${textFieldClasses.root} {
+      width: 100%;
+    }
   }
 `;
 
+const TableColumns = [
+  {name: "ID", width: "7.5%"},
+  {name: "Name", width: "47.5%"},
+  {name: "Tags", width: "21%"},
+  {name: "Time", width: "12%"},
+  {name: "Status", width: "12%"}
+]
 
 export function RunIndex() {
 
@@ -138,8 +131,7 @@ export function RunIndex() {
     setSubmitedSearchString(searchString);
   }, [searchString]);
 
-  return (<StyledContainer>
-      <StyledScroller>
+  return (<StyledScroller>
           <Typography variant="h4" component="h2">
             Runs
           </Typography>
@@ -161,13 +153,12 @@ export function RunIndex() {
               </Box>
             </Box>
           </form>
-        <Box>
-          <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} 
+        <Box className="RunListBox">
+          <RunList columns={TableColumns} 
             search={submitedSearchString}>
             {(run: Run) => <RunRow run={run} key={run.id} onClick={() => null} />}
           </RunList>
         </Box>
       </StyledScroller>
-    </StyledContainer>
   );
 }

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -5,14 +5,16 @@ import Link from "@mui/material/Link";
 import { Run } from "../Models";
 import { RunList } from "../components/RunList";
 import RunStateChip from "../components/RunStateChip";
-import React, { ChangeEvent, FormEvent, FormEventHandler, useCallback, useState } from "react";
+import React, { ChangeEvent, FormEvent, useCallback, useState } from "react";
 import Tags from "../components/Tags";
 import CalculatorPath from "../components/CalculatorPath";
 import Id from "../components/Id";
 import TimeAgo from "../components/TimeAgo";
-import { Box, Button, Container, TextField } from "@mui/material";
+import { Box, Button, Container, TextField, textFieldClasses, buttonClasses } from "@mui/material";
 import { RunTime } from "../components/RunTime";
 import { SearchOutlined } from "@mui/icons-material";
+import { styled } from "@mui/system";
+import { spacing } from "../utils";
 
 type RunRowProps = {
   run: Run;
@@ -26,16 +28,9 @@ export function RunRow(props: RunRowProps) {
   let run = props.run;
 
   let calculatorPath: React.ReactElement | undefined = undefined;
-  let createdAt: React.ReactElement | undefined;
 
   if (props.variant !== "skinny") {
-    calculatorPath = <Box><CalculatorPath calculatorPath={run.calculator_path}/></Box>;
-
-    createdAt = (
-      <Typography fontSize="small" color="GrayText">
-        {new Date(run.created_at).toLocaleString()}
-      </Typography>
-    );
+    calculatorPath = <Box><CalculatorPath calculatorPath={run.calculator_path} /></Box>;
   }
 
   return (
@@ -49,13 +44,13 @@ export function RunRow(props: RunRowProps) {
         <Id id={run.id} trimTo={8} />
       </TableCell>
       <TableCell onClick={props.onClick}>
-      <Typography variant="h6">
-        {props.noRunLink && run.name}
-        {!props.noRunLink && (
-          <Link href={"/runs/" + run.id} underline="hover">
-            {run.name}
-          </Link>
-        )}
+        <Typography variant="h6">
+          {props.noRunLink && run.name}
+          {!props.noRunLink && (
+            <Link href={`/pipelines/${run.calculator_path}/${run.id}`} underline="hover">
+              {run.name}
+            </Link>
+          )}
         </Typography>
         {calculatorPath}
       </TableCell>
@@ -66,11 +61,68 @@ export function RunRow(props: RunRowProps) {
         <TimeAgo date={run.created_at} /><RunTime run={run} prefix="in" />
       </TableCell>
       <TableCell onClick={props.onClick}>
-        <RunStateChip run={run} variant="full"/>
+        <RunStateChip run={run} variant="full" />
       </TableCell>
     </TableRow>
   );
 }
+
+const StyledContainer = styled('div')`
+  height: 100%;
+  transform: translate(0);
+  width: fit-content;
+  margin: auto;
+`;
+
+const StyledScroller = styled(Container)`
+  padding-top: ${spacing(10)};
+  height: 100%;
+  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+
+  @media (min-width: 1280px) {
+    min-width: 800px;
+  }
+
+  & .${buttonClasses.root} {
+    height: 100%;
+  }
+
+  & .${textFieldClasses.root} {
+    width: 100%;
+  }
+
+  & .search-bar {
+    padding-top: ${spacing(10)};
+    padding-bottom: ${spacing(10)};
+    display: flex;
+    flex-direction: row;
+
+    & > :first-child {
+      padding-right: ${spacing(10)};
+      flex-grow: 1
+    }
+  }
+
+  & form {
+    position: sticky;
+    top: -${spacing(15)};
+    background-color: ${({theme}) => theme.palette.background.paper};
+    z-index: 200;
+  }
+
+  & table {
+    position: sticky;
+    bottom: 0;
+    background-color: ${({theme}) => theme.palette.background.paper};
+  }
+
+  & > :last-child {
+    margin-bottom: ${spacing(15)};
+  }
+`;
+
 
 export function RunIndex() {
 
@@ -83,40 +135,39 @@ export function RunIndex() {
 
   const onSubmit = useCallback((event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    console.log(searchString);
     setSubmitedSearchString(searchString);
   }, [searchString]);
 
-  return (
-    <Container sx={{ pt: 10, height: "100vh", overflowY: "scroll", display: "grid", gridTemplateRows: "auto 1fr" }}>
-
-      <Box sx={{gridRow: 1}}>
-
-      <Typography variant="h4" component="h2">
-        Runs
-      </Typography>
-      <form onSubmit={onSubmit}>
-      <Box sx={{py: 10, display: "grid", gridTemplateColumns: "1fr auto"}}>
-        <Box sx={{gridColumn: 1, pr: 10}}>
-        <TextField 
-        id="outlined-basic"
-        label="Search"
-        variant="outlined"
-        sx={{width: "100%"}}
-        onChange={onChange}
-        />
+  return (<StyledContainer>
+      <StyledScroller>
+          <Typography variant="h4" component="h2">
+            Runs
+          </Typography>
+          <form onSubmit={onSubmit}>
+            <Box className={'search-bar'}>
+              <Box sx={{ gridColumn: 1 }}>
+                <TextField
+                  id="outlined-basic"
+                  label="Search"
+                  variant="outlined"
+                  onChange={onChange}
+                />
+              </Box>
+              <Box sx={{ gridColumn: 2 }}>
+                <Button variant="contained" size="large" startIcon={<SearchOutlined />} 
+                type="submit">
+                  SEARCH
+                </Button>
+              </Box>
+            </Box>
+          </form>
+        <Box>
+          <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} 
+            search={submitedSearchString}>
+            {(run: Run) => <RunRow run={run} key={run.id} onClick={() => null} />}
+          </RunList>
         </Box>
-        <Box sx={{gridColumn: 2}}>
-          <Button variant="contained" size="large" startIcon={<SearchOutlined/>} sx={{height: "100%"}} type="submit">SEARCH</Button>
-        </Box>
-      </Box>
-      </form>
-        </Box>
-        <Box sx={{gridRow: 2}}>
-      <RunList columns={["ID", "Name", "Tags", "Time", "Status"]} search={submitedSearchString}>
-        {(run: Run) => <RunRow run={run} key={run.id} onClick={() => null}/>}
-      </RunList>
-        </Box>
-    </Container>
+      </StyledScroller>
+    </StyledContainer>
   );
 }

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -98,3 +98,5 @@ export function atomWithHashCustomSerialization(
 export const graphSocket = io("/graph");
 
 export const pipelineSocket = io("/pipeline");
+
+export const spacing = (val: number) => ({theme}: any) => theme.spacing(val);


### PR DESCRIPTION
This is a work based on PR of https://github.com/sematic-ai/sematic/pull/482

Since that branch is not rebased, the remaining work continues on this branch.

Support full-text search for the `name, calculator_path, description, source_code, id, tags` fields. There is a new page(UI) for searching runs. 

![capture1](https://user-images.githubusercontent.com/1046489/217700051-e2e06e26-c49e-44f2-ba6a-fc843cb10c87.gif)


Closes #546