### PR TITLE
Decrease CloudResolver max poll interval to 1 min

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -26,7 +26,7 @@ from sematic.utils.memoized_property import memoized_property
 logger = logging.getLogger(__name__)
 
 
-_MAX_DELAY_BETWEEN_STATUS_UPDATES_SECONDS = 600  # 600s => 10 min
+_MAX_DELAY_BETWEEN_STATUS_UPDATES_SECONDS = 60  # 60s => 1 min
 _DELAY_BETWEEN_STATUS_UPDATES_BACKOFF = 1.5
 
 # It is important not to change these! They are used for identifying the start/end of

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 _MAX_DELAY_BETWEEN_STATUS_UPDATES_SECONDS = 60  # 60s => 1 min
-_DELAY_BETWEEN_STATUS_UPDATES_BACKOFF = 1.5
+_DELAY_BETWEEN_STATUS_UPDATES_BACKOFF = 1.25
 
 # It is important not to change these! They are used for identifying the start/end of
 # inline run logs. If you change it, inline logs written with prior versions of Sematic


### PR DESCRIPTION
Decreases the `CloudResolver` max polling interval from 10 min to 1 min. This will mean that the expected reaction time for progressing on DAG execution decreases from 5 min to 30 s.

The advantage is that after having waited for long-running runs to complete, the Resolver will continue scheduling new, unblocked runs, after waiting a less amount of extra time.

The disadvantage is more logs being outputted by the Resolver, but these are not viewable yet by the users anyway in the Cloud execution workflow that is improved by this PR.
