### PR TITLE
Release Sematic v0.24.0

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -102,6 +102,11 @@ Do this for all supported versions of Python. You can check your virtual env
 Python version using `sematic version` (as well as the Server and Client
 version).
 
+At this point, you should also deploy the Docker image to a cloud Dev environment
+using the [internal Helm charts](/helm/sematic-server), and execute at least one
+pipeline in detached cloud mode. You will likely also want to smoke test new
+features that were included in the release.
+
 If everything works fine, we are ready to push the release.
 
 ```bash
@@ -123,11 +128,6 @@ Next, build and push the server image. Use the dockerfile at
 ```bash
 $ TAG=v$(python3 sematic/versions.py) make release-server
 ```
-
-At this point, you should also deploy the Docker image to a cloud Dev environment
-using the [internal Helm charts](/helm/sematic-server), and execute at least one
-pipeline in detached cloud mode. You will likely also want to smoke test new
-features that were included in the release.
 
 Next you can generate the Helm package and publish it to the Helm repository.
 Clone the repo with `git clone git@github.com:sematic-ai/helm-charts.git`, and

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -104,8 +104,13 @@ version).
 
 At this point, you should also deploy the Docker image to a cloud Dev environment
 using the [internal Helm charts](/helm/sematic-server), and execute at least one
-pipeline in detached cloud mode. You will likely also want to smoke test new
-features that were included in the release.
+pipeline in detached cloud mode. To build the image, use the same process
+you do when usually deploying dev code to a dev env. If you don't have a
+process for this, you can just copy the wheel to the docker dir,
+build and push an image to a container registry, and follow the public
+deploy procedure. You will want to use values.yaml overrides specific to
+your environment (present in Sematic's secret manager). You will likely also
+want to smoke test new features that were included in the release.
 
 If everything works fine, we are ready to push the release.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
+* [0.24.0](https://pypi.org/project/sematic/0.24.0/)
+    * [feature] Introduction of RayCluster[^1]
+    * [feature] "Tee" cloud function logs so they appear in Sematic dashboard and the pod logs
+    * [improvement] Visualize better which run was the true "root failure" when a resolution fails
+    * [improvement] Improve an error message when using untyped dicts in type annotations
+    * [improvement] Various improvements to Sematic internal test infrastructure
+    * [bugfix] Remove a possible server crash for local servers running on Macs
+    * [bugfix] Eliminate a bug that could leave runs hanging if multiple cancellation events were sent
+    * [bugfix] Fix a bug that removed a useful default for image tag in the Helm chart
+    * [bugfix] Rename an incorrectly named helm-chart value for Slack integration
+    * [bugfix] Gracefully terminate runs when a resolver pod restarts mid-resolution
 * [0.23.0](https://pypi.org/project/sematic/0.23.0/)
     * [feature] Ability to deploy socket.io micro-service separately.
     * [feature] Expose external resources in the dashboard.
@@ -225,3 +236,6 @@ with nothing else on the line.
     * [example] New liver cirrhosis prediction model (SKLearn, XGBoost)
 * [0.0.2.alpha.1654828599](https://pypi.org/project/sematic/0.0.2a1654828599/)
     * Initial release
+
+[^1]: This feature is for Sematic's "Enterprise Edition" only. Please reach out if
+you are interested in using Sematic EE.

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -3,7 +3,7 @@ name: sematic-server
 description: Sematic AI Server
 type: application
 version: 1.0.5
-appVersion: v0.23.0
+appVersion: v0.24.0
 maintainers:
   - name: sematic-ai
     url: https://github.com/sematic-ai/sematic/

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sematic-server
 description: Sematic AI Server
 type: application
-version: 1.0.5
+version: 1.1.0
 appVersion: v0.24.0
 maintainers:
   - name: sematic-ai

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -71,7 +71,7 @@ deployment:
 
 image:
   repository: sematic/sematic-server
-  tag: vX.XX.X # REPLACE ME
+  #tag: vX.XX.X # If not specified, will use the Chart App version
   pull_policy: IfNotPresent
   #pull_secrets: []
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 # Represents the version of the client, server, and all other parts of
 # the sdk. Should be bumped any time a release is made. Should be set
 # to whatever is the version after the most recent one in changelog.md,
-# as well as the version for the sematic wheel in wheel_version.bzl
-CURRENT_VERSION = (0, 23, 0)
+# as well as the version for the sematic wheel in wheel_constants.bzl
+CURRENT_VERSION = (0, 24, 0)
 
 # Represents the smallest client version that works with the server
 # at the CURRENT_VERSION. Should be updated any time a breaking change

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -14,7 +14,7 @@ CURRENT_VERSION = (0, 24, 0)
 # at the CURRENT_VERSION. Should be updated any time a breaking change
 # is made to the web API. If there is a breaking change, there should
 # be a TODO below
-MIN_CLIENT_SERVER_SUPPORTS = (0, 21, 1)
+MIN_CLIENT_SERVER_SUPPORTS = (0, 22, 1)
 
 # Version of the settings file schema
 SETTINGS_SCHEMA_VERSION = 1

--- a/sematic/wheel_constants.bzl
+++ b/sematic/wheel_constants.bzl
@@ -2,7 +2,7 @@
 # changelog.md.
 # This is the version that will be attached to the
 # wheel that bazel builds for sematic.
-wheel_version_string = "0.23.0"
+wheel_version_string = "0.24.0"
 
 wheel_author = "Sematic AI, Inc."
 wheel_author_email = "emmanuel@sematic.ai"


### PR DESCRIPTION
Release Sematic v0.24.0

Testing
--------
- Tested that installing the wheel without any "extras" does not install any ee features or Ray. Tested that installing with `[all]` did.
- Deployed the `ee` server and tested the current testing pipeline code against it: (a) changed values file to allow ray usage, then: `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --ray-resource` (b) `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --sleep 300` and watched pod logs in the UI and from Grafana to guarantee they were there (c) `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --sleep 300 --oom` confirmed that the OOM run was marked as failed, and others were failed up to the root. But sibling and later runs were marked canceled (d) changed the testing pipeline Ray to request a GPU node, confirmed it got assigned/completed
- Deployed the non `ee` server and tested the current testing pipeline code against it: (a) changed values file to allow ray usage, then: `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --ray-resource`, confirmed it failed because Ray was not installed in the server image (b) `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --sleep 300` confirmed logs made it to dashboard and kubectl logs
- while the non-ee server was deployed, went to the dev machine and did `git checkout v0.22.1`. Then nuked my `.sematic` directory and used `bazel run //sematic/cli:main -- settings set X Y` to set up my api address/api key/s3 bucket. Then ran `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --fan-out 3` [run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.testing_pipeline.pipeline.testing_pipeline/d53642212271426d9ca540326d42186d#tab=logs&run=850bf10c012f4a7c8fb587dd0e643dba). Did the same for `v0.23.0` (although didn't recreate the settings that time)