### PR TITLE
Refactor the interface of useHttpClient

### DIFF
--- a/sematic/ui/src/hooks/appHooks.ts
+++ b/sematic/ui/src/hooks/appHooks.ts
@@ -23,10 +23,10 @@ export function useAuthentication() {
     const {fetch} = useHttpClient();
 
     const {value, loading, error} = useAsync(async () => {
-        const response: AuthenticatePayload = await fetch({
+        const response = await fetch({
             url: `/authenticate`
         });
-        return response;
+        return (await response.json()) as AuthenticatePayload;
     }, []);
 
     const isAuthenticationEnabled = useMemo(
@@ -71,10 +71,10 @@ export function useEnv(user: User | null) {
         if (!user) {
             return null;
         }
-        const response: EnvPayload = await fetch({
+        const response = await fetch({
             url: `/api/v1/meta/env`
         });
-        return response;
+        return (await response.json()) as EnvPayload;
     }, [user]);
 
     const envVars = useMemo(() => {

--- a/sematic/ui/src/hooks/externalResourceHooks.ts
+++ b/sematic/ui/src/hooks/externalResourceHooks.ts
@@ -15,11 +15,13 @@ export function useExternalResource(run: Run) {
             url: `/api/v1/runs/${run.id}/external_resources`
         });
 
-        if (!response['content']) {
+        const payload = await response.json();
+
+        if (!payload['content']) {
             throw Error('external_resources response is not in the correct format.')
         }
 
-        return response['content'] as Array<ExternalResource>
+        return payload['content'] as Array<ExternalResource>
     }, [fetch, run.id]);
 
     const timerHandler = useRef<number>();

--- a/sematic/ui/src/hooks/graphHooks.ts
+++ b/sematic/ui/src/hooks/graphHooks.ts
@@ -17,9 +17,11 @@ export function useGraph(runRootId: string): [
     const { devLogger } = useLogger();
 
     const {value: graphPayload, loading, error, retry} = useAsyncRetry(async () => {
-        return await fetch({
+        const response = await fetch({
             url: `/api/v1/runs/${runRootId}/graph?root=1`,
-        }) as RunGraphPayload;
+        });
+
+        return (await response.json()) as RunGraphPayload;
     }, [runRootId]);
 
     const graph = useMemo<Graph | undefined >(() => {

--- a/sematic/ui/src/hooks/httpHooks.ts
+++ b/sematic/ui/src/hooks/httpHooks.ts
@@ -3,7 +3,7 @@ import { UserContext } from "../appContext";
 import { useLogger } from "../utils";
 
 interface HttpClient {
-    fetch: (params: { url: string, method?: string, body?: any }) => Promise<any>;
+    fetch: (params: { url: string, method?: string, body?: any }) => Promise<Response>;
     cancel: () => void
 }
 
@@ -29,7 +29,7 @@ export function useHttpClient(): HttpClient {
         url,
         method,
         body
-    }: { url: string, method?: string, body?: any }) => {
+    }: { url: string, method?: string, body?: any }): Promise<Response>  => {
         method = method || "GET";
 
         const reqBody: BodyInit | null = body ? JSON.stringify(body) : null;
@@ -49,7 +49,7 @@ export function useHttpClient(): HttpClient {
                 throw Error(response.statusText);
             }
 
-            return response.json();
+            return response;
         } catch (e: any) {
             if (e instanceof DOMException && e.name === 'AbortError') {
                 devLogger("fetch() was voluntarily cancelled.")

--- a/sematic/ui/src/hooks/logHooks.ts
+++ b/sematic/ui/src/hooks/logHooks.ts
@@ -43,7 +43,7 @@ export function useLogStream(source: string, filterString: string) {
             const qString = (new URLSearchParams(queryParams)).toString();
             const url = `/api/v1/runs/${source}/logs?${qString}`;
 
-            const payload: LogLineRequestResponse = await fetch({ url });
+            const payload: LogLineRequestResponse = await (await fetch({ url })).json();
 
             const { content: { lines, continuation_cursor, log_info_message } } = payload;
 

--- a/sematic/ui/src/hooks/pipelineHooks.ts
+++ b/sematic/ui/src/hooks/pipelineHooks.ts
@@ -59,8 +59,9 @@ export function useFetchRunsFn(runFilters: Filter | undefined = undefined,
         const response = await fetch({
             url: `/api/v1/runs?${qString}`
         });
+        const payload: RunListPayload = await response.json();
         setIsLoaded(true);
-        return response as RunListPayload;
+        return payload;
     }, [queryParams, fetch]);
 
     const {loading: isLoading, error, value: runs} = state;
@@ -90,10 +91,10 @@ export function useFetchRun(runID: string): [
     const {fetch} = useHttpClient();
 
     const {value, loading, error} = useAsync(async () => {
-        const response: RunViewPayload = await fetch({
+        const response = await fetch({
             url: `/api/v1/runs/${runID}`
         });
-        return response.content
+        return (await response.json() as RunViewPayload).content
     }, [runID]);
     
     return [value, loading, error];
@@ -105,10 +106,10 @@ export function useFetchResolution(resolutionId: string): [
     const {fetch} = useHttpClient();
 
     const {value, loading, error} = useAsync(async () => {
-        const response: ResolutionPayload = await fetch({
+        const response  = await fetch({
             url: `/api/v1/resolutions/${resolutionId}`
         });
-        return response.content;
+        return ((await response.json()) as ResolutionPayload).content;
     }, [resolutionId]);
     
     return [value, loading, error];

--- a/sematic/ui/src/login.tsx
+++ b/sematic/ui/src/login.tsx
@@ -30,13 +30,13 @@ function GoogleLoginComponent({
   const onGoogleLoginSuccess = useCallback(
     async (credentialResponse: CredentialResponse) => {
       try {
-        const payload: GoogleLoginPayload = await fetch({
+        const payload: GoogleLoginPayload = await (await fetch({
           url: "/login/google",
           method: "POST",
           body: {
             token: credentialResponse.credential,
           },
-        });
+        })).json();
         setError(undefined);
         setUser(payload.user);
         navigate(-1);


### PR DESCRIPTION
So now `useHttpClient` returns the raw HTTP responses instead of converting them to JSON. It should be up to the caller to decide in what format it wants to consume the response (there are cases when it does not have to be JSON).