### PR TITLE
Update CI lint step to match dev linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ commands:
           command: mypy --version && mypy sematic
       - run:
           name: Black
-          command: black sematic
+          command: black sematic --diff --check
       - run:
           name: ISort
-          command: isort sematic
+          command: isort sematic --diff --check
       - run:
           name: ESlint
           working_directory: ./sematic/ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,17 @@ commands:
     description: Do linting and other static analysis
     steps:
       - run:
-          name: Linting
+          name: Flake8
           command: python3 -m flake8 --max-line-length=90
       - run:
           name: MyPy
           command: mypy --version && mypy sematic
+      - run:
+          name: Black
+          command: black sematic
+      - run:
+          name: ISort
+          command: isort sematic
       - run:
           name: ESlint
           working_directory: ./sematic/ui

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 import flask
 import sqlalchemy
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.sql.elements import BooleanClauseList
 
 # Sematic
 from sematic.abstract_future import FutureState
@@ -46,7 +47,6 @@ from sematic.scheduling.external_job import ExternalJob
 from sematic.scheduling.job_scheduler import schedule_run, update_run_status
 from sematic.scheduling.kubernetes import cancel_job
 from sematic.utils.retry import retry
-from sqlalchemy.sql.elements import BooleanClauseList
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Currently the lint step that CI performs lacks some operations that are present in the `make pre-commit` target developers use to lint the code before pushing changes.

This updates the CI linter to perform the exact same steps as Developers do.

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/1894533/218541376-4d9b2dc6-7dbc-4c7a-abfd-06069474865d.png">
