### PR TITLE
Allow caching dev requirements for server build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# Sematic dev
+requirements-dev-cache.txt
+Dockerfile.server-dev-cache
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -9,6 +9,14 @@ ARG EXTRA
 
 RUN python3 -m pip install --upgrade pip
 
+# Pre-install some requirements so that installing from the
+# wheel takes less time. This improves caching behavior
+# during development iterations, but should not be used
+# for production builds, as it will install extra dependencies
+# that aren't actually needed for the server to run.
+# <uncomment for pre-install-cache> COPY ./requirements*.txt /requirements/
+# <uncomment for pre-install-cache> RUN pip install -r /requirements/requirements-dev-cache.txt
+
 # Install from a local wheel
 COPY sematic-*.whl .
 RUN pip install $(ls ./sematic-*.whl)["${EXTRA}"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -14,6 +14,11 @@ RUN python3 -m pip install --upgrade pip
 # during development iterations, but should not be used
 # for production builds, as it will install extra dependencies
 # that aren't actually needed for the server to run.
+# The most convenient way to leverage this is by using a script
+# that automatically uncomments these lines and builds using the resulting
+# Dockerfile, but you can manually uncomment them.
+# Just make sure to have a requirements-dev-cache.txt file
+# in the docker dir before uncommenting.
 # <uncomment for pre-install-cache> COPY ./requirements*.txt /requirements/
 # <uncomment for pre-install-cache> RUN pip install -r /requirements/requirements-dev-cache.txt
 


### PR DESCRIPTION
Since the `pip install` of the Sematic wheel is one step in the image build, Docker is not able to cache the install of Sematic's requirements. Requirements installs go in the same layer as whatever local changes have been made. This makes the build & push slower than they need to be, and also makes it so k8s nodes aren't able to effectively cache a layer for the image with deps installed. During iterative development and deployment, the wasted time can add up. This makes a couple changes to the Dockerfile that will make it possible during dev to cache the requirements install in a different image layer. This is meant to be used in conjunction with a change in the "serve-dev" development deployment script, which will be able to leverage the caching.