### PR TITLE
Add run owner info on the run details page

### DIFF
--- a/sematic/ui/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/src/pipelines/PipelineBar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import { useCallback, useContext, useEffect, useMemo } from "react";
 import { Resolution, Run } from "../Models";
-import { fetchJSON } from "../utils";
+import { abbreviatedUserName, fetchJSON } from "../utils";
 import CalculatorPath from "../components/CalculatorPath";
 import GitInfoBox from "../components/GitInfo";
 import Loading from "../components/Loading";
@@ -269,6 +269,9 @@ export default function PipelineBar() {
                       <Typography sx={{ fontSize: "small", color: "GrayText" }}>
                         <code>{id.substring(0, 6)}</code>
                       </Typography>
+                    </Box>
+                    <Box sx={{ml: 3}}>
+                      {abbreviatedUserName(run.user)}
                     </Box>
                     <Box ml={3}>
                       <TimeAgo date={created_at} />

--- a/sematic/ui/src/tests/test_utils.cy.ts
+++ b/sematic/ui/src/tests/test_utils.cy.ts
@@ -1,8 +1,18 @@
-import { sha1 } from "../utils";
+import { abbreviatedUserName, sha1 } from "../utils";
+import user from "ui-test/fixtures/user";
 
 describe('sha1', () => {
     it("should calculate sha1 value from string", async () => {
         expect(await sha1("localhost")).to.equal("334389048b872a533002b34d73f8c29fd09efc50");
         expect(await sha1("127.0.0.1")).to.equal("4b84b15bff6ee5796152495a230e45e3d7e947d9");
+    });
+});
+
+describe('abbreviatedUserName()', () => {
+    it("should generate abbreviated user name with User data", () => {
+        expect(abbreviatedUserName(user)).to.equal("Grace H.");
+    });
+    it("should return empty string when the parameter is not provided", () => {
+        expect(abbreviatedUserName(null)).to.equal("");
     });
 });

--- a/sematic/ui/src/utils.tsx
+++ b/sematic/ui/src/utils.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { atomWithHash } from 'jotai-location'
 import { useLocation } from "react-router-dom";
+import { User } from "./Models";
 
 interface IFetchJSON {
   url: string;
@@ -103,4 +104,14 @@ export async function sha1(text: string) {
     .map((bytes) => bytes.toString(16).padStart(2, '0'))
     .join('');
   return hashHex;
+}
+
+
+export function abbreviatedUserName(user: User | null): string {
+  if (!user) {
+    return "";
+  }
+  const {first_name, last_name} = user;
+
+  return `${first_name} ${(last_name || "").substring(0, 1)}.`
 }

--- a/sematic/ui/tests/fixtures/user.ts
+++ b/sematic/ui/tests/fixtures/user.ts
@@ -1,0 +1,12 @@
+const user = {
+    "avatar_url": "https://cdn.pixabay.com/photo/2017/01/31/19/07/avatar-2026510_960_720.png",
+    "created_at": "2023-02-21T17:32:29.399110+00:00",
+    "first_name": "Grace",
+    "id": "618eabb2b86411edafa10242ac120002",
+    "last_name": "Hopper",
+    "updated_at": "2023-02-28T21:32:02.499142+00:00",
+    "email": "",
+    "api_key": null
+  }
+
+export default user;


### PR DESCRIPTION
The run details page now shows the information of the user who launched the pipeline.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/1046489/222259802-d75b5133-40f4-451a-9f41-18d24780383d.png">

Closes #617