### PR TITLE
Refactor in-app links to use react router

### DIFF
--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -6,7 +6,6 @@ import {
   Container,
   Divider,
   Grid,
-  Link,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -18,6 +17,7 @@ import {
 } from "react";
 import { SiDiscord, SiReadthedocs, SiGithub } from "react-icons/si";
 import { UserContext } from ".";
+import MuiRouterLink from "./components/MuiRouterLink";
 import RunStateChip from "./components/RunStateChip";
 import { useFetchRuns } from "./hooks/pipelineHooks";
 
@@ -79,7 +79,7 @@ export default function Home() {
       sx={{ display: "flex", alignItems: "center" }}
     >
       Your latest run:&nbsp; <RunStateChip run={run} />
-      <Link href={"/pipelines/" + run.calculator_path}>{run.name}</Link>
+      <MuiRouterLink href={"/pipelines/" + run.calculator_path}>{run.name}</MuiRouterLink>
     </Typography>;
   }, [isLoaded, runs]);
 
@@ -176,24 +176,24 @@ export default function Home() {
             spacing={20}
           >
             <Grid item sx={{ textAlign: "center" }}>
-              <Link
+              <MuiRouterLink
                 href="https://discord.gg/PFCpatvy"
                 underline="none"
                 target="_blank"
               >
                 <SiDiscord fontSize={42} color="#7289da" />
                 <Typography>Discord</Typography>
-              </Link>
+              </MuiRouterLink>
             </Grid>
             <Grid item sx={{ textAlign: "center" }}>
-              <Link
+              <MuiRouterLink
                 href="https://github.com/sematic-ai/sematic"
                 underline="none"
                 target="_blank"
               >
                 <SiGithub fontSize={42} color="#000000" />
                 <Typography>GitHub</Typography>
-              </Link>
+              </MuiRouterLink>
             </Grid>
           </Grid>
           <Typography paragraph sx={{ mt: 10 }}>
@@ -204,19 +204,19 @@ export default function Home() {
             sx={{ justifyContent: "center", alignItems: "flex-start", pt: 3 }}
           >
             <Grid item sx={{ textAlign: "center" }}>
-              <Link
+              <MuiRouterLink
                 href="https://docs.sematic.dev"
                 underline="none"
                 target="_blank"
               >
                 <SiReadthedocs fontSize={38} color="#000000" />
                 <Typography>Sematic Documentation</Typography>
-              </Link>
+              </MuiRouterLink>
             </Grid>
           </Grid>
           <Typography paragraph sx={{ mt: 10 }}>
             Or email us at{" "}
-            <Link href="mailto:support@sematic.dev">support@sematic.dev</Link>.
+            <MuiRouterLink href="mailto:support@sematic.dev">support@sematic.dev</MuiRouterLink>.
           </Typography>
         </Grid>
       </Grid>

--- a/sematic/ui/src/components/MuiRouterLink.tsx
+++ b/sematic/ui/src/components/MuiRouterLink.tsx
@@ -1,0 +1,18 @@
+import Link from "@mui/material/Link";
+import { Link as RouterLink } from "react-router-dom";
+
+type LinkPropsType = React.ComponentProps<typeof Link>;
+type RouterLinkPropsType = React.ComponentProps<typeof RouterLink>;
+
+type MuiRouterLinkAllProps = LinkPropsType & RouterLinkPropsType;
+type OptionalHrefProps = Omit<MuiRouterLinkAllProps, 'href'> 
+    & Partial<Pick<LinkPropsType, 'href'>> & Required<Pick<RouterLinkPropsType, 'to'>>
+type OptionalToProps = Omit<MuiRouterLinkAllProps, 'to'> 
+    & Partial<Pick<RouterLinkPropsType, 'to'>> & Required<Pick<LinkPropsType, 'href'>>
+
+export default function MuiRouterLink(
+    props: MuiRouterLinkAllProps | OptionalHrefProps | OptionalToProps) {
+    const {href, to, ...restProps} = props;
+    let linkDestination = to || href;
+    return <Link {...restProps} to={linkDestination!} component={RouterLink} />;
+}

--- a/sematic/ui/src/components/RunId.tsx
+++ b/sematic/ui/src/components/RunId.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom";
 import { getRunUrlPattern } from "../hooks/pipelineHooks";
 import { CopyButton } from "./CopyButton";
+import MuiRouterLink from "./MuiRouterLink";
 
 export default function RunId(props: {
     runId: string;
@@ -11,11 +11,10 @@ export default function RunId(props: {
   
     return (
       <>
-        <Link to={getRunUrlPattern(runId)} style={
-          {fontSize: '12px'}
-        }>
+        <MuiRouterLink to={getRunUrlPattern(runId)} underline="hover" 
+          style={{fontSize: '12px', color: 'revert'}}>
             <code>{trim ? runId.substring(0, 6) : runId}</code>
-        </Link>
+        </MuiRouterLink>
         {copy && <CopyButton text={runId} message="Copied run ID" />}
       </>
     );

--- a/sematic/ui/src/components/SideBar.tsx
+++ b/sematic/ui/src/components/SideBar.tsx
@@ -2,7 +2,6 @@ import { Logout, PlayCircle, Timeline } from "@mui/icons-material";
 import {
   Box,
   Typography,
-  Link,
   Stack,
   ButtonBase,
   Menu,
@@ -17,6 +16,7 @@ import { useContext, useState } from "react";
 import { SiDiscord, SiReadthedocs } from "react-icons/si";
 import { UserContext } from "..";
 import logo from "../Fox.png";
+import MuiRouterLink from "./MuiRouterLink";
 import UserAvatar from "./UserAvatar";
 
 export default function SideBar() {
@@ -36,30 +36,30 @@ export default function SideBar() {
     >
       <Stack sx={{ gridRow: 1, spacing: 2, paddingTop: 3 }}>
         <Box sx={{ color: "#ffffff", paddingBottom: 4 }}>
-          <Link href="/" underline="none">
+          <MuiRouterLink href="/" underline="none">
             <img src={logo} width="30px" alt="Sematic fox" />
             {/*<Typography fontSize={32}>🦊</Typography>*/}
-          </Link>
+          </MuiRouterLink>
         </Box>
         <Box mt={5}>
-          <Link
+          <MuiRouterLink
             href="/pipelines"
             sx={{ color: "rgba(255, 255, 255, 0.5)" }}
             underline="none"
           >
             <Timeline fontSize="large" />
             <Typography fontSize={10}>Pipelines</Typography>
-          </Link>
+          </MuiRouterLink>
         </Box>
         <Box mt={5}>
-          <Link
+          <MuiRouterLink
             href="/runs"
             sx={{ color: "rgba(255, 255, 255, 0.5)" }}
             underline="none"
           >
             <PlayCircle fontSize="large" />
             <Typography fontSize={10}>Runs</Typography>
-          </Link>
+          </MuiRouterLink>
         </Box>
       </Stack>
       <Stack
@@ -72,7 +72,7 @@ export default function SideBar() {
       >
         <Stack spacing={4} sx={{ paddingBottom: 4 }}>
           <Box>
-            <Link
+            <MuiRouterLink
               href="https://docs.sematic.dev"
               sx={{ color: "rgba(255, 255, 255, 0.5)" }}
               underline="none"
@@ -80,17 +80,17 @@ export default function SideBar() {
             >
               <SiReadthedocs />
               <Typography fontSize={10}>Docs</Typography>
-            </Link>
+            </MuiRouterLink>
           </Box>
           <Box>
-            <Link
+            <MuiRouterLink
               href="https://discord.gg/4KZJ6kYVax"
               sx={{ color: "rgba(255, 255, 255, 0.5)" }}
               underline="none"
             >
               <SiDiscord />
               <Typography fontSize={10}>Discord</Typography>
-            </Link>
+            </MuiRouterLink>
           </Box>
         </Stack>
         <UserMenu />

--- a/sematic/ui/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/src/pipelines/PipelineBar.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   FormControl,
   InputLabel,
-  Link,
   MenuItem,
   Select,
   SelectChangeEvent,
@@ -24,6 +23,7 @@ import { SnackBarContext } from "../components/SnackBarProvider";
 import { useFetchRuns, useRunNavigation, usePipelineRunContext } from "../hooks/pipelineHooks";
 import { ExtractContextType } from "../components/utils/typings";
 import PipelineRunViewContext from "./PipelineRunViewContext";
+import MuiRouterLink from "../components/MuiRouterLink";
 
 function PipelineActionMenu(props: {
   onCancel: () => void;
@@ -211,9 +211,9 @@ export default function PipelineBar() {
             borderColor: theme.palette.grey[200],
           }}
         >
-          <Link href="/pipelines">
+          <MuiRouterLink href="/pipelines">
             <ChevronLeft fontSize="large" />
-          </Link>
+          </MuiRouterLink>
         </Box>
         <Box sx={{ gridColumn: 2, pl: 7 }}>
           <Typography variant="h4">{rootRun.name}</Typography>

--- a/sematic/ui/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/src/pipelines/PipelineIndex.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo } from "react";
 import { RunList } from "../components/RunList";
 import Tags from "../components/Tags";
 import { Run } from "../Models";
-import Link from "@mui/material/Link";
 import RunStateChip, { RunStateChipUndefinedStyle } from "../components/RunStateChip";
 import { Alert, AlertTitle, Container, containerClasses } from "@mui/material";
 import { InfoOutlined } from "@mui/icons-material";
@@ -17,6 +16,7 @@ import TimeAgo from "../components/TimeAgo";
 import { useFetchRuns } from "../hooks/pipelineHooks";
 import Loading from "../components/Loading";
 import { styled } from "@mui/system";
+import MuiRouterLink from "../components/MuiRouterLink";
 
 const RecentStatusesWithStyles = styled('span')`
   flex-direction: row;
@@ -86,9 +86,9 @@ function PipelineRow(props: { run: Run }) {
       <TableRow key={id}>
         <TableCell key="name" data-cy={"pipeline-row"}>
           <Box sx={{ mb: 3 }}>
-            <Link href={"/pipelines/" + calculator_path} underline="hover">
+            <MuiRouterLink href={"/pipelines/" + calculator_path} underline="hover">
               <Typography variant="h6">{name}</Typography>
-            </Link>
+            </MuiRouterLink>
             <CalculatorPath calculatorPath={calculator_path} />
           </Box>
           <Tags tags={tags || []} />

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -1,7 +1,6 @@
 import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 import Typography from "@mui/material/Typography";
-import Link from "@mui/material/Link";
 import { Run } from "../Models";
 import { RunList } from "../components/RunList";
 import RunStateChip from "../components/RunStateChip";
@@ -16,6 +15,7 @@ import { SearchOutlined } from "@mui/icons-material";
 import { styled } from "@mui/system";
 import { spacing } from "../utils";
 import { getRunUrlPattern } from "../hooks/pipelineHooks";
+import MuiRouterLink from "../components/MuiRouterLink";
 
 type RunRowProps = {
   run: Run;
@@ -48,9 +48,9 @@ export function RunRow(props: RunRowProps) {
         <Typography variant="h6">
           {props.noRunLink && run.name}
           {!props.noRunLink && (
-            <Link href={getRunUrlPattern(run.id)} underline="hover">
+            <MuiRouterLink href={getRunUrlPattern(run.id)} underline="hover">
               {run.name}
-            </Link>
+            </MuiRouterLink>
           )}
         </Typography>
         {calculatorPath}


### PR DESCRIPTION
Instead of using the default `<Link>` component from MUI for in-app links, change them to use Links from `react-router`, so when these links are clicked, there will be no full page reload. 

The component is implemented as a composition of the `<Link>` component from `MUI` and the one from  `react-router`. So the MUI styles will still apply. 


If interested, here is how React-router's `<Link>` changes the browser URL without reloading the page

https://github.com/remix-run/react-router/blob/2b843a6739c6807e683de9097e20909e78f0a1bd/packages/react-router-dom/index.tsx#L446-L473