### PR TITLE
Mark root run as failed for resolver fails

### DIFF
--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -288,4 +288,6 @@ def test_resolver_restart(
     assert read_run_state_by_id[child_run1.id] == FutureState.CANCELED.value
     assert read_run_state_by_id[child_run2.id] == FutureState.RESOLVED.value
     assert read_run_state_by_id[child_run3.id] == FutureState.CANCELED.value
-    assert read_run_state_by_id[root_run.id] == FutureState.CANCELED.value
+
+    # We want the root run to show up as Failed in this circumstance.
+    assert read_run_state_by_id[root_run.id] == FutureState.FAILED.value


### PR DESCRIPTION
Currently, for certain failure modes of the resolver, the root run will get marked as `CANCELED`. This has been observed "in the wild" in particular for a failure to schedule a run.

Testing
--------
Changed `schedule_run` API call to this:
```python
def schedule_run(run_id: str) -> Run:
    """Ask the server to execute the calculator for the run."""
    import random
    if random.random() < 0.10:
        raise ValueError("Emulate random failure!")
    response = _post(f"/runs/{run_id}/schedule", json_payload={})
    return Run.from_json_encodable(response["content"])
```
And launched a [high fan-out run](https://dev1.dev-usw2-sematic0.sematic.cloud/runs/0fba7d8104ea4cafb6759f6867c39f81). Confirmed that the root run got marked as FAILED rather than CANCELED. 