### PR TITLE
Handle signals in subprocesses of business logic

### DIFF
--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -45,6 +45,7 @@ sematic_py_lib(
         "//sematic/plugins:abstract_external_resource",
         "//sematic/resolvers:abstract_resource_manager",
         "//sematic/utils:exceptions",
+        "//sematic/utils:signals",
     ],
 )
 
@@ -98,6 +99,7 @@ sematic_py_lib(
         "//sematic:api_client",
         "//sematic/config:config",
         "//sematic/config:user_settings",
+        "//sematic/utils:signals",
         "//sematic/utils:stdout",
     ],
 )

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -8,6 +8,7 @@ pytest_test(
         "//sematic:calculator",
         "//sematic:retry_settings",
         "//sematic/api/tests:fixtures",
+        "//sematic/config/tests:fixtures",
         "//sematic/db:db",
         "//sematic/db/models:edge",
         "//sematic/db/models:resolution",

--- a/sematic/resolvers/tests/test_log_streamer.py
+++ b/sematic/resolvers/tests/test_log_streamer.py
@@ -12,7 +12,7 @@ from sematic.resolvers.log_streamer import (
     _do_upload,
     _start_log_streamer_out_of_process,
     _tail_log_file,
-    _wait_or_kill,
+    _wait_or_kill_streamer,
     ingested_logs,
 )
 from sematic.utils.retry import retry
@@ -105,7 +105,7 @@ def test_start_log_streamer_out_of_process():
         # give some time for the process to actually start up
         # and register a handler
         time.sleep(1)
-        _wait_or_kill(child_pid, timeout_seconds=5)
+        _wait_or_kill_streamer(child_pid, timeout_seconds=5)
 
     assert time.time() - started < upload_interval
     try:

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -13,6 +13,31 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "git",
+    srcs = ["git.py"],
+    pip_deps = [
+        "git-python",
+    ],
+    deps = [
+        "//sematic/db/models:git_info",
+    ],
+)
+
+sematic_py_lib(
+    name = "hashing",
+    srcs = ["hashing.py"],
+    deps = [
+        ":json",
+    ],
+)
+
+sematic_py_lib(
+    name = "json",
+    srcs = ["json.py"],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "memoized_property",
     srcs = ["memoized_property.py"],
     deps = [],
@@ -25,32 +50,13 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "signals",
+    srcs = ["signals.py"],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "stdout",
     srcs = ["stdout.py"],
     deps = [],
-)
-
-sematic_py_lib(
-    name = "git",
-    srcs = ["git.py"],
-    pip_deps = [
-        "git-python",
-    ],
-    deps = [
-        "//sematic/db/models:git_info",
-    ],
-)
-
-sematic_py_lib(
-    name = "json",
-    srcs = ["json.py"],
-    deps = [],
-)
-
-sematic_py_lib(
-    name = "hashing",
-    srcs = ["hashing.py"],
-    deps = [
-        ":json",
-    ],
 )

--- a/sematic/utils/signals.py
+++ b/sematic/utils/signals.py
@@ -1,0 +1,17 @@
+"""Utility code for dealing with OS signals."""
+
+# Standard Library
+from types import FrameType as _FrameType
+from typing import Any, Callable, Optional
+
+FrameType = Optional[_FrameType]
+HandlerType = Optional[Callable[[int, FrameType], Any]]
+
+
+def call_signal_handler(
+    signal_handler: HandlerType, signum: int, frame: FrameType
+) -> Any:
+    """Calls the specified signal handler with the specified signal code and frame."""
+
+    if signal_handler is not None and hasattr(signal_handler, "__call__"):
+        return signal_handler(signum, frame)


### PR DESCRIPTION
Fixes #502.

When user business logic inside Sematic `func`s fork subprocesses and then send them signals to kill them, the signal handler that is invoked is a memory copy of the handler installed in the worker process, which is intended to terminate the log streamer process.

As a result, when running in the cloud, the worker pod is terminated early, and when running locally, users have reported weird behaviors where the Resolver hangs.

This not an uncommon occurrence, as many ML or DP frameworks spawn subprocesses.

This PR ensures subprocesses do not execute the worker signal handler, and also installs other safeguards around abnormal subprocesses termination or incorrect or cleanup, to ensure the execution completes naturally, without illegal code accesses.

## Testing

### Unit tests

Added `LocalResolver` unit tests:

```
$ bazel test //sematic/resolvers/tests:test_local_resolver
```

### Manual

Added new functionality to the Testing Pipeline to deal with subprocesses:
```
$ bazel run //sematic/examples/testing_pipeline:__main__ -- --help
[...]
  --fork-subprocess [action [code ...]]
                        Includes a function that forks a subprocess, and then performs the specified action, using the specified value:
                         - on 'return', the subprocess returns the specified value
                         - on 'exit', the subprocess exits with the specified code
                         - on 'signal', the parent process sends the specified signal to the subprocess
```

Example run:
```
$ bazel run //sematic/examples/testing_pipeline:__main__ -- \
    --cloud \
    --fork-subprocess return 1 \
    --fork-subprocess exit 0 \
    --fork-subprocess exit 1 \
    --fork-subprocess signal 15 \
    --fork-subprocess signal 2 \
    --fork-subprocess signal 9
```

![image](https://user-images.githubusercontent.com/1894533/224201034-759c17f0-a07c-47b2-8671-1333c7431001.png)

**Note:** An interesting discovery is that in some of these cases, the log streamer doubles the ingested logs due to the subprocess sharing the worker's file descriptors. This will have to be addressed in another issue.

Logs for `fork_subprocess[signal=9]`:
```
2023-03-10 01:22:30,586 - INFO - __main__: Worker pod: sematic-worker-686bd9baf9f04f0e98419568d01eb016-a44bb1-xkmsc
2023-03-10 01:22:30,589 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:30,589 - INFO - __main__: Worker CLI args: run_id=686bd9baf9f04f0e98419568d01eb016
2023-03-10 01:22:30,589 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:30,593 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:30,594 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:32,619 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:32,619 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=signal, code=9)
2023-03-10 01:22:37,632 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 has started
2023-03-10 01:22:37,633 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 is sleeping...
2023-03-10 01:22:42,633 - INFO - sematic.examples.testing_pipeline.pipeline: Sending signal 9 to subprocess 12...
2023-03-10 01:22:42,639 - INFO - sematic.examples.testing_pipeline.pipeline: Parent is done waiting on the subprocess
2023-03-10 01:22:42,639 - INFO - __main__: Finished executing fork_subprocess
2023-03-10 01:22:42,799 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```

Logs for `fork_subprocess[signal=2]`:
```
2023-03-10 01:22:31,282 - INFO - __main__: Worker pod: sematic-worker-6d108ba05d394869a488120cf66148fc-f35665-9mxs7
2023-03-10 01:22:31,284 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:31,284 - INFO - __main__: Worker CLI args: run_id=6d108ba05d394869a488120cf66148fc
2023-03-10 01:22:31,284 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:31,285 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:31,285 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:32,794 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:32,794 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=signal, code=2)
2023-03-10 01:22:37,807 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 has started
2023-03-10 01:22:37,808 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 is sleeping...
2023-03-10 01:22:42,810 - INFO - sematic.examples.testing_pipeline.pipeline: Sending signal 2 to subprocess 11...
2023-03-10 01:22:42,813 - ERROR - __main__: User code subprocess 11 raised an error
Process 11 raised exception: 
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 190, in main
    output = func.calculate(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 303, in fork_subprocess
    time.sleep(100000)
KeyboardInterrupt
2023-03-10 01:22:42,816 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```

Logs for `fork_subprocess[signal=15]`:
```
2023-03-10 01:22:26,863 - INFO - __main__: Worker pod: sematic-worker-d5e9b442eb754366b84fee03acab6ff3-880578-xz7gz
2023-03-10 01:22:26,866 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:26,866 - INFO - __main__: Worker CLI args: run_id=d5e9b442eb754366b84fee03acab6ff3
2023-03-10 01:22:26,866 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:26,867 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:26,867 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:29,860 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:29,861 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=signal, code=15)
2023-03-10 01:22:34,881 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 has started
2023-03-10 01:22:34,882 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 is sleeping...
2023-03-10 01:22:39,886 - INFO - sematic.examples.testing_pipeline.pipeline: Sending signal 15 to subprocess 12...
2023-03-10 01:22:39,886 - INFO - __main__: Subprocess 12 is exiting with code: 15
Process 12 raised exception: 15
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 190, in main
    output = func.calculate(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 303, in fork_subprocess
    time.sleep(100000)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/pip_dependencies3_8_ray/site-packages/ray/_private/worker.py", line 1640, in sigterm_handler
    sys.exit(signum)
SystemExit: 15
2023-03-10 01:22:39,902 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
2023-03-10 01:22:26,863 - INFO - __main__: Worker pod: sematic-worker-d5e9b442eb754366b84fee03acab6ff3-880578-xz7gz
2023-03-10 01:22:26,866 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:26,866 - INFO - __main__: Worker CLI args: run_id=d5e9b442eb754366b84fee03acab6ff3
2023-03-10 01:22:26,866 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:26,867 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:26,867 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:29,860 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:29,861 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=signal, code=15)
2023-03-10 01:22:34,881 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 has started
2023-03-10 01:22:34,882 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 is sleeping...
2023-03-10 01:22:39,886 - INFO - sematic.examples.testing_pipeline.pipeline: Sending signal 15 to subprocess 12...
2023-03-10 01:22:39,886 - INFO - __main__: Subprocess 12 is exiting with code: 15
Process 12 raised exception: 15
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 190, in main
    output = func.calculate(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 303, in fork_subprocess
    time.sleep(100000)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/pip_dependencies3_8_ray/site-packages/ray/_private/worker.py", line 1640, in sigterm_handler
    sys.exit(signum)
SystemExit: 15
2023-03-10 01:22:39,902 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```

Logs for `fork_subprocess[exit=1]`:
```
2023-03-10 01:22:25,293 - INFO - __main__: Worker pod: sematic-worker-30959174d5184c6caeab2e3df46ad619-001348-qgwlq
2023-03-10 01:22:25,299 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:25,299 - INFO - __main__: Worker CLI args: run_id=30959174d5184c6caeab2e3df46ad619
2023-03-10 01:22:25,299 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:25,300 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:25,301 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:29,814 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:29,814 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=exit, code=1)
2023-03-10 01:22:34,823 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 has started
2023-03-10 01:22:34,823 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 is exiting: 1
2023-03-10 01:22:34,823 - INFO - __main__: Subprocess 12 is exiting with code: 1
Process 12 raised exception: 1
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 190, in main
    output = func.calculate(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 300, in fork_subprocess
    sys.exit(code)
SystemExit: 1
2023-03-10 01:22:34,826 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
2023-03-10 01:22:25,293 - INFO - __main__: Worker pod: sematic-worker-30959174d5184c6caeab2e3df46ad619-001348-qgwlq
2023-03-10 01:22:25,299 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:25,299 - INFO - __main__: Worker CLI args: run_id=30959174d5184c6caeab2e3df46ad619
2023-03-10 01:22:25,299 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:25,300 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:25,301 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:29,814 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:29,814 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=exit, code=1)
2023-03-10 01:22:34,823 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 has started
2023-03-10 01:22:34,823 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 12 is exiting: 1
2023-03-10 01:22:34,823 - INFO - __main__: Subprocess 12 is exiting with code: 1
Process 12 raised exception: 1
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 190, in main
    output = func.calculate(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 300, in fork_subprocess
    sys.exit(code)
SystemExit: 1
2023-03-10 01:22:34,826 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```

Logs for `fork_subprocess[exit=0]`:
```
2023-03-10 01:22:29,845 - INFO - __main__: Worker pod: sematic-worker-4f2955ea602a4da7ad6baa1e8fb82b22-2ae3d8-j44q6
2023-03-10 01:22:29,849 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:29,849 - INFO - __main__: Worker CLI args: run_id=4f2955ea602a4da7ad6baa1e8fb82b22
2023-03-10 01:22:29,849 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:29,850 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:29,850 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:32,246 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:32,247 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=exit, code=0)
2023-03-10 01:22:37,255 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 has started
2023-03-10 01:22:37,256 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 is exiting: 0
2023-03-10 01:22:37,258 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
2023-03-10 01:22:29,845 - INFO - __main__: Worker pod: sematic-worker-4f2955ea602a4da7ad6baa1e8fb82b22-2ae3d8-j44q6
2023-03-10 01:22:29,849 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:29,849 - INFO - __main__: Worker CLI args: run_id=4f2955ea602a4da7ad6baa1e8fb82b22
2023-03-10 01:22:29,849 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:29,850 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:29,850 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:32,246 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:32,247 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=exit, code=0)
2023-03-10 01:22:37,255 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 has started
2023-03-10 01:22:37,256 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 is exiting: 0
2023-03-10 01:22:37,258 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```

Logs for `fork_subprocess[return=1]`:
```
2023-03-10 01:22:23,853 - INFO - __main__: Worker pod: sematic-worker-8bf6fe4cbaa143ecae39126a56ac3d73-e0fb88-rpbmv
2023-03-10 01:22:23,863 - INFO - __main__: Worker Sematic Version: 0.26.0
2023-03-10 01:22:23,863 - INFO - __main__: Worker CLI args: run_id=8bf6fe4cbaa143ecae39126a56ac3d73
2023-03-10 01:22:23,863 - INFO - __main__: Worker CLI args: resolve=False
2023-03-10 01:22:23,864 - INFO - __main__: Worker CLI args: max-parallelism=None
2023-03-10 01:22:23,865 - INFO - __main__: Worker CLI args: rerun_from=None
2023-03-10 01:22:29,267 - INFO - __main__: Executing fork_subprocess
2023-03-10 01:22:29,268 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: fork_subprocess(val=3.0, action=return, code=1)
2023-03-10 01:22:34,275 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 has started
2023-03-10 01:22:34,275 - INFO - sematic.examples.testing_pipeline.pipeline: Subprocess 11 is returning: 1
2023-03-10 01:22:34,276 - INFO - __main__: Finished executing fork_subprocess
2023-03-10 01:22:34,276 - ERROR - __main__: User code subprocess 11 raised an error
Process 11 raised exception: Subprocess 11 spawned by func 'fork_subprocess' did not clean up correctly and is attempting to execute Sematic worker code! Force terminating! Please always finish executing subprocesses with `sys.exit(<code>)`, with `os._exit(<code>)`, or by sending them a termination signal!
Traceback (most recent call last):
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/log_streamer.py", line 339, in ingested_logs
    yield
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 316, in wrap_main_with_logging
    main(
  File "/app/sematic/examples/testing_pipeline/__main___default_image.binary.runfiles/sematic/sematic/resolvers/worker.py", line 196, in main
    raise RuntimeError(
RuntimeError: Subprocess 11 spawned by func 'fork_subprocess' did not clean up correctly and is attempting to execute Sematic worker code! Force terminating! Please always finish executing subprocesses with `sys.exit(<code>)`, with `os._exit(<code>)`, or by sending them a termination signal!
2023-03-10 01:22:34,277 - INFO - sematic.resolvers.log_streamer: Cleaning up log ingestor
```
