### PR TITLE
Make notifying about updates not fatal on failure

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -434,7 +434,10 @@ def _notify_event(namespace: str, event: str, payload: Any = None):
         event,
         payload,
     )
-    _post("/events/{}/{}".format(namespace, event), payload)
+    try:
+        _post("/events/{}/{}".format(namespace, event), payload)
+    except Exception:
+        logger.exception("Error notifying %s/%s", namespace, event)
 
 
 @retry(

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -15,6 +15,7 @@ from sematic.api.tests.fixtures import test_client  # noqa: F401
 from sematic.api_client import (
     IncompatibleClientError,
     ServerError,
+    _notify_event,
     _validate_server_compatibility,
     get_artifact_value_by_id,
 )
@@ -153,3 +154,13 @@ def test_get_artifact_value_by_id(
 
     assert isinstance(value, int)
     assert value == 42
+
+
+@mock.patch("sematic.api_client.requests")
+def test_notify_resilient(mock_requests):
+    mock_requests.post.side_effect = RuntimeError("Intentional fail!")
+
+    # Shouldn't raise
+    _notify_event("foo", "bar", {})
+
+    mock_requests.post.assert_called()


### PR DESCRIPTION
Whenever a resolver makes updates to graph/pipeline state, it tries to send out a notification that it has done so. This helps the UI refresh promptly on changes. However, sometimes the socketio server is unable to fulfill the request to broadcast, in which case the resolver would crash. Since this notification is for UI purposes only, it should not be fatal to a resolution. This PR makes it so that is the case.