### PR TITLE
Integrate PostHog event capturing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
             - project/CIVENV
     environment:
       CI_VENV_NAME: CIVENV
+      REACT_APP_IS_CIRCLE_CI: 1
     
   
   integration-test:

--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -31,6 +31,7 @@
         "jotai-location": "^0.3.2",
         "mpld3": "^0.5.8",
         "plotly.js-cartesian-dist": "^2.12.1",
+        "posthog-js": "^1.45.1",
         "react": "^18.1.0",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.1.0",
@@ -3804,6 +3805,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmmirror.com/@sentry/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.23.5",
@@ -9781,6 +9790,11 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -16735,6 +16749,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/posthog-js": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmmirror.com/posthog-js/-/posthog-js-1.45.1.tgz",
+      "integrity": "sha512-dHB0agl9qc/PIhHhfnJB4hxzcO/wBS8z7U2OLrAAAyrmWU+3K1XnIipyZX3tEFq6hk1yL+tJuidBw+gqgMvo4g==",
+      "dependencies": {
+        "@sentry/types": "7.22.0",
+        "fflate": "^0.4.1",
+        "rrweb-snapshot": "^1.1.14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18061,6 +18085,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmmirror.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz",
+      "integrity": "sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ=="
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.0",
@@ -23522,6 +23551,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
+    "@sentry/types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmmirror.com/@sentry/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q=="
+    },
     "@sinclair/typebox": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
@@ -28080,6 +28114,11 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "figures": {
       "version": "3.2.0",
@@ -32849,6 +32888,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "posthog-js": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmmirror.com/posthog-js/-/posthog-js-1.45.1.tgz",
+      "integrity": "sha512-dHB0agl9qc/PIhHhfnJB4hxzcO/wBS8z7U2OLrAAAyrmWU+3K1XnIipyZX3tEFq6hk1yL+tJuidBw+gqgMvo4g==",
+      "requires": {
+        "@sentry/types": "7.22.0",
+        "fflate": "^0.4.1",
+        "rrweb-snapshot": "^1.1.14"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -33822,6 +33871,11 @@
           }
         }
       }
+    },
+    "rrweb-snapshot": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmmirror.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz",
+      "integrity": "sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ=="
     },
     "rtl-css-js": {
       "version": "1.16.0",

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -50,9 +50,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "REACT_APP_HOST=127.0.0.1 react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "REACT_APP_HOST=127.0.0.1 REACT_APP_GIT_HASH=$(git rev-parse --short HEAD) react-scripts start",
+    "build": "REACT_APP_GIT_HASH=$(git rev-parse --short HEAD) react-scripts build",
+    "test": "REACT_APP_GIT_HASH=$(git rev-parse --short HEAD) react-scripts test",
     "eject": "react-scripts eject",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "lint:app": "eslint --config node_modules/eslint-config-react-app/index.js --ext .ts,.tsx --max-warnings=0 ./src",

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -27,6 +27,7 @@
     "jotai-location": "^0.3.2",
     "mpld3": "^0.5.8",
     "plotly.js-cartesian-dist": "^2.12.1",
+    "posthog-js": "^1.45.1",
     "react": "^18.1.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.1.0",

--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -19,6 +19,7 @@ import {
 import { SiDiscord, SiReadthedocs, SiGithub } from "react-icons/si";
 import { UserContext } from ".";
 import RunStateChip from "./components/RunStateChip";
+import TrackingNotice from "./components/TrackingNotice";
 import { useFetchRuns } from "./hooks/pipelineHooks";
 
 function ShellCommand(props: { command: string }) {
@@ -83,11 +84,12 @@ export default function Home() {
     </Typography>;
   }, [isLoaded, runs]);
 
+  const theme = useTheme();
+
   const h1 = user ? "Hi " + user.first_name : "Welcome to Sematic";
 
   return (
-    <Container sx={{ pt: 10, height: "100vh", overflowY: "scroll" }}>
-      {/*sx={{ pt: 20, mx: 5, height: "100vh", overflowY: "scroll" }}>*/}
+    <Container sx={{ pt: 10, height: "100vh" }}>
       <Typography variant="h1">{h1}</Typography>
       <Box sx={{ mt: 15, mb: 10, minHeight: "1px" }}>
         {!!error && <Alert severity="error">
@@ -220,6 +222,7 @@ export default function Home() {
           </Typography>
         </Grid>
       </Grid>
+      <TrackingNotice sx={{pr: `${theme.spacing(4)}!important`}}/>
     </Container>
   );
 }

--- a/sematic/ui/src/Payloads.tsx
+++ b/sematic/ui/src/Payloads.tsx
@@ -76,6 +76,13 @@ export type EnvPayload = {
   env: { [k: string]: string };
 };
 
+export type SemanticVersion = [number, number, number];
+
+export interface VersionPayload {
+  min_client_supported: SemanticVersion;
+  server: SemanticVersion;
+} 
+
 type Operator = "eq";
 
 type FilterCondition = {

--- a/sematic/ui/src/components/TrackingNotice.tsx
+++ b/sematic/ui/src/components/TrackingNotice.tsx
@@ -1,0 +1,106 @@
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import { styled } from "@mui/system";
+import Link from "@mui/material/Link/Link"
+import Button from "@mui/material/Button/Button"
+import Dialog from "@mui/material/Dialog/Dialog"
+import DialogActions from "@mui/material/DialogActions/DialogActions"
+import { alertClasses, DialogContent, DialogContentText, DialogTitle, FormGroup, FormControlLabel, Checkbox } from "@mui/material";
+import React, { useState, useMemo, useCallback } from "react";
+import { spacing } from "../utils";
+import { applyPostHogOptOutSetting, optOutStorageKey } from "../postHogManager"
+
+const PageFooterContainer = styled('div', {
+  shouldForwardProp: () => true
+})`
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: fit-content;
+
+  & .${alertClasses.root}:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+`;
+
+const StyledNoticeText = styled('div')`
+  padding: ${spacing(2)};
+  cursor: pointer;
+  color: ${({theme}) => theme.palette.grey[100]}
+`;
+
+const optOutSetting = atomWithStorage<boolean | null>(optOutStorageKey, null);
+
+interface TrackingNoticeProps {
+  sx?: React.ComponentProps<typeof PageFooterContainer>['sx'];
+}
+
+export default function TrackingNotice({ sx }: TrackingNoticeProps) {
+  const [open, setOpen] = useState(false);
+  const [attempt, setAttempt] = useState<number>(0);
+  const [optOut, setOptOut] = useAtom(optOutSetting);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const hasUserOptout = useMemo(() => {
+    if (optOut === null) {
+      if (!!(navigator as unknown as any)['globalPrivacyControl']) {
+        return true;
+      }
+    } else {
+      return optOut;
+    }
+    return false;
+  }, [attempt, optOut]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const flipOptOutState = useCallback(() => {
+    const shouldUserOptout = !hasUserOptout;
+    setOptOut(shouldUserOptout);
+    applyPostHogOptOutSetting(shouldUserOptout);
+    setAttempt(value => value + 1);
+  }, [hasUserOptout, setOptOut]);
+
+  return <PageFooterContainer sx={sx}>
+    <StyledNoticeText onClick={() => setOpen(true)}>
+      Anonymous Usage Tracking Policy
+    </StyledNoticeText>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="scroll-dialog-title"
+      aria-describedby="scroll-dialog-description"
+    >
+      <DialogTitle id="scroll-dialog-title">Anonymous Usage Tracking Policy</DialogTitle>
+      <DialogContent>
+        <DialogContentText
+          id="scroll-dialog-description"
+          component={'div'}
+        >
+          <p>In order for Sematic to continuously improve its user experience, and measure the size of the community, minimal anonymous analytics are collected. </p>
+          <p>Sematic counts unique sessions of this web app in a completely anonymous way. No information identifying the user or the host machine are collected. The Sematic backend does not track anything.</p>
+          <p>If you want to opt-out, simply uncheck the box below.</p>
+        </DialogContentText>
+        <FormGroup>
+          <FormControlLabel control={<Checkbox checked={!hasUserOptout}
+            onClick={flipOptOutState} />}
+            label="I am ok with Sematic collecting anonymous usage analytics." />
+        </FormGroup>
+        <DialogContentText>
+          If you have any questions, reach out to us on
+          <Link
+            href="https://discord.gg/PFCpatvy"
+            underline="none"
+            target="_blank"
+          > Discord </Link> or at&nbsp; 
+          <Link href="mailto:support@sematic.dev">support@sematic.dev</Link>.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Ok</Button>
+      </DialogActions>
+    </Dialog>
+  </PageFooterContainer>
+}

--- a/sematic/ui/src/components/TrackingNotice.tsx
+++ b/sematic/ui/src/components/TrackingNotice.tsx
@@ -5,7 +5,7 @@ import Link from "@mui/material/Link/Link"
 import Button from "@mui/material/Button/Button"
 import Dialog from "@mui/material/Dialog/Dialog"
 import DialogActions from "@mui/material/DialogActions/DialogActions"
-import { alertClasses, DialogContent, DialogContentText, DialogTitle, FormGroup, FormControlLabel, Checkbox } from "@mui/material";
+import { DialogContent, DialogContentText, DialogTitle, FormGroup, FormControlLabel, Checkbox } from "@mui/material";
 import React, { useState, useMemo, useCallback } from "react";
 import { spacing } from "../utils";
 import { applyPostHogOptOutSetting, optOutStorageKey } from "../postHogManager"
@@ -17,17 +17,12 @@ const PageFooterContainer = styled('div', {
   bottom: 0;
   right: 0;
   width: fit-content;
-
-  & .${alertClasses.root}:hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
 `;
 
 const StyledNoticeText = styled('div')`
   padding: ${spacing(2)};
   cursor: pointer;
-  color: ${({theme}) => theme.palette.grey[100]}
+  color: ${({theme}) => theme.palette.grey[400]}
 `;
 
 const optOutSetting = atomWithStorage<boolean | null>(optOutStorageKey, null);

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -21,6 +21,7 @@ import {
   AuthenticatePayload,
   EnvPayload,
   GoogleLoginPayload,
+  VersionPayload,
 } from "./Payloads";
 import { User } from "./Models";
 import { Alert, Paper } from "@mui/material";
@@ -189,11 +190,13 @@ function Router() {
   const currentUrl = new URL(window.location.toString());
   const currentHostName = await sha1(currentUrl.hostname);
 
+  const versionResponse: VersionPayload = await (await fetch("/api/v1/meta/versions")).json();
+  const serverVersion = versionResponse.server.join('.');
+
   posthog.init( 
     'phc_nJlFf7MpsrzF5pPaSEQi5GKyTSDjHRcqqL808VLRNXc', { 
       api_host: 'https://app.posthog.com',
       autocapture: false,
-      debug: true,
       disable_session_recording: true,
       capture_pageview: false,
       capture_pageleave: false,
@@ -220,6 +223,12 @@ function Router() {
         if ('$host' in properties) {
           properties['$host'] = currentUrl.host;
         }
+
+        Object.assign(properties, {
+          SERVER_VERSION: serverVersion,
+          GIT_HASH: process.env.REACT_APP_GIT_HASH,
+          NODE_ENV: process.env.NODE_ENV,
+        })
 
         return properties;
       }

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -228,6 +228,7 @@ function Router() {
           SERVER_VERSION: serverVersion,
           GIT_HASH: process.env.REACT_APP_GIT_HASH,
           NODE_ENV: process.env.NODE_ENV,
+          CIRCLECI: process.env.REACT_APP_IS_CIRCLE_CI !== undefined
         })
 
         return properties;

--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from "react-dom/client";
+import posthog, { Properties } from 'posthog-js';
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
@@ -24,10 +25,11 @@ import {
 import { User } from "./Models";
 import { Alert, Paper } from "@mui/material";
 import logo from "./Fox.png";
-import { fetchJSON } from "./utils";
+import { fetchJSON, sha1 } from "./utils";
 import { SnackBarProvider } from "./components/SnackBarProvider";
 import PipelineView from "./pipelines/PipelineView";
 import { RunIndex } from "./runs/RunIndex";
+import { setupPostHogOptout } from "./postHogManager";
 
 export const UserContext = React.createContext<{
   user: User | null;
@@ -182,6 +184,49 @@ function Router() {
 
   return <RouterProvider router={router} />;
 }
+
+(async () => {
+  const currentUrl = new URL(window.location.toString());
+  const currentHostName = await sha1(currentUrl.hostname);
+
+  posthog.init( 
+    'phc_nJlFf7MpsrzF5pPaSEQi5GKyTSDjHRcqqL808VLRNXc', { 
+      api_host: 'https://app.posthog.com',
+      autocapture: false,
+      debug: true,
+      disable_session_recording: true,
+      capture_pageview: false,
+      capture_pageleave: false,
+      persistence: "localStorage",
+      property_blacklist: [
+        '$referrer', '$referring_domain', '$initial_current_url', '$initial_referrer',
+        '$initial_referring_domain'
+      ],
+      loaded: () => {
+        setupPostHogOptout();
+        posthog.capture('$pageview');
+      },
+
+      sanitize_properties: (properties: Properties, event_name: string) => {
+        const currentUrl = new URL(window.location.toString());
+
+        // Use obfuscated host name
+        currentUrl.hostname = currentHostName;
+
+        if ('$current_url' in properties) {
+          properties['$current_url'] = currentUrl.toString();
+        }
+
+        if ('$host' in properties) {
+          properties['$host'] = currentUrl.host;
+        }
+
+        return properties;
+      }
+    }
+);
+
+})();
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/sematic/ui/src/postHogManager.ts
+++ b/sematic/ui/src/postHogManager.ts
@@ -1,0 +1,27 @@
+import posthog from 'posthog-js';
+
+export const optOutStorageKey = 'posthog_opt_out';
+
+export function setupPostHogOptout() {
+    let shouldUserOptout = false;
+
+    const optOutValue = window.localStorage.getItem(optOutStorageKey);
+        
+    if (optOutValue === null) {
+        if (!!(navigator as unknown as any)['globalPrivacyControl']) {
+            shouldUserOptout = true;
+        }
+    } else {
+        shouldUserOptout = (optOutValue === 'true');
+    }
+
+    applyPostHogOptOutSetting(shouldUserOptout);
+}
+
+export function applyPostHogOptOutSetting(shouldUserOptout: boolean) {
+    if (shouldUserOptout) {
+        posthog.has_opted_in_capturing() && posthog.opt_out_capturing();
+    } else {
+        posthog.has_opted_out_capturing() && posthog.opt_in_capturing();
+    }
+}

--- a/sematic/ui/src/runs/RunIndex.tsx
+++ b/sematic/ui/src/runs/RunIndex.tsx
@@ -95,7 +95,7 @@ const StyledScroller = styled(Container)`
     display: flex;
     flex-direction: row;
 
-    & > :first-child {
+    & > *:first-of-type {
       padding-right: ${spacing(10)};
       flex-grow: 1
     }

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -100,3 +100,13 @@ export const graphSocket = io("/graph");
 export const pipelineSocket = io("/pipeline");
 
 export const spacing = (val: number) => ({theme}: any) => theme.spacing(val);
+
+export async function sha1(text: string) {
+  const utf8 = new TextEncoder().encode(text);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', utf8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((bytes) => bytes.toString(16).padStart(2, '0'))
+    .join('');
+  return hashHex;
+}


### PR DESCRIPTION
1. Tracks open load events by leveraging the PostHog platform.
2. Provide a UI for the user to opt out of event capturing.
3. The implementation also respects the settings of `globalPrivacyControl` if a user has not explicitly set the output config yet. 

![capture1](https://user-images.githubusercontent.com/1046489/219816059-ace64c8e-89dc-4cb4-aae8-ba044c090406.gif)


Testing: manually set `globalPrivacyControl` and saw the localStorage value overrides that. Also saw `globalPrivacyControl` takes effect if localStorage is empty.

Closes #591 