### PR TITLE
Avoid urllib usage killing WSGI workers on MacOS

### DIFF
--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -2,7 +2,21 @@
 Sematic Public API
 """
 # Standard Library
+import os
+import platform
 import sys
+
+# `urllib` invokes the underlying OS framework to get configured system proxies.
+# On MacOS, this call causes the OS to immediately kill the `gunicorn` WSGI worker because
+# it had not immediately performed `exec()` after `fork()`.
+# This is a feature intended to prevent fork bombs.
+#
+# Setting the below sys env avoids this Mac feature by deactivating the proxy lookup.
+# In order to deactivate this deactivation, set this env var: NO_PROXY=""
+#
+# This issue is described here: https://bugs.python.org/issue33725
+if platform.system() == "Darwin" and "NO_PROXY" not in os.environ:
+    os.environ["NO_PROXY"] = "*"
 
 MIN_PYTHON_VERSION = (3, 8, 0)
 _CURRENT_PYTHON_VERSION = sys.version_info[0:3]


### PR DESCRIPTION
Fixes #539.

This updates the Server initialization code to set an env variable only when running on MacOS to deactivate `urllib` from making an OS framework call that will kill the `gunicorn` WSGI worker. For mode details, please see the code comment, and [this Python issue](https://bugs.python.org/issue33725).

The consequence is that in local MacOS laptop deployments `urllib` calls (currently used for the Cancelation and Slack notification features) will not use system-level proxies.

## Other Attempted Solutions

- Setting the env variable mentioned in #539 can only be done outside the Sematic code / scripts, and deactivates a system behavior, which is not desired, and which might go away with any future OS release.
- The `gunicorn` version used is already the latest.
- Switching the `multiprocessing` forking strategy is unrelated to how this issue manifests.
- Un-demonizing the Server process does not affect the behavior.
