### PR TITLE
Filter pipelines of current user on the home page

### DIFF
--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -60,8 +60,12 @@ export default function Home() {
   const { user } = useContext(UserContext);
 
   const runFilters = useMemo(() => ({
-    parent_id: { eq: null },
-  }), []);
+    AND: [{
+      parent_id: { eq: null },
+    }, {
+      user_id: { eq: user?.id },
+    }
+  ]}), [user?.id]);
 
   const otherQueryParams = useMemo(() => ({
       limit: '1'

--- a/sematic/ui/src/Home.tsx
+++ b/sematic/ui/src/Home.tsx
@@ -63,7 +63,7 @@ export default function Home() {
     AND: [{
       parent_id: { eq: null },
     }, {
-      user_id: { eq: user?.id },
+      user_id: { eq: user?.id || null },
     }
   ]}), [user?.id]);
 


### PR DESCRIPTION
On the home page (landing page) only show the root pipelines of the currently logged-in user.

Tested with a deployment of pipelines owned by the current user vs not.