### PR TITLE
Use configurable timeouts

### DIFF
--- a/docs/ray.md
+++ b/docs/ray.md
@@ -90,6 +90,8 @@ SilentResolver, this will be ignored and a local cluster will be started instead
 - **forward_logs** (*bool*): Whether or not to have logs from Ray workers returned
 back to the stdout of the Sematic func this resource is used in. Sets `log_to_driver`
 in [`ray.init`](https://docs.ray.io/en/latest/ray-core/package-ref.html?highlight=init#ray.init)
+- **activation_timeout_seconds** (*float*): The number of seconds the cluster has
+to initialize itself before a timeout error occurs.
 
 #### RayClusterConfig
 

--- a/sematic/ee/plugins/external_resource/ray/cluster.py
+++ b/sematic/ee/plugins/external_resource/ray/cluster.py
@@ -74,12 +74,15 @@ class RayCluster(AbstractExternalResource):
         stdout of the Sematic func this resource is used in. Sets
         `log_to_driver` in `ray.init`:
         https://docs.ray.io/en/latest/ray-core/package-ref.html?highlight=init#ray.init
+    activation_timeout_seconds:
+        The number of seconds the cluster can take to initialize before a timeout error.
     """
 
     # Since the parent class has defaults, all params here must technically
     # have defaults. Here we raise an error if no value is provided though.
     config: RayClusterConfig = field(default_factory=_no_default_cluster)
     forward_logs: bool = True
+    activation_timeout_seconds: float = 15 * 60
 
     # The name of the remote cluster, if a remote cluster has been requested
     _cluster_name: Optional[str] = None
@@ -369,6 +372,10 @@ class RayCluster(AbstractExternalResource):
                     f"{cluster._min_required_workers()}."
                 ),
             )
+
+    def get_activation_timeout_seconds(self) -> float:
+        """Get the number of seconds the resource is allowed to take to activate"""
+        return self.activation_timeout_seconds
 
     def _update_n_pods(self) -> "RayCluster":
         if self.status.managed_by == ManagedBy.RESOLVER:

--- a/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
+++ b/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
@@ -56,6 +56,11 @@ def add(a: int, b: int) -> int:
     return result
 
 
+def test_timeout():
+    cluster = RayCluster(activation_timeout_seconds=42)
+    assert cluster.get_activation_timeout_seconds() == 42
+
+
 def test_local_cluster():
     result = add(1, 2).resolve(tracking=False)
     assert result == 3

--- a/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
+++ b/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
@@ -57,7 +57,12 @@ def add(a: int, b: int) -> int:
 
 
 def test_timeout():
-    cluster = RayCluster(activation_timeout_seconds=42)
+    cluster = RayCluster(
+        config=SimpleRayCluster(
+            n_nodes=1, node_config=RayNodeConfig(cpu=1, memory_gb=1)
+        ),
+        activation_timeout_seconds=42,
+    )
     assert cluster.get_activation_timeout_seconds() == 42
 
 

--- a/sematic/plugins/abstract_external_resource.py
+++ b/sematic/plugins/abstract_external_resource.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 _PLUGIN_VERSION = (0, 1, 0)
+_DEFAULT_ACTIVATION_TIMEOUT_SECONDS = 10 * 60
+_DEFAULT_DEACTIVATION_TIMEOUT_SECONDS = 5 * 60
 
 
 @unique
@@ -210,6 +212,14 @@ class AbstractExternalResource(AbstractPlugin):
             raise ValueError(f"ExternalResource had an invalid uuid: '{self.id}'")
         if not isinstance(self.status, ResourceStatus):
             raise ValueError(f"ExternalResource had invalid status: '{self.status}'")
+
+    def get_activation_timeout_seconds(self) -> float:
+        """Get the number of seconds the resource is allowed to take to activate"""
+        return _DEFAULT_ACTIVATION_TIMEOUT_SECONDS
+
+    def get_deactivation_timeout_seconds(self) -> float:
+        """Get the number of seconds the resource is allowed to take to deactivate"""
+        return _DEFAULT_DEACTIVATION_TIMEOUT_SECONDS
 
     @staticmethod
     def get_author() -> str:

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -18,6 +18,8 @@ class FakeExternalResource(AbstractExternalResource):
     raise_on_activate: bool = False
     raise_on_deactivate: bool = False
     raise_on_update: bool = False
+    activation_timeout_seconds: float = 100
+    deactivation_timeout_seconds: float = 100
 
     @classmethod
     def reset_history(cls) -> None:
@@ -55,6 +57,12 @@ class FakeExternalResource(AbstractExternalResource):
             for r, call in _fake_resource_call_history
             if resource_id is None or r.id == resource_id
         ]
+
+    def get_activation_timeout_seconds(self) -> float:
+        return self.activation_timeout_seconds
+
+    def get_deactivation_timeout_seconds(self) -> float:
+        return self.deactivation_timeout_seconds
 
     def __post_init__(self):
         result = super().__post_init__()

--- a/sematic/resolvers/tests/fixtures.py
+++ b/sematic/resolvers/tests/fixtures.py
@@ -18,8 +18,10 @@ class FakeExternalResource(AbstractExternalResource):
     raise_on_activate: bool = False
     raise_on_deactivate: bool = False
     raise_on_update: bool = False
-    activation_timeout_seconds: float = 100
-    deactivation_timeout_seconds: float = 100
+    slow_activate: bool = False
+    slow_deactivate: bool = False
+    activation_timeout_seconds: float = 10
+    deactivation_timeout_seconds: float = 10
 
     @classmethod
     def reset_history(cls) -> None:
@@ -106,6 +108,8 @@ class FakeExternalResource(AbstractExternalResource):
         if self.raise_on_update:
             raise ValueError("Intentional fail")
         if self.status.state == ResourceState.ACTIVATING:
+            if self.slow_activate:
+                return self
             return replace(
                 self,
                 status=replace(
@@ -115,6 +119,8 @@ class FakeExternalResource(AbstractExternalResource):
                 ),
             )
         elif self.status.state == ResourceState.DEACTIVATING:
+            if self.slow_deactivate:
+                return self
             return replace(
                 self,
                 status=replace(

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -1,3 +1,6 @@
+# Standard Library
+import time
+
 # Third-party
 import pytest
 
@@ -209,7 +212,11 @@ def test_activation_failures_for_resource():
                 private=PrivateContext(resolver_class_path=SilentResolver.classpath()),
             )
         ):
-            with FakeExternalResource(raise_on_update=True):
+            with FakeExternalResource(
+                raise_on_update=True,
+                activation_timeout_seconds=0.1,
+                deactivation_timeout_seconds=0.1,
+            ):
                 raise AssertionError("Should not reach here")
     resources = SilentResolver._resource_manager.resources_by_root_id(root_id)
     assert len(resources) == 1
@@ -218,6 +225,52 @@ def test_activation_failures_for_resource():
     # not deactivated because the resolver failed to get an update
     # about the status while trying to deactivate
     assert stored.status.state == ResourceState.DEACTIVATING
+
+
+def test_activation_timeout_for_resource():
+    FakeExternalResource.reset_history()
+    run_id = "abc1233"
+    root_id = "xyz789111"
+    with pytest.raises(ExternalResourceError, match=r"Timed out activating.*"):
+        with set_context(
+            SematicContext(
+                run_id=run_id,
+                root_id=root_id,
+                private=PrivateContext(resolver_class_path=SilentResolver.classpath()),
+            )
+        ):
+            started_activate = time.time()
+            with FakeExternalResource(
+                slow_activate=True, activation_timeout_seconds=0.0
+            ):
+                raise AssertionError("Should not reach here")
+    exited_with_block = time.time()
+    resources = SilentResolver._resource_manager.resources_by_root_id(root_id)
+    assert len(resources) == 1
+    assert exited_with_block - started_activate < 5
+
+
+def test_deactivation_timeout_for_resource():
+    FakeExternalResource.reset_history()
+    run_id = "abc123334"
+    root_id = "xyz789112"
+    with pytest.raises(ExternalResourceError, match=r"Timed out deactivating.*"):
+        with set_context(
+            SematicContext(
+                run_id=run_id,
+                root_id=root_id,
+                private=PrivateContext(resolver_class_path=SilentResolver.classpath()),
+            )
+        ):
+            started_activate = time.time()
+            with FakeExternalResource(
+                slow_deactivate=True, deactivation_timeout_seconds=0.0
+            ):
+                raise AssertionError("Should not reach here")
+    exited_with_block = time.time()
+    resources = SilentResolver._resource_manager.resources_by_root_id(root_id)
+    assert len(resources) == 1
+    assert exited_with_block - started_activate < 5
 
 
 def test_deactivation_failures_for_resource():

--- a/sematic/resolvers/tests/test_silent_resolver.py
+++ b/sematic/resolvers/tests/test_silent_resolver.py
@@ -57,26 +57,6 @@ def custom_resource_func() -> int:
     return value
 
 
-@pytest.fixture
-def short_timeouts():
-    original_values = (
-        SilentResolver._RESOURCE_ACTIVATION_TIMEOUT_SECONDS,
-        SilentResolver._RESOURCE_DEACTIVATION_TIMEOUT_SECONDS,
-        SilentResolver._RESOURCE_UPDATE_INTERVAL_SECONDS,
-    )
-    SilentResolver._RESOURCE_ACTIVATION_TIMEOUT_SECONDS = 0.1
-    SilentResolver._RESOURCE_DEACTIVATION_TIMEOUT_SECONDS = 0.1
-    SilentResolver._RESOURCE_UPDATE_INTERVAL_SECONDS = 0.001
-    try:
-        yield
-    finally:
-        (
-            SilentResolver._RESOURCE_ACTIVATION_TIMEOUT_SECONDS,
-            SilentResolver._RESOURCE_DEACTIVATION_TIMEOUT_SECONDS,
-            SilentResolver._RESOURCE_UPDATE_INTERVAL_SECONDS,
-        ) = original_values
-
-
 def test_silent_resolver():
     assert SilentResolver().resolve(pipeline(3, 5)) == 24
 
@@ -198,7 +178,7 @@ def test_activate_resource_for_run():
     assert SilentResolver._resource_manager.resources_by_root_id(root_id) == [stored]
 
 
-def test_activation_failures_for_resource(short_timeouts):
+def test_activation_failures_for_resource():
     FakeExternalResource.reset_history()
     run_id = "abc1232"
     root_id = "xyz7892"
@@ -210,7 +190,9 @@ def test_activation_failures_for_resource(short_timeouts):
                 private=PrivateContext(resolver_class_path=SilentResolver.classpath()),
             )
         ):
-            with FakeExternalResource(raise_on_activate=True):
+            with FakeExternalResource(
+                raise_on_activate=True, activation_timeout_seconds=0.1
+            ):
                 pass
     resources = SilentResolver._resource_manager.resources_by_root_id(root_id)
     assert len(resources) == 1
@@ -238,7 +220,7 @@ def test_activation_failures_for_resource(short_timeouts):
     assert stored.status.state == ResourceState.DEACTIVATING
 
 
-def test_deactivation_failures_for_resource(short_timeouts):
+def test_deactivation_failures_for_resource():
     FakeExternalResource.reset_history()
     run_id = "abc1234"
     root_id = "xyz7894"
@@ -253,7 +235,9 @@ def test_deactivation_failures_for_resource(short_timeouts):
                 private=PrivateContext(resolver_class_path=SilentResolver.classpath()),
             )
         ):
-            with FakeExternalResource(raise_on_deactivate=True):
+            with FakeExternalResource(
+                raise_on_deactivate=True, deactivation_timeout_seconds=0.1
+            ):
                 reached_inside_with_block = True
     assert reached_inside_with_block
     resources = SilentResolver._resource_manager.resources_by_root_id(root_id)


### PR DESCRIPTION
Addresses #565

Allow the the timeouts for resource activation/deactivation to be configurable on a per-resource basis. Some resource activations may take longer than others. Ex: a big ray cluster takes longer to configure than a small one. Also, large base images take longer to start workers for than small base images. Resources should be able to configure appropriate timeouts for themselves rather than using a universal fixed default.