### PR TITLE
Fix S3 signatures by specifying region and signature version

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -116,6 +116,20 @@ delta, but only:
 when performing the upgrade.
 {% endhint %}
 
+### v0.26.X to v0.27.Y
+
+#### Helm chart changes
+
+A new `bucket_region` value needs to be set in the deployment Helm chart:
+
+```yaml
+aws:
+  enabled: true
+  storage_bucket: my-s3-bucket # REPLACE ME
+  bucket_region: my-s3-region # REPLACE ME
+
+```
+
 ### v0.25.X to v0.26.Y
 
 #### Dependency changes

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
 {{ end }}
 {{ if .Values.aws.enabled }}
   AWS_S3_BUCKET: {{ .Values.aws.storage_bucket | quote }}
+  AWS_S3_REGION: {{ .Values.aws.bucket_region | quote }}
   STORAGE: "sematic.plugins.storage.s3_storage.S3Storage"
 {{ end }}
 {{ if .Values.slack.enabled }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -6,6 +6,7 @@ auth:
 aws:
   enabled: true
   storage_bucket: my-s3-bucket # REPLACE ME
+  bucket_region: my-s3-region # REPLACE ME
 
 slack:
   enabled: true

--- a/sematic/api/endpoints/storage.py
+++ b/sematic/api/endpoints/storage.py
@@ -85,7 +85,7 @@ def get_stored_data_redirect(user: Optional[User], namespace: str, key: str):
     for key, value in destination.request_headers.items():
         response.headers.set(key, value)
 
-    # Disabling caching for now
+    # TODO: Recover caching https://github.com/sematic-ai/sematic/issues/653
     # response.headers.set("Cache-Control", "max-age=31536000, immutable, private")
 
     return response

--- a/sematic/api/endpoints/storage.py
+++ b/sematic/api/endpoints/storage.py
@@ -85,6 +85,7 @@ def get_stored_data_redirect(user: Optional[User], namespace: str, key: str):
     for key, value in destination.request_headers.items():
         response.headers.set(key, value)
 
-    response.headers.set("Cache-Control", "max-age=31536000, immutable, private")
+    # Disabling caching for now
+    # response.headers.set("Cache-Control", "max-age=31536000, immutable, private")
 
     return response

--- a/sematic/plugins/storage/s3_storage.py
+++ b/sematic/plugins/storage/s3_storage.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, List, Type
 
 # Third-party
 import boto3
+import botocore.config
 import botocore.exceptions
 
 # Sematic
@@ -31,6 +32,7 @@ class S3ClientMethod(enum.Enum):
 
 class S3StorageSettingsVar(AbstractPluginSettingsVar):
     AWS_S3_BUCKET = "AWS_S3_BUCKET"
+    AWS_S3_REGION = "AWS_S3_REGION"
 
 
 class S3Storage(AbstractStorage, AbstractPlugin):
@@ -59,16 +61,27 @@ class S3Storage(AbstractStorage, AbstractPlugin):
         return get_plugin_setting(self.__class__, S3StorageSettingsVar.AWS_S3_BUCKET)
 
     @memoized_property
+    def _region(self) -> str:
+        return get_plugin_setting(self.__class__, S3StorageSettingsVar.AWS_S3_REGION)
+
+    @memoized_property
     def _s3_client(self):
-        return boto3.client("s3")
+        return boto3.client(
+            "s3",
+            config=botocore.config.Config(
+                region_name=self._region, signature_version="s3v4"
+            ),
+        )
 
     def _make_presigned_url(self, client_method: S3ClientMethod, key: str) -> str:
+        logger.info("Generating S3 presigned url for %s", key)
         presigned_url = self._s3_client.generate_presigned_url(
             ClientMethod=client_method.value,
             Params={
                 "Bucket": self._bucket,
                 "Key": key,
-                "ResponseCacheControl": "max-age=31536000, immutable, private",
+                # Disabling caching for now
+                # "ResponseCacheControl": "max-age=31536000, immutable, private",
             },
             ExpiresIn=self.PRESIGNED_URL_EXPIRATION,
         )

--- a/sematic/plugins/storage/s3_storage.py
+++ b/sematic/plugins/storage/s3_storage.py
@@ -80,7 +80,7 @@ class S3Storage(AbstractStorage, AbstractPlugin):
             Params={
                 "Bucket": self._bucket,
                 "Key": key,
-                # Disabling caching for now
+                # TODO: Recover caching https://github.com/sematic-ai/sematic/issues/653
                 # "ResponseCacheControl": "max-age=31536000, immutable, private",
             },
             ExpiresIn=self.PRESIGNED_URL_EXPIRATION,


### PR DESCRIPTION
The `Image` type PR #623 added caching to the storage `/data` endpoint and the S3 pre-signed URL.
The caching was always a little risky and made the assumption that both URLs (`/data` and S3) would be cached and expire at the same time, which is fickle. This PR removes S3 caching at this time.

Additionally, not specifying the bucket region and signature version to the boto3 client seems to lead to unstable URL signatures. This PR sets both region and signature version. The region needs to be set in the Helm value file.