### PR TITLE
Release Helm charts v1.1.2 with Sematic v0.24.1

### DIFF
--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sematic-server
 description: Sematic AI Server
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: v0.24.1
 maintainers:
   - name: sematic-ai


### PR DESCRIPTION
A release for the Helm charts only, in order to ship bug fixes to the charts.