### PR TITLE
Additional APIs for the `S3Location` type

### DIFF
--- a/sematic/types/types/aws/s3.py
+++ b/sematic/types/types/aws/s3.py
@@ -55,3 +55,51 @@ class S3Location:
         return S3Location(
             bucket=S3Bucket(name=split_uri.netloc, region=region), location=location
         )
+
+    @property
+    def parent_directory(self) -> "S3Location":
+        """
+        The S3Location of the parent directory.
+
+        If current location is a file, the parent directory is the directory in
+        which the file is stored. If the current location is a directory, the
+        parent directory is its parent directory.
+
+        Returns
+        -------
+        S3Location
+        """
+        location = self.location[:-1] if self.location[-1] == "/" else self.location
+        location_parts = location.split("/")
+
+        return S3Location(bucket=self.bucket, location="/".join(location_parts[:-1]))
+
+    def sibling_location(self, location: str) -> "S3Location":
+        """
+        A location in the same parent directory as the current location.
+
+        Returns
+        -------
+        S3Location
+        """
+        return S3Location(
+            bucket=self.bucket,
+            location="/".join([self.parent_directory.location, location]),
+        )
+
+    def child_location(self, location: str) -> "S3Location":
+        """
+        A location under the current location.
+
+        Returns
+        -------
+        S3Location
+        """
+        child_location = self.location
+        if not child_location.endswith("/"):
+            child_location = child_location + "/"
+
+        return S3Location(bucket=self.bucket, location=f"{child_location}{location}")
+
+    def __truediv__(self, location: str) -> "S3Location":
+        return self.child_location(location)

--- a/sematic/types/types/aws/tests/test_s3.py
+++ b/sematic/types/types/aws/tests/test_s3.py
@@ -2,7 +2,7 @@
 import pytest
 
 # Sematic
-from sematic.types.types.aws.s3 import S3Location
+from sematic.types.types.aws.s3 import S3Bucket, S3Location
 
 
 @pytest.mark.parametrize(
@@ -32,3 +32,66 @@ def test_from_uri(uri, bucket_name, region, location):
     assert s3_location.bucket.name == bucket_name
     assert s3_location.bucket.region == region
     assert s3_location.location == location
+
+
+@pytest.mark.parametrize(
+    "current_location, parent_directory", (("foo/bar", "foo"), ("foo/bar/", "foo"))
+)
+def test_parent_directory(current_location, parent_directory):
+    location = S3Location(
+        bucket=S3Bucket(name="bucket"),
+        location=current_location,
+    )
+
+    parent_location = location.parent_directory
+
+    assert parent_location.bucket == location.bucket
+    assert parent_location.location == parent_directory
+
+
+@pytest.mark.parametrize(
+    "current_location, sibling_location",
+    (("foo/bar", "foo/bat"), ("foo/bar/", "foo/bat")),
+)
+def test_sibling_location(current_location, sibling_location):
+    location = S3Location(
+        bucket=S3Bucket(name="bucket"),
+        location=current_location,
+    )
+
+    sibling = location.sibling_location("bat")
+
+    assert sibling.bucket == location.bucket
+    assert sibling.location == sibling_location
+
+
+@pytest.mark.parametrize(
+    "current_location, sibling_location",
+    (("foo/bar", "foo/bar/bat"), ("foo/bar/", "foo/bar/bat")),
+)
+def test_child_location(current_location, sibling_location):
+    location = S3Location(
+        bucket=S3Bucket(name="bucket"),
+        location=current_location,
+    )
+
+    sibling = location.child_location("bat")
+
+    assert sibling.bucket == location.bucket
+    assert sibling.location == sibling_location
+
+
+@pytest.mark.parametrize(
+    "current_location, sibling_location",
+    (("foo/bar", "foo/bar/bat"), ("foo/bar/", "foo/bar/bat")),
+)
+def test_div(current_location, sibling_location):
+    location = S3Location(
+        bucket=S3Bucket(name="bucket"),
+        location=current_location,
+    )
+
+    sibling = location / "bat"
+
+    assert sibling.bucket == location.bucket
+    assert sibling.location == sibling_location


### PR DESCRIPTION
```
>>> S3Location.from_uri("s3://bucket/foo/bar").parent_directory.location
"foo"

>>> S3Location.from_uri("s3://bucket/foo/bar").sibling_location("bat").location
"foo/bat"

>>> S3Location.from_uri("s3://bucket/foo/bar").child_location("bat").location
"foo/bar/bat"

>>> (S3Location.from_uri("s3://bucket/foo/bar") / "bat").location
"foo/bar/bat"
```
