### PR TITLE
Support deep linking to selected panels on the run details page

### DIFF
--- a/sematic/ui/src/pipelines/NotesPanel.tsx
+++ b/sematic/ui/src/pipelines/NotesPanel.tsx
@@ -111,7 +111,7 @@ export default function NotesPanel() {
         borderColor: theme.palette.grey[200],
         display: "grid",
         gridTemplateRows: "1fr auto",
-        overflowY: "scroll",
+        overflowY: "auto",
       }}
     >
       <Box
@@ -121,7 +121,7 @@ export default function NotesPanel() {
           gridTemplateRows: "1fr auto",
           borderBottom: 1,
           borderColor: theme.palette.grey[200],
-          overflowY: "scroll",
+          overflowY: "auto",
         }}
         id="notesList"
       >

--- a/sematic/ui/src/pipelines/PipelinePanels.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanels.tsx
@@ -1,11 +1,12 @@
 import { Box } from "@mui/material";
 import { useAtom } from "jotai";
-import { RESET } from 'jotai/utils';
+import { RESET } from "jotai/utils";
 import { useEffect, useMemo, useState } from "react";
+import usePrevious from "react-use/lib/usePrevious";
 import Loading from "../components/Loading";
 import { ExtractContextType } from "../components/utils/typings";
 import { useGraph } from "../hooks/graphHooks";
-import { selectedRunHashAtom, selectedTabHashAtom, usePipelineRunContext } from "../hooks/pipelineHooks";
+import { selectedPanelHashAtom, selectedRunHashAtom, selectedTabHashAtom, useHashUpdater, usePipelineRunContext } from "../hooks/pipelineHooks";
 import { Run } from "../Models";
 import GraphContext from "./graph/graphContext";
 import MenuPanel from "./MenuPanel";
@@ -21,8 +22,8 @@ export default function PipelinePanels() {
       rootRun: Run
     };
     
-  const [selectedRunId, setSelectedRunId] = useAtom(selectedRunHashAtom);
-  const [selectedPanelItem, setSelectedPanelItem] = useState("run");
+  const [selectedRunIdHash, setSelectedRunId] = useAtom(selectedRunHashAtom);
+  const [selectedPanelItemHash, setSelectedPanelItem] = useAtom(selectedPanelHashAtom);
 
   const [graph, isGraphLoading, error] = useGraph(rootRun.id);
   const graphContext = useMemo<ExtractContextType<typeof GraphContext>>(() => ({
@@ -31,7 +32,7 @@ export default function PipelinePanels() {
   }), [graph, isGraphLoading]);
 
   const selectedRun = useMemo(() => {
-    let runId = selectedRunId;
+    let runId = selectedRunIdHash;
     if (!runId) {
       runId = rootRun.id;
     }
@@ -39,7 +40,7 @@ export default function PipelinePanels() {
       return undefined;
     }
     return graph.runsById.get(runId) || rootRun;
-  }, [selectedRunId, graph, rootRun]);
+  }, [selectedRunIdHash, graph, rootRun]);
 
   const [selectedTabHash, setSelectedRunTab] = useAtom(selectedTabHashAtom);
 
@@ -55,6 +56,13 @@ export default function PipelinePanels() {
     return run?.future_state === "FAILED" ? "logs" : "output";
   }, [selectedTabHash, selectedRun, rootRun]);
 
+  const selectedPanelItem = useMemo(() => {
+    if (!selectedPanelItemHash) {
+      return 'run';
+    }
+    return selectedPanelItemHash;
+  }, [selectedPanelItemHash]);
+
   const [selectedArtifactName, setSelectedArtifactName] = useState("");
 
   const pipelinePanelsContext = useMemo<ExtractContextType<typeof PipelinePanelsContext>>(() => ({
@@ -62,15 +70,34 @@ export default function PipelinePanels() {
     selectedRun, setSelectedRunId,
     selectedRunTab, setSelectedRunTab,
     selectedArtifactName, setSelectedArtifactName
-  }), [selectedPanelItem, selectedRun, setSelectedRunId, selectedRunTab, selectedArtifactName, setSelectedRunTab]);
+  }), [selectedPanelItem, setSelectedPanelItem, selectedRun, setSelectedRunId, selectedRunTab, selectedArtifactName, setSelectedRunTab]);
+  
+  const updateHash = useHashUpdater();
 
+  // Clear the `run` hash when the selected run is not available in the graph or
+  // the selected run is the root run.
   useEffect(()=> {
-    if (selectedRunId === rootRun.id || 
-      (!!graph && !graph.runsById.get(selectedRunId))) {
-      setSelectedRunId(RESET);
+    if (selectedRunIdHash === rootRun.id || 
+      (!!graph && !graph.runsById.get(selectedRunIdHash))) {
+      if (!!selectedRunIdHash) {
+        updateHash({'run': RESET}, true);
+      }
       return;
     }
-  }, [selectedRunId, graph, rootRun, setSelectedRunId])
+  }, [selectedRunIdHash, graph, rootRun, updateHash]);
+
+  const prevSelectedPanelItemHash = usePrevious(selectedPanelItemHash);
+  // Clear the `tab`, `run` hash when we move away from the run panel.
+  useEffect(()=> {
+    // Only clear the hash when the selected panel item has just changed.
+    if (selectedPanelItemHash === prevSelectedPanelItemHash) {
+      return;
+    }
+    if (selectedPanelItemHash !== 'run') {
+        updateHash({'tab': RESET, 'run': RESET}, true);
+    }
+  }, [selectedPanelItemHash, prevSelectedPanelItemHash, updateHash])
+
 
   if (error || (!graph && isGraphLoading)) {
     return (

--- a/sematic/ui/src/pipelines/RunPanel.tsx
+++ b/sematic/ui/src/pipelines/RunPanel.tsx
@@ -39,7 +39,6 @@ export default function RunPanel() {
   const scrollerId = 'run-panel-scrolling-area';
   const scrollContainerRef = useRef<HTMLElement>();
 
-
   const [footerRenderProp, setFooterRenderPropState] = useState<(() => JSX.Element) | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -64,7 +63,7 @@ export default function RunPanel() {
           <Loading isLoaded={false} />
         </LoadingOverlay>}
       <Box id={scrollerId} ref={scrollContainerRef}
-      sx={{ overflowY: "scroll", position: 'relative', height: '100%' }}>
+      sx={{ overflowY: "auto", position: 'relative', height: '100%' }}>
         <RunPanelContext.Provider value={runDetailsContextValue}>
 
           {selectedPanelItem === "graph" && (


### PR DESCRIPTION
Besides adding support for deep linking selected panels, I also fixed a bug that prevented the browser back-forward buttons from working correctly.

The experience is deployed to https://chance.dev-usw2-sematic0.sematic.cloud/ to try out.

![capture1](https://user-images.githubusercontent.com/1046489/222607662-27951b14-e0c6-4a76-90a0-f57dbffa226e.gif)
