### PR TITLE
Refactor pipeline page layout

### DIFF
--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -8,7 +8,7 @@ import Tags from "../components/Tags";
 import { Run } from "../Models";
 import Link from "@mui/material/Link";
 import RunStateChip, { RunStateChipUndefinedStyle } from "../components/RunStateChip";
-import { Alert, AlertTitle, Container } from "@mui/material";
+import { Alert, AlertTitle, Container, containerClasses } from "@mui/material";
 import { InfoOutlined } from "@mui/icons-material";
 import { RunTime } from "../components/RunTime";
 import { pipelineSocket } from "../utils";
@@ -21,6 +21,26 @@ import { styled } from "@mui/system";
 const RecentStatusesWithStyles = styled('span')`
   flex-direction: row;
   display: flex;
+`;
+
+const StyledRootBox = styled(Box, {
+  shouldForwardProp: () => true,
+})`
+  height: 100%;
+
+  & .main-content {
+    overflow-y: hidden;
+
+    & .${containerClasses.root} {
+      height: 100%;
+
+      & > * {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+    }
+  }
 `;
 
 const TableColumns = [
@@ -94,8 +114,8 @@ function PipelineIndex() {
   }, []);
 
   return (
-    <Box sx={{ display: "grid", gridTemplateColumns: "1fr 300px" }}>
-      <Box sx={{ gridColumn: 1 }}>
+    <StyledRootBox sx={{ display: "grid", gridTemplateColumns: "1fr 300px" }}>
+      <Box sx={{ gridColumn: 1 }} className={"main-content"}>
         <Container sx={{ pt: 15 }}>
           <Box sx={{ mx: 5 }}>
             <Box sx={{ mb: 10 }}>
@@ -124,7 +144,7 @@ function PipelineIndex() {
           </p>
         </Alert>
       </Box>
-    </Box>
+    </StyledRootBox>
   );
 }
 


### PR DESCRIPTION
Unify the layout experience of the runs page and pipeline list page. So the header and footer of the table are sticky, and only the data rows portion is scrollable.

Before:
![capture1](https://user-images.githubusercontent.com/1046489/217967760-d234fa7c-3647-4926-833e-2dc1cb352fc5.gif)


After:
![capture1](https://user-images.githubusercontent.com/1046489/217967535-3e32d339-72e4-4fde-b0f1-bcb7e44765ec.gif)
