### PR TITLE
Supports runs link

### DIFF
--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -41,7 +41,7 @@
         "react-markdown": "^8.0.3",
         "react-medium-image-zoom": "^4.4.3",
         "react-plotly.js": "^2.5.1",
-        "react-router-dom": "^6.3.0",
+        "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
         "react-syntax-highlighter": "^15.5.0",
         "react-time-ago": "^7.1.9",
@@ -3716,6 +3716,14 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -10608,14 +10616,6 @@
         "node": "*"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -17374,23 +17374,29 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "dependencies": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.3.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -23458,6 +23464,11 @@
       "integrity": "sha512-Az6w/EL3QHSvWVbfX2WbUB15PGqM0hm86bpAoyvjw2nhDdPp9IOjpFg5HfSGJQJBydjbCFnZjI8PJskTzLOhew==",
       "requires": {}
     },
+    "@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -28656,14 +28667,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
-    "history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -33311,20 +33314,20 @@
       }
     },
     "react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "requires": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.3.2"
       }
     },
     "react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
       }
     },
     "react-scripts": {

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -37,7 +37,7 @@
     "react-markdown": "^8.0.3",
     "react-medium-image-zoom": "^4.4.3",
     "react-plotly.js": "^2.5.1",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "react-time-ago": "^7.1.9",

--- a/sematic/ui/src/components/RunId.tsx
+++ b/sematic/ui/src/components/RunId.tsx
@@ -1,5 +1,5 @@
-import { useParams, Link } from "react-router-dom";
-import { getPipelineUrlPattern } from "../hooks/pipelineHooks";
+import { Link } from "react-router-dom";
+import { getRunUrlPattern } from "../hooks/pipelineHooks";
 import { CopyButton } from "./CopyButton";
 
 export default function RunId(props: {
@@ -9,11 +9,9 @@ export default function RunId(props: {
   }) {
     const { runId, trim = true, copy = true } = props;
   
-    const { pipelinePath } = useParams();
-  
     return (
       <>
-        <Link to={getPipelineUrlPattern(pipelinePath!, runId)} style={
+        <Link to={getRunUrlPattern(runId)} style={
           {fontSize: '12px'}
         }>
             <code>{trim ? runId.substring(0, 6) : runId}</code>

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -112,11 +112,11 @@ export function useFetchResolution(resolutionId: string): [
     return [value, loading, error];
 }
 
-export function getPipelineUrlPattern(pipelinePath: string, requestedRootId: string) {
-    return `/pipelines/${pipelinePath}/${requestedRootId}`;
+export function getRunUrlPattern(requestedRootId: string) {
+    return `/runs/${requestedRootId}`;
 }
 
-export function usePipelineNavigation(pipelinePath: string) {
+export function useRunNavigation() {
     const navigate = useNavigate();
     const { rootId } = useParams();
     const { hash } = useLocation();
@@ -138,10 +138,10 @@ export function usePipelineNavigation(pipelinePath: string) {
         }
 
         navigate({
-            pathname: getPipelineUrlPattern(pipelinePath, requestedRootId),
+            pathname: getRunUrlPattern(requestedRootId),
             hash: newHashValue
         }, {
             replace
         });
-    }, [pipelinePath, rootId, hash, navigate]);
+    }, [rootId, hash, navigate]);
 }

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -4,9 +4,9 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import "./index.css";
-import { Route, BrowserRouter, Routes, useNavigate } from "react-router-dom";
+import { Route, useNavigate, RouterProvider, createRoutesFromElements, createBrowserRouter, redirect } from "react-router-dom";
 import PipelineIndex from "./pipelines/PipelineIndex";
-import PipelineRunView from "./pipelines/PipelineRunView";
+import RunView from "./pipelines/PipelineRunView";
 import Shell from "./components/Shell";
 import Loading from "./components/Loading";
 import Home from "./Home";
@@ -111,19 +111,7 @@ function App() {
     <UserContext.Provider value={userContextValue}>
       <EnvContext.Provider value={envContextValue}>
         <SnackBarProvider>
-          <Routes>
-            <Route path="/" element={<Shell />}>
-              <Route path="" element={<Home />} />
-              <Route path="pipelines" element={<PipelineIndex />} />
-              <Route path="runs" element={<RunIndex />} />
-              <Route
-                path="pipelines/:pipelinePath/:rootId" element={<PipelineRunView />}
-              />
-              <Route
-                path="pipelines/:pipelinePath" element={<PipelineView />}
-              />
-            </Route>
-          </Routes>
+          <Shell />
         </SnackBarProvider>
       </EnvContext.Provider>
     </UserContext.Provider>
@@ -173,11 +161,29 @@ function App() {
   );
 }
 
+function Router() {
+  const router = createBrowserRouter(createRoutesFromElements(
+    <Route path="/" element={<App />}>
+      <Route index element={<Home />} />
+      <Route path="pipelines" element={<PipelineIndex />} />
+      <Route path="runs" element={<RunIndex />} />
+      <Route
+        path="pipelines/:pipelinePath/:rootId" 
+          loader={({params}) => redirect(`/runs/${params.rootId}`)}
+      />
+      <Route
+        path="pipelines/:pipelinePath" element={<PipelineView />}
+      />
+      <Route
+        path="runs/:rootId" element={<RunView />}
+      />
+    </Route>
+  ));
+
+  return <RouterProvider router={router} />;
+}
+
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
-);
+root.render(<Router />);

--- a/sematic/ui/src/pipelines/OutputPanel.tsx
+++ b/sematic/ui/src/pipelines/OutputPanel.tsx
@@ -1,7 +1,7 @@
 import { Alert } from "@mui/material";
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { getPipelineUrlPattern, usePipelinePanelsContext } from "../hooks/pipelineHooks";
+import { getRunUrlPattern, usePipelinePanelsContext } from "../hooks/pipelineHooks";
 import { Artifact } from "../Models";
 import { ArtifactList } from "./Artifacts";
 
@@ -14,9 +14,9 @@ export default function OutputPanel(props: {
 
     const logsLinkPath = useMemo(
         () => {
-            const { calculator_path, id} = selectedRun!;
+            const { id } = selectedRun!;
             return {
-                pathname: getPipelineUrlPattern(calculator_path, id),
+                pathname: getRunUrlPattern(id),
                 hash: 'tab=logs'
             }
         }, [selectedRun]);

--- a/sematic/ui/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/src/pipelines/PipelineBar.tsx
@@ -21,7 +21,7 @@ import RunStateChip from "../components/RunStateChip";
 import TimeAgo from "../components/TimeAgo";
 import { ActionMenu, ActionMenuItem } from "../components/ActionMenu";
 import { SnackBarContext } from "../components/SnackBarProvider";
-import { useFetchRuns, usePipelineNavigation, usePipelineRunContext } from "../hooks/pipelineHooks";
+import { useFetchRuns, useRunNavigation, usePipelineRunContext } from "../hooks/pipelineHooks";
 import { ExtractContextType } from "../components/utils/typings";
 import PipelineRunViewContext from "./PipelineRunViewContext";
 
@@ -128,10 +128,12 @@ function PipelineActionMenu(props: {
 export default function PipelineBar() {
   const { setSnackMessage } = useContext(SnackBarContext);
 
-  const { rootRun, resolution, pipelinePath } 
+  const { rootRun, resolution } 
   = usePipelineRunContext() as ExtractContextType<typeof PipelineRunViewContext> & {
     rootRun: Run, resolution: Resolution
   };;
+
+  const pipelinePath = rootRun.calculator_path;
 
   const theme = useTheme();
 
@@ -148,7 +150,7 @@ export default function PipelineBar() {
 
   const {isLoaded, error, runs: latestRuns, reloadRuns } = useFetchRuns(runFilters, otherQueryParams);
 
-  const navigate = usePipelineNavigation(pipelinePath!);
+  const navigate = useRunNavigation();
 
   const changeRootId = useCallback((runId: string) => {
     navigate(runId);

--- a/sematic/ui/src/pipelines/PipelineRunViewContext.ts
+++ b/sematic/ui/src/pipelines/PipelineRunViewContext.ts
@@ -5,7 +5,6 @@ export const PipelineRunViewContext = React.createContext<{
     rootRun: Run | undefined;
     resolution: Resolution | undefined;
     isLoading: boolean;
-    pipelinePath: string | null;
 } | null>(null);
 
 export default PipelineRunViewContext;

--- a/sematic/ui/src/pipelines/PipelineView.tsx
+++ b/sematic/ui/src/pipelines/PipelineView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import Loading from "../components/Loading";
-import { useFetchRuns, usePipelineNavigation } from "../hooks/pipelineHooks";
+import { useFetchRuns, useRunNavigation } from "../hooks/pipelineHooks";
 import { Alert } from "@mui/material";
 
 /**
@@ -28,7 +28,7 @@ export default function PipelineView() {
 
     const {isLoaded, error, runs: latestRuns} = useFetchRuns(runFilters, otherQueryParams);
 
-    const navigate = usePipelineNavigation(pipelinePath!);
+    const navigate = useRunNavigation();
 
     useEffect(() => {
         if (!isLoaded || !!error) {

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -15,6 +15,7 @@ import { RunTime } from "../components/RunTime";
 import { SearchOutlined } from "@mui/icons-material";
 import { styled } from "@mui/system";
 import { spacing } from "../utils";
+import { getRunUrlPattern } from "../hooks/pipelineHooks";
 
 type RunRowProps = {
   run: Run;
@@ -47,7 +48,7 @@ export function RunRow(props: RunRowProps) {
         <Typography variant="h6">
           {props.noRunLink && run.name}
           {!props.noRunLink && (
-            <Link href={`/pipelines/${run.calculator_path}/${run.id}`} underline="hover">
+            <Link href={getRunUrlPattern(run.id)} underline="hover">
               {run.name}
             </Link>
           )}


### PR DESCRIPTION
Now we support a URL of the following form in the URL

```
http://localhost:3000/runs/953c084342014b0e89fe389d8fa2e75d
```

The current URL pattern `http://host/pipelines/:pipeline_path/:rootId` redirects to `http://host/runs/:rootId`


<img width="1036" alt="image" src="https://user-images.githubusercontent.com/1046489/218902810-429fc9f4-956a-4574-8214-78eb1ef1c67c.png">
