### PR TITLE
UI Bug fix + makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,11 @@ else
 endif
 
 .PHONY: ui
-ui:
+ui: sematic/ui/node_modules/.build_timestamp
 	cd sematic/ui; npm run build
+
+sematic/ui/node_modules/.build_timestamp: sematic/ui/package.json
+	cd sematic/ui; npm install; touch -r ./package.json ./node_modules/.build_timestamp
 
 worker-image:
 	cd docker; docker build -t sematicai/sematic-worker-base:latest -f Dockerfile.worker .

--- a/sematic/ui/src/pipelines/RunTree.tsx
+++ b/sematic/ui/src/pipelines/RunTree.tsx
@@ -44,7 +44,7 @@ export default function RunTree(props: {
       }}
     >
       {runTreeNodes.map(({run, children}) => (
-        <Fragment key={run!.id}>
+        <Fragment key={`${run!.id}---${run!.future_state}`}>
           <ListItemButton
             onClick={() => onSelectRun(run!.id)}
             key={run!.id}


### PR DESCRIPTION
Fixed a UI issue that runs status updates is not reflected on the run tree.

Improve the make file to auto-run `npm install` during the `make ui` rule. `npm install`  will be skipped if `node_modules` already exists or `package.json` is not updated. 