### PR TITLE
Reference new support email

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -252,5 +252,5 @@ with nothing else on the line.
 * [0.0.2.alpha.1654828599](https://pypi.org/project/sematic/0.0.2a1654828599/)
     * Initial release
 
-[^1]: This feature is for Sematic's "Enterprise Edition" only. Please reach out if
-you are interested in using Sematic EE.
+[^1]: This feature is for Sematic's "Enterprise Edition" only. Please reach out
+to support@sematic.dev if you are interested in using Sematic EE.

--- a/docs/ray.md
+++ b/docs/ray.md
@@ -194,4 +194,5 @@ ray:
 ```
 
 [^1]: This feature of Sematic is only available with the "Enterprise Edition."
-Before using, please reach out to Sematic to obtain a license for "Sematic EE."
+Before using, please reach out to Sematic via support@sematic.dev to obtain a
+license for "Sematic EE."

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -139,7 +139,7 @@ parameter to
 
 ## FOSS to "Enterprise Edition"
 
-0. Reach out to Sematic to obtain a license for "Sematic EE."
+0. Reach out to Sematic via support@sematic.dev to obtain a license for "Sematic EE."
 1. In your helm deployment, change `image.repository` to `sematic/sematic-server-ee`.
 2. In your `pip` installation (client installation), change from depending on `sematic`
 to `sematic[<extra>]`, where `<extra>` is the appropriate variant of Sematic containing

--- a/sematic/ee/LICENSE
+++ b/sematic/ee/LICENSE
@@ -6,7 +6,7 @@ With regard to the Sematic Software:
 This software and associated documentation files (the "Software") may only be
 used in production, if you (and any entity that you represent) have agreed to,
 and are in compliance with, the Sematic Enterprise Terms of Service, available
-via email (emmanuel@sematic.dev) (the "Enterprise Terms"), or other
+via email (support@sematic.dev) (the "Enterprise Terms"), or other
 agreement governing the use of the Software, as agreed by you and Sematic,
 and otherwise have a valid Sematic Enterprise license for the
 correct usage volume. Subject to the foregoing sentence, you are free to

--- a/sematic/ee/README.md
+++ b/sematic/ee/README.md
@@ -2,5 +2,6 @@
 
 The code in this directory is only intended for usage with the paid version of
 Sematic. Please see the [LICENSE](./LICENSE) file for reference. Interested in
-using some of the features here? We'd love to hear from you! Reach out on our
+using some of the features here? We'd love to hear from you! Reach out to
+support@sematic.dev or on our
 [Discord channel](https://discord.gg/4KZJ6kYVax).

--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -216,7 +216,7 @@ export default function Home() {
           </Grid>
           <Typography paragraph sx={{ mt: 10 }}>
             Or email us at{" "}
-            <Link href="mailto:support@sematic.ai">support@sematic.ai</Link>.
+            <Link href="mailto:support@sematic.dev">support@sematic.dev</Link>.
           </Typography>
         </Grid>
       </Grid>


### PR DESCRIPTION
We have a lot of places where we tell people to reach out, but point them either to Discord or Emmanuel's email. Now that we're using support@sematic.dev , it's better to point them there.