### PR TITLE
Make wheel slimmer

### DIFF
--- a/sematic/tests/integration/test_pip_install.sh
+++ b/sematic/tests/integration/test_pip_install.sh
@@ -16,6 +16,7 @@ pwd
 
 source ./$VENV_NAME/bin/activate
 
+make wheel
 WHEEL_PATH=$(ls bazel-bin/sematic/sematic-*.whl)
 
 if test -f "$WHEEL_PATH"; then

--- a/sematic/tests/integration/test_pip_install.sh
+++ b/sematic/tests/integration/test_pip_install.sh
@@ -16,7 +16,31 @@ pwd
 
 source ./$VENV_NAME/bin/activate
 
+WHEEL_PATH=$(ls bazel-bin/sematic/sematic-*.whl)
+
+if test -f "$WHEEL_PATH"; then
+    echo "Error: Wheel not found"
+    exit 1
+fi
+
+N_MB_SIZE_LIMIT=10
+WHEEL_SIZE_MB=$(python3 -c "import os; print(int(os.path.getsize('$WHEEL_PATH') / 2**20))")
+
+if (( WHEEL_SIZE_BYTES > N_BYTE_SIZE_LIMIT )); then
+    echo "Error: Wheel bigger than $N_MB_SIZE_LIMIT Mb. Size: $WHEEL_SIZE_MB Mb"
+    exit 1
+else
+    echo "Wheel is $WHEEL_SIZE_MB Mb"
+fi
+
 pip install bazel-bin/sematic/sematic-*.whl
+
+if $? ; then
+    echo "Pip install succeeded"
+else
+    echo "Pip install failed"
+    exit 1
+fi
 
 deactivate
 

--- a/sematic/tests/integration/test_pip_install.sh
+++ b/sematic/tests/integration/test_pip_install.sh
@@ -16,11 +16,12 @@ pwd
 
 source ./$VENV_NAME/bin/activate
 
-make wheel
 WHEEL_PATH=$(ls bazel-bin/sematic/sematic-*.whl)
 
 if test -f "$WHEEL_PATH"; then
-    echo "Error: Wheel not found"
+    echo "Wheel found at $WHEEL_PATH"
+else
+    echo "Wheel not present at $WHEEL_PATH"
     exit 1
 fi
 

--- a/sematic/tests/integration/test_pip_install.sh
+++ b/sematic/tests/integration/test_pip_install.sh
@@ -36,13 +36,7 @@ else
 fi
 
 pip install bazel-bin/sematic/sematic-*.whl
-
-if $? ; then
-    echo "Pip install succeeded"
-else
-    echo "Pip install failed"
-    exit 1
-fi
+python3 -c "import sematic; print(sematic.__version__)" || exit 1
 
 deactivate
 

--- a/tools/sematic_wheel_rule.bzl
+++ b/tools/sematic_wheel_rule.bzl
@@ -129,6 +129,7 @@ def _sematic_py_wheel_impl(ctx):
             deps_files.append(input_file)
 
     for input_file in ee_inputs.to_list():
+        file_path = _path_inside_wheel(input_file)
         if file_path.startswith("sematic"):
             deps_files.append(input_file)
 


### PR DESCRIPTION
A regression in our wheel building macro patch made it so we were stuffing a bunch of irrelevant third party dep files into the wheel. This resolves the regression, and improves our basic sanity testing of the wheel to include wheel size.