### PR TITLE
Sort run tree nodes

### DIFF
--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "ui",
       "version": "0.1.0",
+      "workspaces": [
+        "tests"
+      ],
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -20210,6 +20213,10 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ui-test": {
+      "resolved": "tests",
+      "link": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -21509,6 +21516,12 @@
           "optional": true
         }
       }
+    },
+    "tests": {
+      "name": "ui-test",
+      "version": "0.1.0",
+      "license": "ISC",
+      "devDependencies": {}
     }
   },
   "dependencies": {
@@ -35949,6 +35962,9 @@
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+    },
+    "ui-test": {
+      "version": "file:tests"
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -92,5 +92,8 @@
     "@types/uuid": "^8.3.4",
     "cypress": "^12.5.0",
     "eslint-plugin-cypress": "^2.12.1"
-  }
+  },
+  "workspaces": [
+    "tests"
+  ]
 }

--- a/sematic/ui/src/components/tests/test_RunStateChip.cy.tsx
+++ b/sematic/ui/src/components/tests/test_RunStateChip.cy.tsx
@@ -1,5 +1,5 @@
 import RunStateChip from "../RunStateChip";
-import run from "../../../tests/fixtures/run.js";
+import run from "ui-test/fixtures/run";
 
 describe('RunStateChip component', () => {
     it("should render", () => {

--- a/sematic/ui/src/hooks/graphHooks.ts
+++ b/sematic/ui/src/hooks/graphHooks.ts
@@ -87,6 +87,33 @@ export function useGraph(runRootId: string): [
     return [graph, loading, error];
 }
 
+/**
+ * Sort the run tree by start time.
+ * @param rootTreeNode 
+ */
+function sortRunTree(rootTreeNode: RunTreeNode) {
+    const queue = [rootTreeNode];
+    while (queue.length > 0) {
+        const treeNode = queue.shift()!;
+        treeNode.children.sort((a, b) => {
+            const aRun = a.run!;
+            const bRun = b.run!;
+
+            const aCreatedTime = new Date(aRun.created_at);
+            const bCreatedTime = new Date(bRun.created_at);
+
+            if (aCreatedTime < bCreatedTime) {
+                return 1;
+            } else if (aCreatedTime > bCreatedTime) {
+                return -1;
+            } else {
+                return 0;
+            }
+        });
+        queue.push(...treeNode.children);
+    }
+}
+
 export function useRunsTree(graph: Graph | undefined) {
     return useMemo(() => {
         if (!graph) {
@@ -110,6 +137,7 @@ export function useRunsTree(graph: Graph | undefined) {
             const treeNode = runTreeNodeMappinng.get(id);
             parentNode!.children.push(treeNode!);
         });
+        sortRunTree(rootTreeNode);
         return rootTreeNode;
     }, [graph]);
 }

--- a/sematic/ui/src/hooks/tests/test_graphHooks.cy.tsx
+++ b/sematic/ui/src/hooks/tests/test_graphHooks.cy.tsx
@@ -1,0 +1,74 @@
+import { Graph, RunTreeNode } from "../../interfaces/graph";
+import { useRunsTree } from "../graphHooks";
+import { createRun } from "ui-test/support/utils"
+
+describe('useRunsTree hook', () => {
+    it("create a run tree from graph data", () => {
+        const graph: Graph = {
+            runs: [
+                createRun({ id: "1", name: "run1", created_at: new Date("2021-01-01T00:00:00Z") }),
+                createRun({ id: "4", name: "run4", created_at: new Date("2021-01-01T00:00:15Z") }),
+                createRun({ id: "3", name: "run3", created_at: new Date("2021-01-01T00:00:10Z") }),
+                createRun({ id: "2", name: "run2", created_at: new Date("2021-01-01T00:00:05Z") }),
+                createRun({ id: "5", name: "run5", created_at: new Date("2021-01-01T00:01:05Z"), parent_id: "2" }),
+                createRun({ id: "7", name: "run7", created_at: new Date("2021-01-01T00:01:25Z"), parent_id: "2" }),
+                createRun({ id: "6", name: "run6", created_at: new Date("2021-01-01T00:01:15Z"), parent_id: "2" }),
+                createRun({ id: "8", name: "run8", created_at: new Date("2021-01-01T00:02:00Z"), parent_id: "4" }),
+            ],
+            runsById: null as any,
+            edges: null as any,
+            artifacts: null as any,
+            artifactsById: null as any,
+        };
+
+        let runTree: RunTreeNode | undefined
+
+        const TestComponent = () => {
+            runTree = useRunsTree(graph);
+            return <></>;
+        };
+
+        cy.mount(<TestComponent />);
+        cy.wait(0).then(() => {
+            expect(runTree).to.eql({
+                run: null,
+                children: [
+                    {
+                        run: graph.runs[1],
+                        children: [
+                            {
+                                run: graph.runs[7],
+                                children: [],
+                            },
+                        ],
+                    },
+                    {
+                        run: graph.runs[2],
+                        children: [],
+                    },
+                    {
+                        run: graph.runs[3],
+                        children: [
+                            {
+                                run: graph.runs[5],
+                                children: [],
+                            },
+                            {
+                                run: graph.runs[6],
+                                children: [],
+                            },
+                            {
+                                run: graph.runs[4],
+                                children: [],
+                            },
+                        ],
+                    },
+                    {
+                        run: graph.runs[0],
+                        children: [],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/sematic/ui/tests/fixtures/run.ts
+++ b/sematic/ui/tests/fixtures/run.ts
@@ -14,7 +14,7 @@ export default {
     "name": "Basic add example pipeline",
     "nested_future_id": "dc9203e31c764656a424a2c274ba40c0",
     "original_run_id": null,
-    "parent_id": null,
+    "parent_id": null as string | null,
     "resolved_at": new Date("2023-02-03T16:52:13.146034+00:00"),
     "resource_requirements_json": null,
     "root_id": "e5a0aca06816414fa6fd2ffa0649ea6d",
@@ -25,5 +25,7 @@ export default {
         "basic",
         "final"
     ],
-    "updated_at": new Date("2023-02-03T16:51:47.578636+00:00")
+    "updated_at": new Date("2023-02-03T16:51:47.578636+00:00"),
+    "user": null as any,
+    "user_id": "uid" as string | null
 }

--- a/sematic/ui/tests/package.json
+++ b/sematic/ui/tests/package.json
@@ -1,4 +1,8 @@
 {
   "name": "ui-test",
-  "version": "0.0.1"
+  "version": "0.1.0",
+  "description": "UI test library",
+  "devDependencies": {},
+  "author": "",
+  "license": "ISC"
 }

--- a/sematic/ui/tests/support/utils.ts
+++ b/sematic/ui/tests/support/utils.ts
@@ -1,0 +1,8 @@
+import run from '../fixtures/run';
+
+export function createRun(props: Partial<typeof run> = {}) {
+    return {
+        ...run,
+        ...props
+    };
+}

--- a/sematic/ui/tsconfig.json
+++ b/sematic/ui/tsconfig.json
@@ -6,6 +6,7 @@
       "dom.iterable",
       "esnext"
     ],
+    "baseUrl": "./",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Sort the nested runs under the same parent run by their `created_at` field.

Added unit test for the sorting logic.

This is a fix to a regression issue.

before 
<img width="261" alt="image" src="https://user-images.githubusercontent.com/1046489/221725583-9252dff5-41cf-4620-b993-e0b58731939b.png">

after:

<img width="249" alt="image" src="https://user-images.githubusercontent.com/1046489/221725783-21ab4e90-db87-4abe-8e6c-51648b3073e3.png">

which matches the DAG more closely.


