### PR TITLE
Add k8s toleration to allow Mnist train on our K8s setup

### DIFF
--- a/sematic/examples/mnist/pytorch/README.md
+++ b/sematic/examples/mnist/pytorch/README.md
@@ -1,2 +1,4 @@
 The PyTorch MNIST example as implemented in the [PyTorch
 repository](https://github.com/pytorch/examples/blob/main/mnist/main.py).
+
+This example can only be run on Kubernetes clusters set up with specific Kubernetes node types available, and is primarily useful as a reference.

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -15,7 +15,12 @@ from torchvision.transforms import Compose, Normalize, ToTensor
 
 # Sematic
 import sematic
-from sematic import KubernetesResourceRequirements, ResourceRequirements
+from sematic import (
+    KubernetesResourceRequirements,
+    KubernetesToleration,
+    KubernetesTolerationEffect,
+    ResourceRequirements,
+)
 from sematic.examples.mnist.pytorch.train_eval import Net, test, train
 
 
@@ -52,10 +57,19 @@ class PipelineConfig:
     use_cuda: bool = False
 
 
+# The node selector and toleration(s) you need to use to access
+# GPUs will vary depending on your Kubernetes setup.
 GPU_RESOURCE_REQS = ResourceRequirements(
     kubernetes=KubernetesResourceRequirements(
         node_selector={"node.kubernetes.io/instance-type": "g4dn.xlarge"},
         requests={"cpu": "2", "memory": "4Gi"},
+        tolerations=[
+            KubernetesToleration(
+                key="nvidia.com/gpu",
+                value="true",
+                effect=KubernetesTolerationEffect.NoSchedule,
+            )
+        ],
     )
 )
 


### PR DESCRIPTION
Our cluster requires a toleration to be able to use GPU-enabled nodes. This PR adds that toleration for Mnist training. Sample [run](https://dev1.dev-usw2-sematic0.sematic.cloud/pipelines/sematic.examples.mnist.pytorch.pipeline.pipeline/175fd51d6d8346aab736037c92a1131a#tab=input)