### PR TITLE
Fix noop SQL migrations

### DIFF
--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -13,6 +13,7 @@ import functools
 import importlib
 import logging
 import os
+import re
 import subprocess
 from typing import List, Optional
 from urllib.parse import urlparse
@@ -111,8 +112,12 @@ def _run_sql_migration(
         )
 
     up_sql, down_sql = sql.split(_DOWN_MARKER)
-    up_sql = up_sql.split(_UP_MARKER)[1].strip()
-    down_sql = down_sql.strip()
+    # remove comments, in order to ensure commented-out statements are not considered
+    # otherwise, splitting by ";" will result in commented-out statements being executed,
+    # which will result in an error on Postgres
+    up_sql = up_sql.split(_UP_MARKER)[1]
+    up_sql = re.sub("-- .*\n?", "", up_sql).strip()
+    down_sql = re.sub("-- .*\n?", "", down_sql).strip()
 
     statements = (up_sql if direction == MigrationDirection.UP else down_sql).split(";")
 


### PR DESCRIPTION
On PostgreSQL, SQL migration scripts that contain commented-out statements fail:
```
INFO:root:Applying 20221004183943_remove_exception_from_runs.sql
ERROR:root:20221004183943_remove_exception_from_runs.sql failed with error:
(psycopg2.ProgrammingError) can't execute an empty query
[SQL: -- TODO #302: implement sustainable way to upgrade sqlite3 DBs
-- ALTER TABLE runs DROP COLUMN exception;]
(Background on this error at: https://sqlalche.me/e/14/f405)
Last successful migration is: 20220930014400_migrate_exception_data.py
```

This update eliminates comments from the parsed SQL migration statements, and introduces a unit test to validate the logic. The unit test was falsified by failing the un-patched version.
