### PR TITLE
Fix Resolver import error on Server plugin

### DIFF
--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -128,7 +128,6 @@ def get_active_settings() -> ProfileSettings:
 
         _apply_scopes_overrides(profile_settings.scopes)
         _ensure_mandatory_plugins(profile_settings.settings)
-        _ensure_scoped_plugins(profile_settings.settings, profile_settings.scopes)
 
         for plugin_path, plugin_settings in profile_settings.settings.items():
             plugin_settings_vars = _get_plugin_settings_vars(plugin_path)
@@ -360,7 +359,7 @@ def _load_settings(file_path: str) -> Settings:
             profile_settings.scopes, PluginScope
         )
 
-        # We are mutating the dictionary as we iterate so we iterate on keys.
+        # We are mutating the dictionary as we iterate, so we iterate on keys.
         for plugin_path in list(profile_settings.settings):
             try:
                 plugin = import_plugin(plugin_path)
@@ -476,16 +475,6 @@ def _ensure_mandatory_plugins(plugin_settings: PluginsSettings) -> None:
     for plugin_path in _MANDATORY_SYSTEM_PLUGIN_PATHS:
         if plugin_path not in plugin_settings:
             plugin_settings[plugin_path] = {}
-
-
-def _ensure_scoped_plugins(plugin_settings, scopes):
-    """
-    Adds any plugins that are in a scope to the parameter, if not present.
-    """
-    for scope_plugins in scopes.values():
-        for plugin_path in scope_plugins:
-            if plugin_path not in plugin_settings:
-                plugin_settings[plugin_path] = {}
 
 
 def dump_settings(settings: ProfileSettings) -> str:

--- a/sematic/config/tests/BUILD
+++ b/sematic/config/tests/BUILD
@@ -35,8 +35,6 @@ pytest_test(
         "//sematic/config:settings",
         "//sematic/plugins/storage:local_storage",
         "//sematic/tests:fixtures",
-        "//sematic/plugins/external_resource:timed_message",
-        "//sematic/plugins/kuberay_wrapper:standard",
     ],
 )
 

--- a/sematic/config/tests/test_settings.py
+++ b/sematic/config/tests/test_settings.py
@@ -23,11 +23,6 @@ from sematic.config.tests.fixtures import (
     mock_settings,
 )
 from sematic.config.user_settings import UserSettings, UserSettingsVar
-from sematic.plugins.external_resource.timed_message import TimedMessage
-from sematic.plugins.kuberay_wrapper.standard import (
-    StandardKuberaySettingsVar,
-    StandardKuberayWrapper,
-)
 from sematic.tests.fixtures import environment_variables
 
 
@@ -242,7 +237,8 @@ def test_get_specific_plugin_no_file(no_settings_file):
 
 def test_env_override_specific_plugin_no_file(no_settings_file):
     with environment_variables({"SOME_SETTING": "override"}):
-        # the plugin is not present in the scope, so its variables won't be even loaded
+        # when asking for the plugin specifically,
+        # its variables will be loaded, and overridden
         assert get_plugin_setting(TestPlugin, SettingsVar.SOME_SETTING) == "override"
 
 
@@ -257,23 +253,3 @@ def test_env_override_absent_plugin_no_file(no_settings_file):
 def test_get_active_settings_no_file(no_settings_file):
     active_settings = get_active_settings()
     assert active_settings == EXPECTED_DEFAULT_ACTIVE_SETTINGS
-
-
-def test_get_active_settings_env_scope_override():
-    scope_env_var = (
-        f",{TimedMessage.__module__}.{TimedMessage.__name__},,\n,"
-        f"{StandardKuberayWrapper.__module__}.{StandardKuberayWrapper.__name__},,"
-    )
-    with environment_variables(
-        {
-            PluginScope.EXTERNAL_RESOURCE.value: scope_env_var,
-            StandardKuberaySettingsVar.RAY_SUPPORTS_GPUS.value: "true",
-        }
-    ):
-        settings = get_active_settings()
-    assert (
-        settings.settings[
-            f"{StandardKuberayWrapper.__module__}.{StandardKuberayWrapper.__name__}"
-        ][StandardKuberaySettingsVar.RAY_SUPPORTS_GPUS]
-        == "true"
-    )


### PR DESCRIPTION
Fixes a bug where in a collocated local deployment of both Server and pipeline submission, the submission of the pipeline itself fails with an import error if the local settings file configures a plugin that is Server-only.

This is because the pipeline submission binary is built without the Server plugins.

The plugin import error is gracefully handled already in [this section of the code](https://github.com/sematic-ai/sematic/blob/8cde601767ae3be60685da728b3acd8a4dc6583e/sematic/config/settings.py#L363-L372), which removes the unknown settings and logs a warning.
However, afterwards, [the settings are re-added](https://github.com/sematic-ai/sematic/blob/8cde601767ae3be60685da728b3acd8a4dc6583e/sematic/config/settings.py#L131) based on the corresponding declaration of the plugin in the scopes section.

This fix removes the re-adding of these settings.

The intent of (re-)adding the settings was to enable environment overrides for the plugin settings values - the settings cannot be overridden if we don't know what they are, and we know what they are by importing the plugin and asking it what the settings are.

This functionality is supported however, as long as the call site explicitly requests settings for a specific plugin, which currently happens in the codebase anyway, as the current usage pattern is to interrogate the settings what plugin is configured for a specific scope, import it, and look up a specific setting value for it. This flow [double-checks for env overrides](https://github.com/sematic-ai/sematic/blob/8cde601767ae3be60685da728b3acd8a4dc6583e/sematic/config/settings.py#L208-L214), so they are applied even after the settings were loaded and cached on first access.

This functionality is exemplified and tested in [these unit tests](https://github.com/sematic-ai/sematic/blob/8cde601767ae3be60685da728b3acd8a4dc6583e/sematic/config/tests/test_settings.py#L243-L254) (this PR also corrects the code comment on one of those tests).

## Testing

**Local setup:**
```
~/work/sematic$ bazel run sematic/cli:main -- settings show
INFO: Analyzed target //sematic/cli:main (16 packages loaded, 27923 targets configured).
INFO: Found 1 target...
WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
  cannot create symbolic link bazel-bin -> /private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin:  /Users/tudorscurtu/work/sematic/bazel-bin (File exists)
Target //sematic/cli:main up-to-date:
  bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main
INFO: Elapsed time: 3.874s, Critical Path: 2.89s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-out/darwin_arm64-fastbuild/bin/sematic/cli/main settings show
Active profile settings:

scopes:
  PUBLISH:
  - sematic.plugins.publishing.slack.SlackPublisher
settings:
  sematic.config.server_settings.ServerSettings:
    SEMATIC_DASHBOARD_URL: http://localhost:3000
    __version__: 0.1.0
  sematic.config.user_settings.UserSettings:
    AWS_S3_BUCKET: sematic-dev
    SEMATIC_API_ADDRESS: http://127.0.0.1:5001
    SEMATIC_API_KEY: XXX
  sematic.plugins.publishing.slack.SlackPublisher:
    SLACK_WEBHOOK_TOKEN: XXX
    __version__: 0.1.0
  sematic.plugins.storage.s3_storage.S3Storage:
    AWS_S3_BUCKET: XXX
    __version__: 0.1.0

~/work/sematic$
```

**Before:**
```
~/work/sematic$ bazel run sematic/examples/testing_pipeline
INFO: Analyzed target //sematic/examples/testing_pipeline:testing_pipeline (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
  cannot create symbolic link bazel-bin -> /private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin:  /Users/tudorscurtu/work/sematic/bazel-bin (File exists)
Target //sematic/examples/testing_pipeline:testing_pipeline up-to-date:
  bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline
INFO: Elapsed time: 0.444s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline
INFO:__main__:Command line arguments: Namespace(cache_namespace=None, cloud=False, detach=False, exit_code=None, expand_shared_memory=False, external_resource=False, fan_out=0, inline=False, log_level='INFO', max_parallelism=None, nested=False, oom=False, raise_retry_probability=None, ray_resource=False, rerun_from=None, should_raise=False, silent=False, sleep_time=0, virtual_funcs=False)
INFO:__main__:Pipeline arguments: {'external_resource': False, 'raise_retry_probability': None, 'oom': False, 'exit_code': None, 'should_raise': False, 'ray_resource': False, 'virtual_funcs': False, 'sleep_time': 0, 'nested': False, 'inline': False, 'fan_out': 0}
INFO:__main__:Invoking the pipeline...
INFO:sematic.resolvers.state_machine_resolver:Starting resolution 29c85ff2a8854bf5b7de9486a388b92c
WARNING:sematic.config.settings:Unable to find plug-in sematic.plugins.publishing.slack.SlackPublisher. Module or class is missing.
INFO:sematic.abstract_plugin:Imported plugin sematic.plugins.storage.s3_storage.S3Storage, version (0, 1, 0)
ERROR:sematic.resolvers.state_machine_resolver:Unable to fail resolution: Unable to find plug-in sematic.plugins.publishing.slack.SlackPublisher. Module or class is missing.
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/abstract_plugin.py", line 149, in import_plugin
    module = import_module(import_path)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/external/python3_8_aarch64-apple-darwin/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'sematic.plugins.publishing'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 328, in <module>
    main()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 323, in main
    result = future.resolve(resolver)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/future.py", line 44, in resolve
    self.value = resolver.resolve(self)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 53, in resolve
    self._resolution_loop()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/state_machine_resolver.py", line 78, in _resolution_loop
    self._resolution_will_start()
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/resolvers/local_resolver.py", line 224, in _resolution_will_start
    self._sio_client.connect(get_config().socket_io_url, namespaces=["/pipeline"])
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/config.py", line 120, in socket_io_url
    SEMATIC_WORKER_SOCKET_IO_ADDRESS, self.server_url
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/config.py", line 194, in server_url
    return get_user_setting(UserSettingsVar.SEMATIC_API_ADDRESS)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/settings.py", line 204, in get_plugin_setting
    plugin_settings = get_plugin_settings(plugin)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/settings.py", line 183, in get_plugin_settings
    settings = get_active_settings().settings
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/settings.py", line 134, in get_active_settings
    plugin_settings_vars = _get_plugin_settings_vars(plugin_path)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/config/settings.py", line 401, in _get_plugin_settings_vars
    plugin_class = import_plugin(plugin_path)
  File "/private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline.runfiles/sematic/sematic/abstract_plugin.py", line 160, in import_plugin
    raise MissingPluginError(plugin_import_path)
sematic.utils.exceptions.MissingPluginError: Unable to find plug-in sematic.plugins.publishing.slack.SlackPublisher. Module or class is missing.
~/work/sematic$
```

**After:**
```
~/work/sematic$ bazel run sematic/examples/testing_pipeline
INFO: Analyzed target //sematic/examples/testing_pipeline:testing_pipeline (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
  cannot create symbolic link bazel-bin -> /private/var/tmp/_bazel_tudorscurtu/a689328a338e85f1cbb50b96a7f1fc5e/execroot/sematic/bazel-out/darwin_arm64-fastbuild/bin:  /Users/tudorscurtu/work/sematic/bazel-bin (File exists)
Target //sematic/examples/testing_pipeline:testing_pipeline up-to-date:
  bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline
INFO: Elapsed time: 0.574s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/testing_pipeline/testing_pipeline
INFO:__main__:Command line arguments: Namespace(cache_namespace=None, cloud=False, detach=False, exit_code=None, expand_shared_memory=False, external_resource=False, fan_out=0, inline=False, log_level='INFO', max_parallelism=None, nested=False, oom=False, raise_retry_probability=None, ray_resource=False, rerun_from=None, should_raise=False, silent=False, sleep_time=0, virtual_funcs=False)
INFO:__main__:Pipeline arguments: {'inline': False, 'oom': False, 'external_resource': False, 'sleep_time': 0, 'raise_retry_probability': None, 'nested': False, 'ray_resource': False, 'should_raise': False, 'virtual_funcs': False, 'exit_code': None, 'fan_out': 0}
INFO:__main__:Invoking the pipeline...
INFO:sematic.resolvers.state_machine_resolver:Starting resolution 8a2d05ffd5974565bd8374b1d48a6428
WARNING:sematic.config.settings:Unable to find plug-in sematic.plugins.publishing.slack.SlackPublisher. Module or class is missing.
INFO:sematic.abstract_plugin:Imported plugin sematic.plugins.storage.s3_storage.S3Storage, version (0, 1, 0)
INFO:sematic.resolvers.state_machine_resolver:Running inline 8a2d05ffd5974565bd8374b1d48a6428 sematic.examples.testing_pipeline.pipeline.testing_pipeline
INFO:sematic.resolvers.state_machine_resolver:Scheduling 25ba41dde7ca4dd3a5ef49451666d1fa sematic.examples.testing_pipeline.pipeline.add
INFO:sematic.examples.testing_pipeline.pipeline:Executing: add(a=1.0, b=2.0)
INFO:__main__:Pipeline result: 3.0
~/work/sematic$
```
