### PR TITLE
Add ability to use image layers for Sematic pipelines

### DIFF
--- a/sematic/examples/testing_pipeline/BUILD
+++ b/sematic/examples/testing_pipeline/BUILD
@@ -16,9 +16,12 @@ sematic_pipeline(
     dev = True,
     registry = "558717131297.dkr.ecr.us-west-2.amazonaws.com",
     repository = "sematic-dev",
-    deps = [
-        ":testing_pipeline_lib",
+    image_layers = [
+        # Include these in their own layers, since they don't change often.
         requirement("debugpy"),
         requirement("ray"),
+    ],
+    deps = [
+        ":testing_pipeline_lib",
     ],
 )


### PR DESCRIPTION
The default behavior for [`py3_image`](https://github.com/bazelbuild/rules_docker#py3_image), which Sematic uses to build docker images from bazel, is to gzip all the bazel dependencies into one zip. It then puts this zip as a new layer in the image. This is problematic because any change to any code invalidates the bazel and docker caches for the whole zip and layer. `py3_image` provides a `layers` parameter which allows you to break up the monolithic zip and layers into individual ones. This can make it much faster to iterate on code that needs to be built & pushed. This PR exposes this parameter in the `sematic_pipeline` macro.

Testing
-------
```
sematic-dev $ bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --ray-resource --detach
sematic-dev $ bazel run //sematic/examples/testing_pipeline:__main___local -- --silent --ray-resource
```

Also performed some time trials to confirm that the caching was happening. Procedure:

```
$ # ensure ray and debugpy are listed as layers
$ # now prime the cache
$ bazel run //sematic/examples/testing_pipeline:__main__ -- --help
$ # make trivial code change
$ time bazel run //sematic/examples/testing_pipeline:__main__ -- --help
real    0m22.151s
$ # make trivial code change
$ time bazel run //sematic/examples/testing_pipeline:__main__ -- --help
real    0m22.492s
$ # list ray and debugpy as "normal" deps instead of layers
$ # now prime the cache (should get invalidated soon anyway)
$ bazel run //sematic/examples/testing_pipeline:__main__ -- --help
$ # make trivial code change
$ time bazel run //sematic/examples/testing_pipeline:__main__ -- --help
real    0m36.799s
$ # make trivial code change
$ time bazel run //sematic/examples/testing_pipeline:__main__ -- --help
real    0m36.454s
```

You can see that moving these two third party deps to `layers` made it so that trivial code changes were able to leverage the cache to build ~40% faster in this case. With proper specification of cached layers, end-users might be able to see even more substantial gains.
