### PR TITLE
Add manual tag to other image targets

### DIFF
--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -97,11 +97,13 @@ def sematic_pipeline(
             name = with_tools_layer,
             files = script_data,
             directory = "/sematic/bin/",
+            tags = ["manual"],
         )
         container_image(
             name = with_tools_image,
             base = base_image,
             layers = [with_tools_layer],
+            tags = ["manual"],
         )
         env = env or {}
 
@@ -157,7 +159,8 @@ def sematic_pipeline(
 
     sematic_push_and_run(
         name = name,
-        push_rule_names = push_rule_names
+        push_rule_names = push_rule_names,
+        tags = ["manual"],
     )
 
 def base_images():

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -21,7 +21,9 @@ def sematic_pipeline(
         data = None,
         base = "@sematic-worker-base//image",
         bases = None,
+        tags = None,
         image_layers = None,
+        image_tags = None,
         env = None,
         dev = False):
     """
@@ -50,6 +52,8 @@ def sematic_pipeline(
 
         bases: (optional)
 
+        tags: (optional) add these tags to ALL generated targets. Defaults to ["manual"]
+
         image_layers: (optional) pass through arg to the `layers`
             parameter of `py3_image`: https://github.com/bazelbuild/rules_docker#py3_image
 
@@ -64,6 +68,8 @@ def sematic_pipeline(
         data = []
     if image_layers == None:
         image_layers = []
+    if tags == None:
+        tags = ["manual"]
 
     if "default" not in bases:
         if base != None:
@@ -97,13 +103,13 @@ def sematic_pipeline(
             name = with_tools_layer,
             files = script_data,
             directory = "/sematic/bin/",
-            tags = ["manual"],
+            tags = tags,
         )
         container_image(
             name = with_tools_image,
             base = base_image,
             layers = [with_tools_layer],
-            tags = ["manual"],
+            tags = tags,
         )
         env = env or {}
 
@@ -121,7 +127,7 @@ def sematic_pipeline(
             visibility = ["//visibility:public"],
             base = with_tools_image,
             env = env,
-            tags = ["manual"],
+            tags = tags,
         )
 
         push_rule_name = "{}_{}_push".format(name, tag)
@@ -134,7 +140,7 @@ def sematic_pipeline(
             repository = repository,
             tag = "{}_{}".format(name, tag),
             format = "Docker",
-            tags = ["manual"],
+            tags = tags,
         )
 
     # image_layers also contains dependencies, they're just ones that
@@ -146,21 +152,21 @@ def sematic_pipeline(
         srcs = ["{}.py".format(name)],
         main = "{}.py".format(name),
         deps = binary_deps,
-        tags = ["manual"],
+        tags = tags,
     )
 
     py_binary(
         name = "{}_local".format(name),
         main = "{}.py".format(name),
         srcs = ["{}.py".format(name)],
-        tags = ["manual"],
+        tags = tags,
         deps = binary_deps,
     )
 
     sematic_push_and_run(
         name = name,
         push_rule_names = push_rule_names,
-        tags = ["manual"],
+        tags = tags,
     )
 
 def base_images():


### PR DESCRIPTION
The "manual" tag was not being added to all image-related targets in `sematic_pipeline`. This adds that tag.

Testing
-------
```
bazel build //sematic/examples/add/... --subcommands -s --explain=tmp.txt --verbose_explanations
```

Did this before and after the change. Cleared the bazel cache between executions.

Before:
```
Build options: --subcommands=1 --subcommands=1 --explain=before.txt --verbose_explanations
Executing action 'BazelWorkspaceStatusAction stable-status.txt': unconditional execution is requested.
Executing action 'Creating source manifest for //sematic/examples/add:__main__': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_10': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:__main___default_image_with_tools': no entry in the cache (action is new).
Executing action 'Writing file sematic/examples/add/__main___default_image_with_tools_layer-layer.manifest': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/__main__.sh.runfiles': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild-ST-4a519fd6d3e4/bin/sematic/examples/add/__main___default_image_with_tools.executable.runfiles': no entry in the cache (action is new).
Executing action 'Creating source manifest for @io_bazel_rules_docker//container:build_tar [for host]': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/host/bin/external/io_bazel_rules_docker/container/build_tar.runfiles [for host]': no entry in the cache (action is new).
Executing action 'Expanding template stub.py [for host]': no entry in the cache (action is new).
Executing action 'Expanding template external/io_bazel_rules_docker/container/build_tar [for host]': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add.runfiles': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_10.runfiles': no entry in the cache (action is new).
Executing action 'ImageLayer sematic/examples/add/__main___default_image_with_tools_layer-layer.tar': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_10': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add': no entry in the cache (action is new).
Executing action 'Expanding template stub.py': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/__main___default_image_with_tools.executable': no entry in the cache (action is new).
Executing action 'Creating source manifest for @io_bazel_rules_docker//container/go/cmd/zipper:zipper [for host]': no entry in the cache (action is new).
Executing action 'Writing file external/go_sdk/packages.txt [for host]': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/host/bin/external/io_bazel_rules_docker/container/go/cmd/zipper/zipper_/zipper.runfiles [for host]': no entry in the cache (action is new).
Executing action 'Creating source manifest for @io_bazel_rules_docker//container/go/cmd/sha256:sha256 [for host]': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/host/bin/external/io_bazel_rules_docker/container/go/cmd/sha256/sha256_/sha256.runfiles [for host]': no entry in the cache (action is new).
Executing action 'Creating source manifest for @io_bazel_rules_docker//container/go/cmd/create_image_config:create_image_config [for host]': no entry in the cache (action is new).
Executing action 'GenerateScript sematic/examples/add/__main__.sh': no entry in the cache (action is new).
Executing action 'Writing file sematic/examples/add/__main___default_image_with_tools_layer-layer.manifest': no entry in the cache (action is new).
Executing action 'ImageLayer sematic/examples/add/__main___default_image_with_tools_layer-layer.tar': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/host/bin/external/io_bazel_rules_docker/container/go/cmd/create_image_config/create_image_config_/create_image_config.runfiles [for host]': no entry in the cache (action is new).
Executing action 'GoToolchainBinaryCompile external/go_sdk/builder.a [for host]': no entry in the cache (action is new).
Executing action 'Writing file sematic/examples/add/__main___default_image_with_tools-layer.manifest': no entry in the cache (action is new).
Executing action 'ImageLayer sematic/examples/add/__main___default_image_with_tools-layer.tar': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_9': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_9': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_8': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_8': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_9.runfiles': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_8.runfiles': no entry in the cache (action is new).
Executing action 'GoToolchainBinary external/go_sdk/builder [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/pkg/errors/errors.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/name/name.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/io_bazel_rules_docker/container/go/cmd/zipper/zipper.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/opencontainers/image-spec/specs-go/specs-go.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/internal/and/and.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/opencontainers/go-digest/go-digest.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/containerd/stargz-snapshotter/estargz/errorutil/errorutil.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/golang.org/x/sync/errgroup/errgroup.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_pkg_errors/errors.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/io_bazel_rules_docker/container/go/cmd/sha256/sha256.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/internal/gzip/gzip.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/types/types.a [for host]': no entry in the cache (action is new).
Executing action 'GoLink external/io_bazel_rules_docker/container/go/cmd/sha256/sha256_/sha256 [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/io_bazel_rules_docker/container/go/pkg/utils/go_default_library.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/containerd/stargz-snapshotter/estargz/estargz.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/opencontainers/image-spec/specs-go/v1/specs-go.a [for host]': no entry in the cache (action is new).
Executing action 'GoLink external/io_bazel_rules_docker/container/go/cmd/zipper/zipper_/zipper [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/pkg.a [for host]': no entry in the cache (action is new).
Executing action 'SHA256 sematic/examples/add/__main___default_image_with_tools-layer.tar.sha256': no entry in the cache (action is new).
Executing action 'SHA256 sematic/examples/add/__main___default_image_with_tools_layer-layer.tar.sha256': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/000.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/006.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/005.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/007.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/002.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/004.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/001.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GUNZIP external/sematic-worker-base/image/003.tar.gz.nogz': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/match/match.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/internal/estargz/estargz.a [for host]': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/006.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/005.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/007.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/partial/partial.a [for host]': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/003.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/tarball/tarball.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/io_bazel_rules_docker/container/go/pkg/compat/go_default_library.a [for host]': no entry in the cache (action is new).
Executing action 'GoCompilePkg external/io_bazel_rules_docker/container/go/cmd/create_image_config/create_image_config.a [for host]': no entry in the cache (action is new).
Executing action 'GoLink external/io_bazel_rules_docker/container/go/cmd/create_image_config/create_image_config_/create_image_config [for host]': no entry in the cache (action is new).
Executing action 'ImageConfig sematic/examples/add/__main___default_image_with_tools.0.config': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/001.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'ImageConfig sematic/examples/add/__main___default_image_with_tools.1.config': no entry in the cache (action is new).
Executing action 'SHA256 sematic/examples/add/__main___default_image_with_tools.1.config.sha256': no entry in the cache (action is new).
Executing action 'Action sematic/examples/add/__main___default_image_with_tools.json.sha256': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/000.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/004.tar.gz.nogz.sha256': no entry in the cache (action is new).
Executing action 'SHA256 external/sematic-worker-base/image/002.tar.gz.nogz.sha256': no entry in the cache (action is new).
```

After:
```
Build options: --subcommands=1 --subcommands=1 --explain=tmp.txt --verbose_explanations
Executing action 'BazelWorkspaceStatusAction stable-status.txt': unconditional execution is requested.
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_10': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_9': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add_py3_8': no entry in the cache (action is new).
Executing action 'Expanding template stub.py': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_9.runfiles': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_10.runfiles': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add_py3_8.runfiles': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_10': no entry in the cache (action is new).
Executing action 'Creating source manifest for //sematic/examples/add:add': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_8': no entry in the cache (action is new).
Executing action 'Creating runfiles tree bazel-out/darwin_arm64-fastbuild/bin/sematic/examples/add/add.runfiles': no entry in the cache (action is new).
Executing action 'Expanding template sematic/examples/add/add_py3_9': no entry in the cache (action is new).
```

Note that many image-related things are skipped in the "after." This also speeds up the build fairly substantially.