### PR TITLE
Force runs to pass through only allowed states

### DIFF
--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -115,7 +115,7 @@ _ALLOWED_TRANSITIONS = {
     FutureState.RESOLVED: frozenset(),
 }
 
-# TODO: retries should
+
 _TERMINAL_STATES = frozenset(
     {
         FutureState.NESTED_FAILED,

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -65,7 +65,57 @@ class FutureState(enum.Enum):
     def terminal_state_strings(cls) -> FrozenSet[str]:
         return _TERMINAL_STATE_STRINGS
 
+    @classmethod
+    def is_allowed_transition(
+        cls,
+        from_status: Optional[Union["FutureState", str]],
+        to_status: Union["FutureState", str],
+    ) -> bool:
+        if isinstance(from_status, str):
+            from_status = FutureState[from_status]
+        if isinstance(to_status, str):
+            to_status = FutureState[to_status]
+        return to_status in _ALLOWED_TRANSITIONS[from_status]
 
+
+_ALLOWED_TRANSITIONS = {
+    None: frozenset({FutureState.CREATED}),
+    FutureState.CREATED: frozenset(
+        {
+            FutureState.SCHEDULED,
+            # Not all that uncommon: if run is downstream from something that
+            # is canceled/failed, it goes from CREATED -> CANCELLED
+            FutureState.CANCELED,
+        }
+    ),
+    FutureState.SCHEDULED: frozenset(
+        {
+            FutureState.RAN,
+            FutureState.RETRYING,
+            FutureState.CANCELED,
+            FutureState.RESOLVED,
+            # TODO: remove (See https://github.com/sematic-ai/sematic/issues/609)
+            FutureState.FAILED,
+        }
+    ),
+    FutureState.RAN: frozenset(
+        {FutureState.NESTED_FAILED, FutureState.RESOLVED, FutureState.CANCELED}
+    ),
+    FutureState.RETRYING: frozenset(
+        {FutureState.FAILED, FutureState.SCHEDULED, FutureState.CANCELED}
+    ),
+    FutureState.FAILED: frozenset(
+        {
+            # TODO: remove (See https://github.com/sematic-ai/sematic/issues/609)
+            FutureState.RETRYING
+        }
+    ),
+    FutureState.NESTED_FAILED: frozenset(),
+    FutureState.CANCELED: frozenset(),
+    FutureState.RESOLVED: frozenset(),
+}
+
+# TODO: retries should
 _TERMINAL_STATES = frozenset(
     {
         FutureState.NESTED_FAILED,

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -47,6 +47,7 @@ from sematic.log_reader import load_log_lines
 from sematic.scheduling.external_job import ExternalJob
 from sematic.scheduling.job_scheduler import schedule_run, update_run_status
 from sematic.scheduling.kubernetes import cancel_job
+from sematic.utils.exceptions import IllegalStateTransitionError
 from sematic.utils.retry import retry
 
 logger = logging.getLogger(__name__)
@@ -359,7 +360,12 @@ def update_run_status_endpoint(user: Optional[User]) -> flask.Response:
         run = _get_run_if_modified(run_id, future_state, jobs)
         if run is not None:
             new_future_state_value = run.future_state
-            save_run(run)
+            try:
+                save_run(run)
+            except IllegalStateTransitionError as e:
+                raise _DetectedRunRaceCondition(
+                    "Run appears to have been modified since being queried: %s", e
+                )
             broadcast_graph_update(run.root_id, user=user)
 
         result_list.append(
@@ -427,28 +433,37 @@ def save_graph_endpoint(user: Optional[User]):
 
     graph = flask.request.json["graph"]
 
-    runs = [Run.from_json_encodable(run) for run in graph["runs"]]
-
-    for run in runs:
-        logger.info("Graph update, run %s is in state %s", run.id, run.future_state)
-
-        if user is not None:
-            run.user_id = user.id
-
-        if FutureState[run.future_state].is_terminal():
-            logger.info("Ensuring jobs for %s are stopped %s", run.id, run.future_state)
-            jobs = []
-            for external_job in run.external_jobs:
-                jobs.append(cancel_job(external_job))
-            run.external_jobs = jobs
-
     artifacts = [
         Artifact.from_json_encodable(artifact) for artifact in graph["artifacts"]
     ]
 
     edges = [Edge.from_json_encodable(edge) for edge in graph["edges"]]
 
+    runs = [Run.from_json_encodable(run) for run in graph["runs"]]
+
+    for run in runs:
+        logger.info("Graph update, run %s is in state %s", run.id, run.future_state)
+        if user is not None:
+            run.user_id = user.id
+
+    # save graph BEFORE ensuring jobs are stopped. This way
+    # code that is checking on job status will be ok if it
+    # sees the jobs as gone while we are going through and
+    # deleting them.
     save_graph(runs, artifacts, edges)
+
+    updated_jobs = False
+    for run in runs:
+        if FutureState[run.future_state].is_terminal():
+            updated_jobs = True
+            logger.info("Ensuring jobs for %s are stopped %s", run.id, run.future_state)
+            jobs = []
+            for external_job in run.external_jobs:
+                jobs.append(cancel_job(external_job))
+            run.external_jobs = jobs
+
+    if updated_jobs:
+        save_graph(runs, [], [])
 
     return flask.jsonify({})
 

--- a/sematic/api/endpoints/tests/test_notes.py
+++ b/sematic/api/endpoints/tests/test_notes.py
@@ -17,6 +17,7 @@ from sematic.db.models.run import Run
 from sematic.db.models.user import User  # noqa: F401
 from sematic.db.queries import get_note, save_note  # noqa: F401
 from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
     persisted_run,
     persisted_user,
     run,

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -33,6 +33,7 @@ from sematic.db.queries import (
     save_run_external_resource_links,
 )
 from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
     make_resolution,
     persisted_external_resource,
     persisted_resolution,

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -35,6 +35,7 @@ from sematic.db.queries import (
     save_run_external_resource_links,
 )
 from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
     make_run,
     persisted_external_resource,
     persisted_resolution,

--- a/sematic/cli/tests/BUILD
+++ b/sematic/cli/tests/BUILD
@@ -49,6 +49,7 @@ pytest_test(
         "//sematic/cli:logs",
         "//sematic/db:queries",
         "//sematic/db/tests:fixtures",
+        "//sematic/tests:fixtures",
     ],
 )
 

--- a/sematic/cli/tests/test_cancel.py
+++ b/sematic/cli/tests/test_cancel.py
@@ -7,7 +7,12 @@ from click.testing import CliRunner
 # Sematic
 from sematic.cli.cancel import cancel
 from sematic.db.models.run import Run
-from sematic.db.tests.fixtures import persisted_run, run, test_db  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    persisted_run,
+    run,
+    test_db,
+)
 
 
 @mock.patch("sematic.cli.cancel.api_client.get_run")

--- a/sematic/cli/tests/test_logs.py
+++ b/sematic/cli/tests/test_logs.py
@@ -15,6 +15,7 @@ from sematic.db.queries import save_resolution, save_run
 from sematic.db.tests.fixtures import make_resolution, make_run, test_db  # noqa: F401
 from sematic.log_reader import LogLineResult, log_prefix
 from sematic.scheduling.external_job import ExternalJob, JobType
+from sematic.tests.fixtures import allow_any_run_state_transition  # noqa: F401
 
 
 @pytest.fixture
@@ -52,7 +53,9 @@ def fill_log_dir(mock_storage, text_lines, prefix):  # noqa: F811
     return prefix
 
 
-def test_logs(test_db, mock_storage, mock_api_client):  # noqa: F811
+def test_logs(
+    test_db, mock_storage, mock_api_client, allow_any_run_state_transition  # noqa: F811
+):
     run = make_run(future_state=FutureState.RESOLVED)
     run.external_jobs = [ExternalJob(JobType.driver, 0, external_job_id="abc")]
     resolution = make_resolution(root_id=run.id, status=ResolutionStatus.COMPLETE)
@@ -69,7 +72,11 @@ def test_logs(test_db, mock_storage, mock_api_client):  # noqa: F811
 
 
 def test_follow_logs(
-    test_db, mock_storage, mock_api_client, mock_load_log_lines  # noqa: F811
+    test_db,  # noqa: F811
+    mock_storage,  # noqa: F811
+    mock_api_client,
+    mock_load_log_lines,
+    allow_any_run_state_transition,  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
     run.external_jobs = [ExternalJob(JobType.driver, 0, external_job_id="abc")]
@@ -134,7 +141,9 @@ def test_follow_logs(
     assert list(result.output.split("\n"))[:-1] == early_lines + late_lines
 
 
-def test_empty_logs(test_db, mock_storage, mock_api_client):  # noqa: F811
+def test_empty_logs(
+    test_db, mock_storage, mock_api_client, allow_any_run_state_transition  # noqa: F811
+):
     run = make_run(future_state=FutureState.RESOLVED)
     run.external_jobs = [ExternalJob(JobType.driver, 0, external_job_id="abc")]
     resolution = make_resolution(root_id=run.id, status=ResolutionStatus.COMPLETE)

--- a/sematic/cli/tests/test_logs.py
+++ b/sematic/cli/tests/test_logs.py
@@ -12,10 +12,14 @@ from sematic.api.tests.fixtures import mock_storage  # noqa: F401
 from sematic.cli.logs import dump_log_storage, logs
 from sematic.db.models.resolution import ResolutionStatus
 from sematic.db.queries import save_resolution, save_run
-from sematic.db.tests.fixtures import make_resolution, make_run, test_db  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    make_resolution,
+    make_run,
+    test_db,
+)
 from sematic.log_reader import LogLineResult, log_prefix
 from sematic.scheduling.external_job import ExternalJob, JobType
-from sematic.tests.fixtures import allow_any_run_state_transition  # noqa: F401
 
 
 @pytest.fixture

--- a/sematic/db/BUILD
+++ b/sematic/db/BUILD
@@ -28,6 +28,7 @@ sematic_py_lib(
         "//sematic/db/models:user",
         "//sematic/plugins:abstract_external_resource",
         "//sematic/scheduling:external_job",
+        "//sematic/utils:exceptions",
     ],
 )
 

--- a/sematic/db/models/tests/test_json_encodable_mixin.py
+++ b/sematic/db/models/tests/test_json_encodable_mixin.py
@@ -1,6 +1,11 @@
 # Sematic
 from sematic.db.models.run import Run
-from sematic.db.tests.fixtures import persisted_run, run, test_db  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    persisted_run,
+    run,
+    test_db,
+)
 
 
 def test_utc_timestamp(persisted_run: Run):  # noqa: F811

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -24,6 +24,7 @@ from sematic.db.models.user import User
 from sematic.plugins.abstract_external_resource import ResourceState
 from sematic.scheduling.external_job import ExternalJob
 from sematic.types.serialization import value_from_json_encodable
+from sematic.utils.exceptions import IllegalStateTransitionError
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +190,30 @@ def save_run(run: Run) -> Run:
     """
     _assert_external_jobs_not_removed([run])
     with db().get_session() as session:
+        existing_run_future_state = (
+            session.query(Run.future_state).filter(Run.id == run.id).one_or_none()
+        )
+        existing_run_future_state = (
+            existing_run_future_state[0]
+            if existing_run_future_state is not None
+            else None
+        )
+        new_state = run.future_state
+        if isinstance(new_state, FutureState):
+            # despite run.future_state being typed as FutureState, it
+            # is sometimes a string.
+            new_state = new_state.name  # type: ignore
+
+        if (
+            existing_run_future_state != new_state
+            and not FutureState.is_allowed_transition(
+                existing_run_future_state, run.future_state
+            )
+        ):
+            raise IllegalStateTransitionError(
+                f"Cannot transition run from '{existing_run_future_state}' to "
+                f"'{run.future_state}'"
+            )
         session.add(run)
         session.commit()
         session.refresh(run)

--- a/sematic/db/tests/BUILD
+++ b/sematic/db/tests/BUILD
@@ -39,6 +39,7 @@ pytest_test(
     # buildifier: leave-alone
     deps = [
         ":fixtures",
+        "//sematic:abstract_future",
         "//sematic:calculator",
         "//sematic/api/tests:fixtures",
         "//sematic/db:db",

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -27,7 +27,10 @@ from sematic.resolvers.resource_requirements import (
     KubernetesResourceRequirements,
     ResourceRequirements,
 )
-from sematic.tests.fixtures import test_storage  # noqa: F401
+from sematic.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    test_storage,
+)
 
 
 def handler(postgresql):
@@ -173,7 +176,7 @@ def run() -> Run:
 
 
 @pytest.fixture
-def persisted_run(run, test_db) -> Run:
+def persisted_run(run, test_db, allow_any_run_state_transition) -> Run:  # noqa: F811
     return save_run(run)
 
 

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -27,10 +27,7 @@ from sematic.resolvers.resource_requirements import (
     KubernetesResourceRequirements,
     ResourceRequirements,
 )
-from sematic.tests.fixtures import (  # noqa: F401
-    allow_any_run_state_transition,
-    test_storage,
-)
+from sematic.tests.fixtures import test_storage  # noqa: F401
 
 
 def handler(postgresql):
@@ -173,6 +170,16 @@ def persisted_external_resource(test_db) -> AbstractExternalResource:
 @pytest.fixture
 def run() -> Run:
     return make_run()
+
+
+@pytest.fixture
+def allow_any_run_state_transition():
+    original = FutureState.is_allowed_transition
+    try:
+        FutureState.is_allowed_transition = lambda *args, **kwargs: True
+        yield
+    finally:
+        FutureState.is_allowed_transition = original
 
 
 @pytest.fixture

--- a/sematic/plugins/publishing/tests/test_slack.py
+++ b/sematic/plugins/publishing/tests/test_slack.py
@@ -12,6 +12,7 @@ from sematic.config.tests.fixtures import mock_settings
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
     make_resolution,
     persisted_resolution,
     persisted_run,

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -23,7 +23,10 @@ from sematic.db.tests.fixtures import persisted_resolution  # noqa: F401
 from sematic.db.tests.fixtures import persisted_run  # noqa: F401
 from sematic.db.tests.fixtures import pg_mock  # noqa: F401
 from sematic.db.tests.fixtures import run  # noqa: F401
-from sematic.db.tests.fixtures import test_db  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    test_db,
+)
 from sematic.resolvers.cloud_resolver import CloudResolver
 from sematic.tests.fixtures import (  # noqa: F401
     environment_variables,

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -96,8 +96,23 @@ def update_run_status(
     The second is the updated external jobs tuple.
     """
     external_jobs = tuple(external_jobs)
+    active_jobs_remain = any(job.is_active() for job in external_jobs)
     if future_state.is_terminal():
-        return future_state, external_jobs
+        if active_jobs_remain:
+            logger.warning(
+                "There are still active external jobs for run in "
+                "state %s (will refresh jobs): %s",
+                future_state,
+                external_jobs,
+            )
+            refreshed_jobs = _refresh_external_jobs(external_jobs)
+            logger.warning(
+                "After refresh, jobs are: " "%s",
+                refreshed_jobs,
+            )
+            return future_state, refreshed_jobs
+        else:
+            return future_state, external_jobs
 
     if future_state.value == FutureState.RAN.value:
         # If the job already RAN, the only reason it's not

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -4,6 +4,7 @@ sematic_py_lib(
     name = "fixtures",
     srcs = ["fixtures.py"],
     deps = [
+        "//sematic:abstract_future",
         "//sematic:api_client",
         "//sematic/plugins/storage:memory_storage",
     ],

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -11,6 +11,7 @@ import pytest
 # Sematic
 import sematic.api_client as api_client
 import sematic.config.settings as sematic_settings
+from sematic.abstract_future import FutureState
 from sematic.plugins.storage.memory_storage import MemoryStorage
 
 
@@ -29,6 +30,16 @@ def valid_client_version():
         yield
     finally:
         api_client._validated_client_version = current_validated_client_version
+
+
+@pytest.fixture
+def allow_any_run_state_transition():
+    original = FutureState.is_allowed_transition
+    try:
+        FutureState.is_allowed_transition = lambda *args, **kwargs: True
+        yield
+    finally:
+        FutureState.is_allowed_transition = original
 
 
 @contextlib.contextmanager

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -27,6 +27,7 @@ from sematic.resolvers.cloud_resolver import (
     START_INLINE_RUN_INDICATOR,
 )
 from sematic.scheduling.external_job import ExternalJob, JobType
+from sematic.tests.fixtures import allow_any_run_state_transition  # noqa: F401
 
 _streamed_lines: List[str] = []
 _DUMMY_LOGS_FILE = "logs.log"
@@ -244,7 +245,10 @@ def prepare_logs_v2(
     ),
 )
 def test_load_non_inline_logs(
-    test_db, mock_storage, log_preparation_function  # noqa: F811
+    test_db,  # noqa: F811
+    mock_storage,  # noqa: F811
+    log_preparation_function,
+    allow_any_run_state_transition,  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
     save_run(run)
@@ -326,7 +330,9 @@ def test_load_non_inline_logs(
     )
 
 
-def test_line_stream_from_log_directory(mock_storage, test_db):  # noqa: F811
+def test_line_stream_from_log_directory(
+    mock_storage, test_db, allow_any_run_state_transition  # noqa: F811
+):
     run = make_run(future_state=FutureState.RESOLVED)
     save_run(run)
     n_lines = 500
@@ -364,7 +370,10 @@ def test_line_stream_from_log_directory(mock_storage, test_db):  # noqa: F811
     ),
 )
 def test_load_inline_logs(
-    mock_storage, test_db, log_preparation_function  # noqa: F811
+    mock_storage,  # noqa: F811
+    test_db,  # noqa: F811
+    log_preparation_function,
+    allow_any_run_state_transition,  # noqa: F811
 ):
     run = make_run(future_state=FutureState.RESOLVED)
     save_run(run)
@@ -698,7 +707,9 @@ def test_load_cloned_run_log_lines(
     assert result.lines == ["Line 42"]
 
 
-def test_continue_from_end_with_no_new_logs(test_db, mock_storage):  # noqa: F811
+def test_continue_from_end_with_no_new_logs(
+    test_db, mock_storage, allow_any_run_state_transition  # noqa: F811
+):
     run = make_run(future_state=FutureState.SCHEDULED)
     save_run(run)
 

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -9,7 +9,12 @@ from sematic.abstract_future import FutureState
 from sematic.api.tests.fixtures import mock_storage  # noqa: F401
 from sematic.db.models.resolution import ResolutionStatus
 from sematic.db.queries import save_resolution, save_run
-from sematic.db.tests.fixtures import make_resolution, make_run, test_db  # noqa: F401
+from sematic.db.tests.fixtures import (  # noqa: F401
+    allow_any_run_state_transition,
+    make_resolution,
+    make_run,
+    test_db,
+)
 from sematic.log_reader import (
     Cursor,
     LogLine,
@@ -27,7 +32,6 @@ from sematic.resolvers.cloud_resolver import (
     START_INLINE_RUN_INDICATOR,
 )
 from sematic.scheduling.external_job import ExternalJob, JobType
-from sematic.tests.fixtures import allow_any_run_state_transition  # noqa: F401
 
 _streamed_lines: List[str] = []
 _DUMMY_LOGS_FILE = "logs.log"

--- a/sematic/types/type.py
+++ b/sematic/types/type.py
@@ -13,7 +13,7 @@ else:
     # parameterized a Union, we just use an example. Why use two types
     # instead of just Union[int]? Because that is disallowed--all Union
     # parameterizations must have at least two types.
-    UnionType = typing.get_origin(typing.Union[int, float])
+    UnionType = typing.get_origin(typing.Union[int, float])  # type: ignore
 
 
 class TypeMeta(abc.ABCMeta):


### PR DESCRIPTION
As a part of pod lifecycle work, I discovered some issues with our state management of runs and resolutions. This PR addresses them, and adds some safeguards:

- There is a race condition where if a resolver has hit the `/api/v1/runs/future_states` endpoint at the same time as the run is hitting `POST /api/v1/graph` from `worker.py`, invalid status updates can occur. In particular, external jobs can be deleted by the latter when the former still expects those jobs to be present. Fixed this by having the logic in `/api/v1/graph` which deletes external jobs save the run status before doing so. This enables an existing race condition detection mechanism to work as expected in `/api/v1/runs/future_states` so the run doesn't get marked as failed when it doesn't find jobs.
- Also enforced that runs only pass between expected state transitions. This is enforced during a db transaction to ensure it is valid even across interleaved request handling workers
- Added a warning that will get logged if external jobs are not cancelled properly

Testing
-------
- `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --fan-out 50` [run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/f3ca601507d046c594a9be2fb387da5f#run=73fca02bc67942608c9e30527c7069f7)
- `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --raise-retry 0.5` [run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/bd4022fe60714e2b8839f08043ff3f64#run=aabac1f363584ad7a591f2b49087242d&tab=logs)
- `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --raise` [run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/50b08302be854eb4afaef0627acfb90d#tab=logs) (expected to fail)