### PR TITLE
Use custom SA for Ray

### DIFF
--- a/sematic/plugins/kuberay_wrapper/BUILD
+++ b/sematic/plugins/kuberay_wrapper/BUILD
@@ -3,8 +3,10 @@ sematic_py_lib(
     srcs = ["standard.py"],
     deps = [
         "//sematic:abstract_plugin",
+        "//sematic/config:server_settings",
         "//sematic/config:settings",
         "//sematic/plugins:abstract_kuberay_wrapper",
+        "//sematic/scheduling:kubernetes",
         "//sematic/utils:exceptions",
     ],
 )

--- a/sematic/plugins/kuberay_wrapper/tests/test_standard.py
+++ b/sematic/plugins/kuberay_wrapper/tests/test_standard.py
@@ -114,6 +114,8 @@ _EXPECTED_HEAD_ONLY_MANIFEST = {
                         }
                     ],
                     "tolerations": [],
+                    "serviceAccount": "default",
+                    "serviceAccountName": "default",
                     "nodeSelector": {},
                     "volumes": [{"name": "ray-logs", "emptyDir": {}}],
                 },
@@ -161,6 +163,8 @@ _EXPECTED_SINGLE_WORKER_GROUP = {
                 }
             ],
             "tolerations": [],
+            "serviceAccount": "default",
+            "serviceAccountName": "default",
             "nodeSelector": {},
             "volumes": [{"name": "ray-logs", "emptyDir": {}}],
         }
@@ -397,3 +401,34 @@ def test_worker_node_gpus():
     assert manifest["spec"]["workerGroupSpecs"][0]["template"]["spec"]["containers"][0][
         "resources"
     ]["requests"] == {"cpu": "1000m", "nvidia.com/gpu": 2, "memory": "2048M"}
+
+
+def test_custom_service_account():
+    custom_sa = "foosa"
+    with environment_variables(
+        {
+            "SEMATIC_WORKER_KUBERNETES_SA": custom_sa,
+        }
+    ):
+        manifest = StandardKuberayWrapper.create_cluster_manifest(  # type: ignore
+            image_uri=_TEST_IMAGE_URI,
+            cluster_name=_TEST_CLUSTER_NAME,
+            cluster_config=_MULTIPLE_WORKER_GROUP_CONFIG,
+            kuberay_version=_TEST_KUBERAY_VERSION,
+        )
+    assert (
+        manifest["spec"]["workerGroupSpecs"][0]["template"]["spec"]["serviceAccount"]
+        == custom_sa
+    )
+    assert (
+        manifest["spec"]["workerGroupSpecs"][0]["template"]["spec"]["serviceAccountName"]
+        == custom_sa
+    )
+    assert (
+        manifest["spec"]["headGroupSpec"]["template"]["spec"]["serviceAccount"]
+        == custom_sa
+    )
+    assert (
+        manifest["spec"]["headGroupSpec"]["template"]["spec"]["serviceAccountName"]
+        == custom_sa
+    )


### PR DESCRIPTION
Addresses #568 

In the same way we want Ray workers to have access to the same code dependencies as the associated Sematic func, we also want them to have access to the same permissions. This means that if a custom SA is being used for Sematic workers, it should be used for Ray workers as well.

Testing
-------
In an environment using a custom SA for Sematic workers, launched a Ray cluster using `with RayCluster`. Looked at the pod SA for the workers and the head to confirm that they had the custom SA set.