### PR TITLE
Fix Slack publishing Helm activation

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
   STORAGE: "sematic.plugins.storage.s3_storage.S3Storage"
 {{ end }}
 {{ if .Values.slack.enabled }}
+  PUBLISH: "sematic.plugins.publishing.slack.SlackPublisher"
   SLACK_WEBHOOK_TOKEN: {{ .Values.slack.slack_webhook_token | quote }}
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}


### PR DESCRIPTION
On configuration of the Slack publishing plugin, it is not actually activated in the `PUBLISH` scope.