### PR TITLE
Warn on Python migration error

### DIFF
--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -140,6 +140,7 @@ def _run_py_migration(migration_file: str, version: str, direction: MigrationDir
             _update_version(conn, version, direction)
 
     except Exception as e:
+        logging.exception("Error during Python migration; reverting")
         down() if direction == MigrationDirection.UP else up()
         raise e
 

--- a/sematic/db/migrations/20221214142609_plugin_settings_file.py
+++ b/sematic/db/migrations/20221214142609_plugin_settings_file.py
@@ -19,6 +19,11 @@ def up():
 
     schema_version = user_loaded_yaml.get("version", 0)
 
+    if schema_version == THIS_MIGRATION_SCHEMA_VERSION:
+        # the current settings file is already at the correct version,
+        # just that this migration hadn't been marked as performed yet
+        return
+
     if schema_version != THIS_MIGRATION_SCHEMA_VERSION - 1:
         raise RuntimeError(
             f"Cannot upgrade settings file from version {schema_version} "


### PR DESCRIPTION
Currently when a Python migration fails, the exception is swallowed and a revert is immediately executed, creating a bad experience.

This updates the migration logic to also inform the user what the original exception was.

Also, an existing migration script is edited to permit accepting the new version of the settings file and completing successfully, instead of only accepting the previous version that had to be migrated away from.