### PR TITLE
Actually fail migrations and don't force local

### DIFF
--- a/helm/sematic-server/templates/migration-job.yaml
+++ b/helm/sematic-server/templates/migration-job.yaml
@@ -27,6 +27,9 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-install-migration
+        envFrom:
+        - secretRef:
+            name: {{ .Release.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        command: ["sematic", "--verbose", "migrate"]
+        command: ["python3", "-m", "sematic.db.migrate", "up", "--verbose", "--env", "cloud"]
 {{- end }}

--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -235,7 +235,7 @@ def migrate_up():
                 f"{e}\n"
                 f"Last successful migration is: {last_successful}"
             )
-            return
+            raise e
 
         last_successful = migration_file
 


### PR DESCRIPTION
- failed migrations now reraise their exceptions all the way out
- migration job container now has access to the db url secret
- migration job now runs from the interpreter rather than cli, mirroring how the api server runs in docker