### PR TITLE
Fix client hanging after multiple cancelation events

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -227,13 +227,16 @@ def cancel_resolution_endpoint(
             HTTPStatus.NOT_FOUND,
         )
 
+    if resolution.status == ResolutionStatus.CANCELED.value:
+        logger.info("Resolution is already canceled")
+        return flask.jsonify(dict(content=resolution.to_json_encodable()))
+
     if not ResolutionStatus.is_allowed_transition(
         from_status=resolution.status, to_status=ResolutionStatus.CANCELED
     ):
-        return jsonify_error(
-            f"Resolution cannot be canceled. Current state: {resolution.status}",
-            HTTPStatus.BAD_REQUEST,
-        )
+        message = f"Resolution cannot be canceled. Current state: {resolution.status}"
+        logger.warning(message)
+        return jsonify_error(message, HTTPStatus.BAD_REQUEST)
 
     root_run = get_run(resolution.root_id)
 


### PR DESCRIPTION
Fixes a behavior when the Resolver is left hanging and the Resolution incorrectly marked as failed if a cancelation event is emitted more than once.

This can happen either if the user (or a runtime environment) sends a cancelation signal, but I've also seen this happen sporadically where both the Resolver and the Dashboard both emit the cancelation event (possibly due to an apparent race condition in the socket.io broadcasting).

The below tests were executed by running the testing pipeline, and sending 2 / multiple interrupts from the console while the sleep func was executing. The fact that the sleep func itself was not canceled is a separate, missing feature.

## Before

**Resolver logs:**

```
~/work/sematic$ bazel run sematic/examples/testing_pipeline -- --sleep 10
[...]
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 7.990863800048828 more seconds to sleep
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
WARNING:sematic.resolvers.local_resolver:Received cancelation event
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
ERROR:sematic.api_client:Server returned 400 for PUT http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel: {"error": "Resolution cannot be canceled. Current state: CANCELED"}
ERROR:sematic.resolvers.silent_resolver:Error executing future
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/calculator.py", line 186, in calculate
    output = self.func(**kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 207, in do_sleep
    time.sleep(1)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 174, in _handle_sig_cancel
    self._resolution_did_cancel()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/local_resolver.py", line 297, in _resolution_did_cancel
    api_client.cancel_resolution(self._root_future.id)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 212, in cancel_resolution
    response = _put(f"/resolutions/{resolution_id}/cancel", {})
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 30, in wrapper
    return caller(f, *args, **kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 137, in retry_decorator
    return __retry_internal(
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 77, in __retry_internal
    return f()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 451, in _put
    response = request(requests.put, endpoint, dict(json=json_payload, data=data))
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 586, in request
    _raise_for_response(
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 635, in _raise_for_response
    raise exception
sematic.api_client.BadRequestError: The PUT request to http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel was invalid, response was 400

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/silent_resolver.py", line 37, in _run_inline
    value = future.calculator.calculate(**future.resolved_kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/calculator.py", line 188, in calculate
    raise CalculatorError(f"Error from running {self.func.__name__}") from e
sematic.abstract_calculator.CalculatorError: Error from running do_sleep
INFO:root:No retries configured for 26d4c728c07a463280cf88bf8e2b86f0, failing now.
INFO:sematic.resolvers.local_resolver:Processing failure of run 26d4c728c07a463280cf88bf8e2b86f0, state: FutureState.FAILED
INFO:sematic.resolvers.local_resolver:Processing failure of run 9eab75e28a9340ce98962bf8313738c9, state: FutureState.NESTED_FAILED
ERROR:sematic.api_client:Server returned 400 for PUT http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9: {"error": "Resolution 9eab75e28a9340ce98962bf8313738c9 cannot be moved from the CANCELED state to the FAILED state."}
ERROR:sematic.resolvers.state_machine_resolver:Unable to fail resolution: The PUT request to http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9 was invalid, response was 400
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/calculator.py", line 186, in calculate
    output = self.func(**kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 207, in do_sleep
    time.sleep(1)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 174, in _handle_sig_cancel
    self._resolution_did_cancel()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/local_resolver.py", line 297, in _resolution_did_cancel
    api_client.cancel_resolution(self._root_future.id)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 212, in cancel_resolution
    response = _put(f"/resolutions/{resolution_id}/cancel", {})
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 30, in wrapper
    return caller(f, *args, **kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 137, in retry_decorator
    return __retry_internal(
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 77, in __retry_internal
    return f()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 451, in _put
    response = request(requests.put, endpoint, dict(json=json_payload, data=data))
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 586, in request
    _raise_for_response(
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 635, in _raise_for_response
    raise exception
sematic.api_client.BadRequestError: The PUT request to http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel was invalid, response was 400

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/silent_resolver.py", line 37, in _run_inline
    value = future.calculator.calculate(**future.resolved_kwargs)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/calculator.py", line 188, in calculate
    raise CalculatorError(f"Error from running {self.func.__name__}") from e
sematic.abstract_calculator.CalculatorError: Error from running do_sleep

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 328, in <module>
    main()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 323, in main
    result = future.resolve(resolver)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/future.py", line 44, in resolve
    self.value = resolver.resolve(self)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 53, in resolve
    self._resolution_loop()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 83, in _resolution_loop
    self._schedule_future_if_args_resolved(future_)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 311, in _schedule_future_if_args_resolved
    self._execute_future(future)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/local_resolver.py", line 352, in _execute_future
    super()._execute_future(future=future)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 328, in _execute_future
    self._schedule_future(future)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/silent_resolver.py", line 22, in _schedule_future
    self._run_inline(future)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/silent_resolver.py", line 46, in _run_inline
    self._handle_future_failure(future, format_exception_for_run(e))
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 365, in _handle_future_failure
    raise ResolutionError(exception_metadata, external_exception_metadata)
sematic.utils.exceptions.ResolutionError: The pipeline resolution failed due to previous errors!

Pipeline failure:
Traceback (most recent call last):

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/calculator.py", line 186, in calculate
    output = self.func(**kwargs)

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 207, in do_sleep
    time.sleep(1)

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 174, in _handle_sig_cancel
    self._resolution_did_cancel()

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/local_resolver.py", line 297, in _resolution_did_cancel
    api_client.cancel_resolution(self._root_future.id)

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 212, in cancel_resolution
    response = _put(f"/resolutions/{resolution_id}/cancel", {})

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 30, in wrapper
    return caller(f, *args, **kwargs)

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 137, in retry_decorator
    return __retry_internal(

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/utils/retry.py", line 77, in __retry_internal
    return f()

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 451, in _put
    response = request(requests.put, endpoint, dict(json=json_payload, data=data))

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 586, in request
    _raise_for_response(

  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/api_client.py", line 635, in _raise_for_response
    raise exception

sematic.api_client.BadRequestError: The PUT request to http://127.0.0.1:5001/api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel was invalid, response was 400

[hangs forever]
```

**Server logs:**

```
2023-02-07 14:41:06,078 [INFO] sematic.api.endpoints.events: Broadcasting: namespace=pipeline; event=cancel
2023-02-07 14:41:06,080 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:41:06 -0800] "POST /api/v1/events/pipeline/cancel HTTP/1.1" 200 3 "-" "python-requests/2.28.2"
2023-02-07 14:41:06,081 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:41:06 -0800] "PUT /api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
[...]
023-02-07 14:41:06,225 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:41:06 -0800] "PUT /api/v1/resolutions/9eab75e28a9340ce98962bf8313738c9/cancel HTTP/1.1" 400 67 "-" "python-requests/2.28.1"
[...]
2023-02-07 14:41:06,295 [WARNING] sematic.api.endpoints.resolutions: Could not update resolution: Resolution 9eab75e28a9340ce98962bf8313738c9 cannot be moved from the CANCELED state to the FAILED state.
[...]
```

**Dashboard:**

![image](https://user-images.githubusercontent.com/1894533/217387372-ed488967-018f-4970-8b78-339486d7efc0.png)

## After

**Resolver logs:**

```
~/work/sematic$ bazel run sematic/examples/testing_pipeline -- --sleep 10
[...]
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 8.99443793296814 more seconds to sleep
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
WARNING:sematic.resolvers.local_resolver:Received cancelation event
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 7.989297866821289 more seconds to sleep
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 6.985903739929199 more seconds to sleep
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 5.984691858291626 more seconds to sleep
^CWARNING:sematic.resolvers.state_machine_resolver:Received SIGINT, canceling resolution...
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 4.979572057723999 more seconds to sleep
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 3.9743387699127197 more seconds to sleep
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 2.969082832336426 more seconds to sleep
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 1.968458890914917 more seconds to sleep
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep has 0.9643189907073975 more seconds to sleep
INFO:sematic.examples.testing_pipeline.pipeline:do_sleep is done sleeping!
INFO:__main__:Pipeline result: None
~/work/sematic$
```

**Server logs:**

```
2023-02-07 14:49:36,536 [INFO] sematic.api.endpoints.events: Broadcasting: namespace=pipeline; event=cancel
2023-02-07 14:49:36,537 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:36 -0800] "POST /api/v1/events/pipeline/cancel HTTP/1.1" 200 3 "-" "python-requests/2.28.2"
2023-02-07 14:49:36,538 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:36 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
[...]
2023-02-07 14:49:37,562 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:37,564 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:37 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:37,933 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:37,934 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:37 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:38,232 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:38,233 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:38 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:38,483 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:38,484 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:38 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:38,717 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:38,719 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:38 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:38,950 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:38,952 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:38 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
2023-02-07 14:49:39,190 [INFO] sematic.api.endpoints.resolutions: Resolution is already canceled
2023-02-07 14:49:39,191 [INFO] gunicorn.access: 127.0.0.1 - - [07/Feb/2023:14:49:39 -0800] "PUT /api/v1/resolutions/15aec69ea4184004bdbd1fef01a5c1ae/cancel HTTP/1.1" 200 511 "-" "python-requests/2.28.1"
[...]
```

**Dashboard:**

![image](https://user-images.githubusercontent.com/1894533/217387747-17adfea4-9a60-4bdb-a77a-f8aa2c13d87e.png)
