### PR TITLE
Resilient against non-standard torch import fails

### DIFF
--- a/sematic/types/types/pytorch/__init__.py
+++ b/sematic/types/types/pytorch/__init__.py
@@ -1,8 +1,25 @@
+# Standard Library
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     # Third-party
     import torch  # noqa: F401
 except ImportError:
     pass
+except Exception:
+    # Why include errors besides ImportError?
+    # Because torch can raise weird things under certain circumstances on
+    # import when Cuda is missing:
+    #
+    # Traceback (most recent call last):
+    #     File "site-packages/torch/__init__.py", line 172, in _load_global_deps
+    #         ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+    #     File "/lib/python3.9/ctypes/__init__.py", line 374, in __init__
+    #         self._handle = _dlopen(self._name, mode)
+    # OSError: libcublas.so.11: cannot open shared object file: No such file or directory
+    logger.exception("Error importing torch")
 else:
     # Sematic
     import sematic.types.types.pytorch.dataloader  # noqa: F401

--- a/sematic/types/types/pytorch/__init__.py
+++ b/sematic/types/types/pytorch/__init__.py
@@ -8,7 +8,7 @@ try:
     import torch  # noqa: F401
 except ImportError:
     pass
-except Exception:
+except Exception as e:
     # Why include errors besides ImportError?
     # Because torch can raise weird things under certain circumstances on
     # import when Cuda is missing:
@@ -19,7 +19,7 @@ except Exception:
     #     File "/lib/python3.9/ctypes/__init__.py", line 374, in __init__
     #         self._handle = _dlopen(self._name, mode)
     # OSError: libcublas.so.11: cannot open shared object file: No such file or directory
-    logger.exception("Error importing torch")
+    logger.exception("Error importing torch: %s", e)
 else:
     # Sematic
     import sematic.types.types.pytorch.dataloader  # noqa: F401


### PR DESCRIPTION
Closes #572

We can try to import `torch` near the top of resolver jobs when we try to import type deserialization logic. The existing code is resilient against "normal" `ImportError`, but not against more complicated import failures like the following:

```python
Traceback (most recent call last):
  File "/pip_deps_torch/site-packages/torch/__init__.py", line 172, in _load_global_deps
    ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
  File "/python_x86_64-unknown-linux-gnu/lib/python3.9/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libcublas.so.11: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/rules_sematic/worker.py", line 8, in <module>
    from sematic.resolvers.worker import wrap_main_with_logging
  File "/pip_deps_sematic/site-packages/sematic/__init__.py", line 34, in <module>
    import sematic.future_operators  # noqa: F401,E402
  File "/pip_deps_sematic/site-packages/sematic/future_operators/__init__.py", line 2, in <module>
    import sematic.future_operators.getitem  # noqa: F401
  File "/pip_deps_sematic/site-packages/sematic/future_operators/getitem.py", line 9, in <module>
    from sematic.calculator import func
  File "/pip_deps_sematic/site-packages/sematic/calculator.py", line 25, in <module>
    from sematic.future import Future
  File "/pip_deps_sematic/site-packages/sematic/future.py", line 7, in <module>
    from sematic.resolvers.local_resolver import LocalResolver
  File "/pip_deps_sematic/site-packages/sematic/resolvers/local_resolver.py", line 12, in <module>
    import sematic.api_client as api_client
  File "/pip_deps_sematic/site-packages/sematic/api_client.py", line 12, in <module>
    from sematic.api.endpoints.auth import API_KEY_HEADER
  File "/pip_deps_sematic/site-packages/sematic/api/endpoints/auth.py", line 22, in <module>
    from sematic.db.models.factories import make_user
  File "/pip_deps_sematic/site-packages/sematic/db/models/factories.py", line 14, in <module>
    from sematic.db.models.resolution import Resolution, ResolutionStatus
  File "/pip_deps_sematic/site-packages/sematic/db/models/resolution.py", line 31, in <module>
    from sematic.db.models.has_external_jobs_mixin import HasExternalJobsMixin
  File "/pip_deps_sematic/site-packages/sematic/db/models/has_external_jobs_mixin.py", line 6, in <module>
    from sematic.types.serialization import (
  File "/pip_deps_sematic/site-packages/sematic/types/__init__.py", line 38, in <module>
    import sematic.types.types.pytorch  # noqa: F401
  File "/pip_deps_sematic/site-packages/sematic/types/types/pytorch/__init__.py", line 3, in <module>
    import torch  # noqa: F401
  File "/pip_deps_torch/site-packages/torch/__init__.py", line 217, in <module>
    _load_global_deps()
  File "/pip_deps_torch/site-packages/torch/__init__.py", line 178, in _load_global_deps
    _preload_cuda_deps()
  File "/pip_deps_torch/site-packages/torch/__init__.py", line 158, in _preload_cuda_deps
    ctypes.CDLL(cublas_path)
  File "/python_x86_64-unknown-linux-gnu/lib/python3.9/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
```

In such cases, the resolver job can fail before it even is able to reach out to the Sematic API server. The resolver pod will thus error out but the Sematic UI will show the job as permanently "created".

This PR makes it so we should catch these and log an error instead of failing the whole resolver abnormally.