### PR TITLE
Split deps and layers

### DIFF
--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -52,6 +52,10 @@ def sematic_pipeline(
 
         image_layers: (optional) pass through arg to the `layers`
             parameter of `py3_image`: https://github.com/bazelbuild/rules_docker#py3_image
+            Does NOT automatically get passed through to the python
+            binary target. So if you are including direct dependencies
+            of the binary here, you will need to *also* pass them in
+            to "deps".
 
         env: (optional) mapping of environment variables to set in the container
 
@@ -134,16 +138,12 @@ def sematic_pipeline(
             format = "Docker",
             tags = ["manual"],
         )
-
-    # image_layers also contains dependencies, they're just ones that
-    # should be added separately when creating the image.
-    binary_deps = deps + image_layers
     
     py_binary(
         name = "{}_binary".format(name),
         srcs = ["{}.py".format(name)],
         main = "{}.py".format(name),
-        deps = binary_deps,
+        deps = deps,
         tags = ["manual"],
     )
 
@@ -152,7 +152,7 @@ def sematic_pipeline(
         main = "{}.py".format(name),
         srcs = ["{}.py".format(name)],
         tags = ["manual"],
-        deps = binary_deps,
+        deps = deps,
     )
 
     sematic_push_and_run(

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -92,6 +92,8 @@ def sematic_pipeline(
         script_data = ["@rules_sematic//:ray", "@rules_sematic//:bazel_python"]
         py3_image_deps = deps
 
+    py3_image_deps = [dep for dep in deps if dep not in image_layers]
+
     push_rule_names = {}
 
     for tag, base_image in bases.items():

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -91,7 +91,10 @@ def sematic_pipeline(
         srcs = ["@rules_sematic//:worker.py"]
         script_data = ["@rules_sematic//:ray", "@rules_sematic//:bazel_python"]
         py3_image_deps = deps
-
+    
+    # If a dependency is already in the image via layers,
+    # we don't want to duplicate the dependency via the other
+    # deps.
     py3_image_deps = [dep for dep in deps if dep not in image_layers]
 
     push_rule_names = {}

--- a/sematic/examples/testing_pipeline/BUILD
+++ b/sematic/examples/testing_pipeline/BUILD
@@ -22,6 +22,8 @@ sematic_pipeline(
         requirement("ray"),
     ],
     deps = [
+        requirement("debugpy"),
+        requirement("ray"),
         ":testing_pipeline_lib",
     ],
 )


### PR DESCRIPTION
Currently, if you add anything to the image layers, you must also add it as a dependency of the py binary. This may not always be desirable. This PR makes it possible to separate the two.


Testing
--------

```
bazel run //sematic/examples/testing_pipeline:__main___local -- --silent --ray-resource
```

```
bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --ray-resource
```