### PR TITLE
Remove hash from URL in telemetry

### DIFF
--- a/sematic/ui/src/index.tsx
+++ b/sematic/ui/src/index.tsx
@@ -126,6 +126,7 @@ function Router() {
         // Use obfuscated host name
         currentUrl.hostname = currentHostName;
         currentUrl.pathname = '[redacted]';
+        currentUrl.hash = '';
 
         if ('$current_url' in properties) {
           properties['$current_url'] = currentUrl.toString();


### PR DESCRIPTION
Remove the hash portion from URL in telemetry reporting

<img width="616" alt="image" src="https://user-images.githubusercontent.com/1046489/221996883-afecf025-3d99-40d4-8f53-3af79e6ee381.png">
