### PR TITLE
Log message to be used for pipeline stats

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -77,6 +77,11 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
 
     resolution_json_encodable = flask.request.json["resolution"]
     resolution = Resolution.from_json_encodable(resolution_json_encodable)
+    logger.info(
+        "Attempting to update resolution %s. Status: %s",
+        resolution.root_id,
+        resolution.status,
+    )
 
     if user is not None:
         resolution.user_id = user.id
@@ -114,8 +119,10 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
     except NoResultFound:
         existing_resolution = None
 
+    previous_status = None
     try:
         if existing_resolution is not None:
+            previous_status = existing_resolution.status
             # This field is scrubbed on read, but should be immutable.
             # ignore whatever the caller sent back this time.
             resolution.settings_env_vars = existing_resolution.settings_env_vars
@@ -128,6 +135,21 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
     if ResolutionStatus[resolution.status].is_terminal():
+        if previous_status is not None and previous_status.is_terminal():
+
+            # Note: This message can be used to extract information about pipeline
+            # status for usage in dashboards. Some users may be leveraging it for
+            # such purposes, so think carefully before changing/removing it.
+            was_remote = len(resolution.external_jobs)
+            logger.info(
+                "%s resolution %s for pipeline %s terminated with "
+                "root run in state %s. The root run had tags: %s",
+                "Remote" if was_remote else "Local",
+                resolution.root_id,
+                root_run.calculator_path,
+                root_run.future_state,
+                root_run.tags,
+            )
         try:
             _cancel_non_terminal_runs(resolution.root_id)
         except Exception as e:

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -135,8 +135,13 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
     if ResolutionStatus[resolution.status].is_terminal():
-        if previous_status is not None and previous_status.is_terminal():
-
+        # we want to log a message when the resolution is moved
+        # from a non-terminal state to a terminal state.
+        is_termination_update = (
+            previous_status is not None
+            and not ResolutionStatus[previous_status].is_terminal()  # type: ignore
+        )
+        if is_termination_update:
             # Note: This message can be used to extract information about pipeline
             # status for usage in dashboards. Some users may be leveraging it for
             # such purposes, so think carefully before changing/removing it.


### PR DESCRIPTION
Some users would like to be able to use their monitoring infra to create dashboards around various pipelines. A simple way for us to enable this for them is to add a log message that contains the relevant info about a pipeline's terminal state. Any users who rely on this should do so at their own risk: this is not a public API and is subject to change at any time. However, it can be useful if people are willing to accept that it may change/disappear.

Testing
--------
Deployed and ran a couple pipelines; one of which was known to fail:

Sample messages:
```
2023-03-02 18:53:53,050 [INFO] sematic.api.endpoints.resolutions: Remote resolution df55c4cccf5c4573b8812ca882deef00 for pipeline sematic.examples.testing_pipeline.pipeline.testing_pipeline terminated with root run in state NESTED_FAILED. The root run had tags: ["example", "testing"]
2023-03-02 18:54:17,548 [INFO] sematic.api.endpoints.resolutions: Remote resolution 34df7c05dedd40cd99d4d3ff50c4b953 for pipeline sematic.examples.testing_pipeline.pipeline.testing_pipeline terminated with root run in state RESOLVED. The root run had tags: ["example", "testing"]
```