### PR TITLE
Atomic database migrations with Helm hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-exclude = sematic/ui/node_modules
+exclude = sematic/ui/node_modules,.venv
 max-line-length=90

--- a/helm/sematic-server/templates/NOTES.txt
+++ b/helm/sematic-server/templates/NOTES.txt
@@ -1,7 +1,7 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.create }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
+Sematic dashboard url:
+{{- if .Values.ingress.create -}}
+{{- range $host := .Values.ingress.hosts -}}
+  {{- range .paths -}}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}

--- a/helm/sematic-server/templates/NOTES.txt
+++ b/helm/sematic-server/templates/NOTES.txt
@@ -1,5 +1,4 @@
-Sematic dashboard url: 
-{{- if .Values.ingress.create -}}
+Sematic dashboard url: {{ if .Values.ingress.create -}}
 {{- range $host := .Values.ingress.hosts -}}
   {{- range .paths -}}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}

--- a/helm/sematic-server/templates/NOTES.txt
+++ b/helm/sematic-server/templates/NOTES.txt
@@ -1,10 +1,10 @@
-Sematic dashboard url:
+Sematic dashboard url: 
 {{- if .Values.ingress.create -}}
 {{- range $host := .Values.ingress.hosts -}}
   {{- range .paths -}}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
-{{- end }}
+{{- end -}}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -19,4 +19,4 @@ Sematic dashboard url:
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+{{- end -}}

--- a/helm/sematic-server/templates/_helpers.tpl
+++ b/helm/sematic-server/templates/_helpers.tpl
@@ -7,7 +7,7 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | 
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end }}
 
 {{/*

--- a/helm/sematic-server/templates/migration-job.yaml
+++ b/helm/sematic-server/templates/migration-job.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "migration-{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-migration
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        command: ["sematic", "migrate"]

--- a/helm/sematic-server/templates/migration-job.yaml
+++ b/helm/sematic-server/templates/migration-job.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.database.auto_migrate }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}"
+  name: "migration-{{ .Release.Name }}"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -28,3 +29,4 @@ spec:
       - name: pre-install-migration
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["sematic", "migrate"]
+{{- end }}

--- a/helm/sematic-server/templates/migration-job.yaml
+++ b/helm/sematic-server/templates/migration-job.yaml
@@ -28,5 +28,5 @@ spec:
       containers:
       - name: pre-install-migration
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        command: ["sematic", "migrate"]
+        command: ["sematic", "--verbose", "migrate"]
 {{- end }}

--- a/helm/sematic-server/templates/migration-job.yaml
+++ b/helm/sematic-server/templates/migration-job.yaml
@@ -14,6 +14,7 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: "migration-{{ .Release.Name }}"

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -16,6 +16,7 @@ secret:
 
 database:
   url: postgres://postgresql:5432/postgres # REPLACE ME
+  auto_migrate: true
 
 deployment:
   socket_io:

--- a/sematic/cli/BUILD
+++ b/sematic/cli/BUILD
@@ -14,7 +14,6 @@ sematic_py_lib(
         ":settings",
         ":version",
         "//sematic/config:config",
-        "//sematic/db:migrate_lib",
         # Examples
         "//sematic/examples/template:template_lib",
         # These do not add dependencies on 3rd party packages
@@ -30,7 +29,9 @@ sematic_py_lib(
     pip_deps = [
         "click",
     ],
-    deps = [],
+    deps = [
+        "//sematic/db:migrate_lib",
+    ],
 )
 
 sematic_py_lib(

--- a/sematic/cli/cli.py
+++ b/sematic/cli/cli.py
@@ -10,7 +10,7 @@ from sematic.db.migrate import migrate_up
 
 
 @click.group("sematic")
-@click.option('-v', '--verbose', count=True)
+@click.option("-v", "--verbose", count=True)
 def cli(verbose: int):
     """
     Welcome to Sematic

--- a/sematic/cli/cli.py
+++ b/sematic/cli/cli.py
@@ -1,9 +1,17 @@
+# Standard Library
+import logging
+
 # Third-party
 import click
 
+# Sematic
+from sematic.config.config import switch_env
+from sematic.db.migrate import migrate_up
+
 
 @click.group("sematic")
-def cli():
+@click.option('-v', '--verbose', count=True)
+def cli(verbose: int):
     """
     Welcome to Sematic
 
@@ -13,7 +21,13 @@ def cli():
     Run an example:
         $ sematic run examples/mnist/pytorch
     """
-    pass
+    if verbose == 1:
+        logging.basicConfig(level=logging.INFO)
+    elif verbose > 1:
+        logging.basicConfig(level=logging.DEBUG)
+
+    switch_env("local")
+    migrate_up()
 
 
 @cli.group("advanced")

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -2,6 +2,10 @@
 from sematic.config.config import switch_env
 from sematic.db.migrate import migrate_up
 
+# Configure logging so that the migration container shows output
+import logging
+logging.basicConfig(level=logging.INFO)
+
 switch_env("local")
 migrate_up()
 

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -4,6 +4,7 @@ from sematic.db.migrate import migrate_up
 
 # Configure logging so that the migration container shows output
 import logging
+
 logging.basicConfig(level=logging.INFO)
 
 switch_env("local")

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -1,12 +1,11 @@
+# Standard Library
+import logging
+
 # Sematic
 from sematic.config.config import switch_env
 from sematic.db.migrate import migrate_up
 
-# Configure logging so that the migration container shows output
-import logging
-
 logging.basicConfig(level=logging.INFO)
-
 switch_env("local")
 migrate_up()
 

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -1,14 +1,3 @@
-# Standard Library
-import logging
-
-# Sematic
-from sematic.config.config import switch_env
-from sematic.db.migrate import migrate_up
-
-logging.basicConfig(level=logging.INFO)
-switch_env("local")
-migrate_up()
-
 # Sematic
 import sematic.cli.cancel  # noqa: F401, E402
 import sematic.cli.logs  # noqa: F401, E402


### PR DESCRIPTION
Resolve #588.

* Runs the migration as a separate container before starting api/socket servers.
* Does not start the servers if migration failed.
* Keeps the migration pod around in a Completed state until the next deploy so logs are accessible.
* Configured a logger explicitly since the CLI call doesn't.
* Cleaned up the Helm install notes a bit.