### PR TITLE
Add minimally required resources to pre-install Helm hook

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
 {{ if .Values.auth.enabled }}
   GOOGLE_OAUTH_CLIENT_ID: {{ .Values.auth.google_oauth_client_id | quote }}

--- a/helm/sematic-server/templates/secret.yaml
+++ b/helm/sematic-server/templates/secret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   DATABASE_URL: {{ .Values.database.url | b64enc }}
 {{ end }}

--- a/helm/sematic-server/templates/server-role-binding.yaml
+++ b/helm/sematic-server/templates/server-role-binding.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Values.service_account.name | default .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.service_account.name | default .Release.Name }}

--- a/helm/sematic-server/templates/server-role.yaml
+++ b/helm/sematic-server/templates/server-role.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Values.service_account.name | default .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]

--- a/helm/sematic-server/templates/serviceaccount.yaml
+++ b/helm/sematic-server/templates/serviceaccount.yaml
@@ -8,5 +8,8 @@ metadata:
   {{- with .Values.service_account.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
   {{- end }}
 {{- end }}


### PR DESCRIPTION
our helm installs break on new clusters where sematic is not currently installed, because the db migration pod gets created before its secret/configmap is created.  this pr remedies this by creating the base resources at pre-install via a helm hook as well, and by giving them a negative weight value, which means they get created even before the db migration job does.