### PR TITLE
Fix incorrect set command in user docs

### DIFF
--- a/docs/local-execution.md
+++ b/docs/local-execution.md
@@ -25,7 +25,7 @@ your machine or a remote one deployed in your cloud environment is dictated by
 the value of the `SEMATIC_API_ADDRESS` setting, which you can set using the following:
 
 ```shell
-$ sematic set SEMATIC_API_ADDRESS https://address.to.deployed.server
+$ sematic settings set SEMATIC_API_ADDRESS https://address.to.deployed.server
 ```
 
 By default, i.e. if you haven't set `SEMATIC_API_ADDRESS` to any value, metadata


### PR DESCRIPTION
Fixes an incorrect instruction in the user-facing documentation.
