### PR TITLE
Force /bin/bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+SHELL=/bin/bash
+
 UNAME_S := $(shell uname -s)
 RED := \033[0;31m
 NO_COLOR := \033[1;0m
-SHELL=/bin/bash
 
 migrate_up_rds:
 	cd sematic; DATABASE_URL=${DATABASE_URL} dbmate -s db/schema.sql.pg up 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 UNAME_S := $(shell uname -s)
 RED := \033[0;31m
 NO_COLOR := \033[1;0m
+SHELL=/bin/bash
 
 migrate_up_rds:
 	cd sematic; DATABASE_URL=${DATABASE_URL} dbmate -s db/schema.sql.pg up 


### PR DESCRIPTION
make does not care about your `$SHELL` setting because that would cause portability issues for people that share makefiles because `make` shell behavior would change across machines, and it defaults to `/bin/sh` which can be changed by passing args to the make command or by explicitly setting it in the Makefile.

`make pre-commit` fails on linux because `pushd` is not available.  it turns out it _is_ available on macos, but not on linux.  so this pr forces bash instead because we don't need to live in the stone age.

```
$ make pre-commit
python3 -m flake8
python3 -m mypy sematic
Success: no issues found in 256 source files
python3 -m black sematic --check
All done! ✨ 🍰 ✨
304 files would be left unchanged.
python3 -m isort sematic --diff
Skipped 3 files
pushd sematic/ui && npm run lint && popd
/bin/sh: 1: pushd: not found
make: *** [Makefile:25: pre-commit] Error 127
```