### PR TITLE
Fixes that ErrorBoundary error never dismisses.

### DIFF
--- a/sematic/ui/packages/main/src/pipelines/Artifacts.tsx
+++ b/sematic/ui/packages/main/src/pipelines/Artifacts.tsx
@@ -30,7 +30,7 @@ function ArtifactError(props: { error: Error }) {
 function ArtifactView(props: { artifact: Artifact }) {
   let { artifact } = props;
   return (
-    <ErrorBoundary FallbackComponent={ArtifactError}>
+    <ErrorBoundary resetKeys={[artifact.id]} FallbackComponent={ArtifactError}>
       <Box>
         <Box sx={{ float: "right" }}>
           <ArtifactID artifactId={artifact.id} />


### PR DESCRIPTION
Fixes a bug that the `<ErrorBoundary />` component had no way to recover from an error state. Now use `resetKeys` to fix that, docs [here](https://www.npmjs.com/package/react-error-boundary)

Before:

![capture1](https://user-images.githubusercontent.com/1046489/225484041-0ecb8b2a-6472-4ca5-b6c8-4de21ff23ccd.gif)


After:

![capture1](https://user-images.githubusercontent.com/1046489/225483840-0647d705-17d1-4d8f-b0ab-d530c8401b60.gif)
