### PR TITLE
Correct rerun documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -93,9 +93,9 @@ input arguments and output value are tracked as artifacts.
     
     When `None`, the pipeline is resolved from scratch, as normally. When not `None`,
     must be the id of a `Run` from a previous resolution. Instead of running from
-    scratch, parts of that previous resolution is cloned up until and including the
-    specified `Run`, and only nested and downstream `Future`s are executed. This is
-    meant to be used for retries or for hotfixes, without needing to re-run the
+    scratch, parts of that previous resolution is cloned up until the specified `Run`,
+    and only the specified `Run`, nested and downstream `Future`s are executed. This
+    is meant to be used for retries or for hotfixes, without needing to re-run the
     entire pipeline again.
 
 ### `CloudResolver`
@@ -132,9 +132,9 @@ Resolves a pipeline on a Kubernetes cluster.
 
     When `None`, the pipeline is resolved from scratch, as normally. When not `None`,
     must be the id of a `Run` from a previous resolution. Instead of running from
-    scratch, parts of that previous resolution is cloned up until and including the
-    specified `Run`, and only nested and downstream `Future`s are executed. This is
-    meant to be used for retries or for hotfixes, without needing to re-run the
+    scratch, parts of that previous resolution is cloned up until the specified `Run`,
+    and only the specified `Run`, nested and downstream `Future`s are executed. This
+    is meant to be used for retries or for hotfixes, without needing to re-run the
     entire pipeline again.
 
 ### `SilentResolver`

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -73,9 +73,9 @@ class CloudResolver(LocalResolver):
     rerun_from: Optional[str]
         When `None`, the pipeline is resolved from scratch, as normally. When not `None`,
         must be the id of a `Run` from a previous resolution. Instead of running from
-        scratch, parts of that previous resolution is cloned up until and including the
-        specified `Run`, and only nested and downstream `Future`s are executed. This is
-        meant to be used for retries or for hotfixes, without needing to re-run the
+        scratch, parts of that previous resolution is cloned up until the specified `Run`,
+        and only the specified `Run`, nested and downstream `Future`s are executed. This
+        is meant to be used for retries or for hotfixes, without needing to re-run the
         entire pipeline again.
     _is_running_remotely: bool
         For Sematic internal usage. End users should always leave this at the default

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -55,9 +55,9 @@ class LocalResolver(SilentResolver):
     rerun_from: Optional[str]
         When `None`, the pipeline is resolved from scratch, as normally. When not `None`,
         must be the id of a `Run` from a previous resolution. Instead of running from
-        scratch, parts of that previous resolution is cloned up until and including the
-        specified `Run`, and only nested and downstream `Future`s are executed. This is
-        meant to be used for retries or for hotfixes, without needing to re-run the
+        scratch, parts of that previous resolution is cloned up until the specified `Run`,
+        and only the specified `Run`, nested and downstream `Future`s are executed. This
+        is meant to be used for retries or for hotfixes, without needing to re-run the
         entire pipeline again.
     """
 


### PR DESCRIPTION
The rerun documentation was mentioning in a few places that the rerun-from-here run was not rerun itself, [which is incorrect](https://github.com/sematic-ai/sematic/blob/3a5bfeee684e7ccbc62f50ed3f247ceb69a4f6c0/sematic/graph.py#L366).

Updated the documentation and code comments in question.