### PR TITLE
Simplify the Circleci Slack notification configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ commands:
     description: Send a notification to Slack about job completion
     steps:
       - slack/notify:
-          channel: C03CPMXA1QU
           event: always
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs


### PR DESCRIPTION
This removes an unnecessary setting from the Circleci configuration file. The Slack notification still works:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/1894533/217690744-36476acb-e463-42ed-aa21-f6a0abca989b.png">
