### PR TITLE
Fixes a bug that removes the selected tab when the page is first loaded

### DIFF
--- a/sematic/ui/src/pipelines/PipelinePanels.tsx
+++ b/sematic/ui/src/pipelines/PipelinePanels.tsx
@@ -86,17 +86,17 @@ export default function PipelinePanels() {
     }
   }, [selectedRunIdHash, graph, rootRun, updateHash]);
 
-  const prevSelectedPanelItemHash = usePrevious(selectedPanelItemHash);
+  const prevSelectedPanelItem = usePrevious(selectedPanelItem);
   // Clear the `tab`, `run` hash when we move away from the run panel.
   useEffect(()=> {
     // Only clear the hash when the selected panel item has just changed.
-    if (selectedPanelItemHash === prevSelectedPanelItemHash) {
+    if (selectedPanelItem === prevSelectedPanelItem) {
       return;
     }
-    if (selectedPanelItemHash !== 'run') {
+    if (selectedPanelItem !== 'run') {
         updateHash({'tab': RESET, 'run': RESET}, true);
     }
-  }, [selectedPanelItemHash, prevSelectedPanelItemHash, updateHash])
+  }, [prevSelectedPanelItem, selectedPanelItem, updateHash])
 
 
   if (error || (!graph && isGraphLoading)) {


### PR DESCRIPTION
Explain: `selectedPanelItemHash` is initially empty and caused the logic to believe it is not on the `run` panel. Hence removes the `run` and `tab` hashes from the URL. 

Using `selectedPanelItem` is safer because if `selectedPanelItemHash` is null, `selectedPanelItem`, as a proxy, will default to `run`. 