### PR TITLE
Fixes bug when displaying duration for cloned run

### DIFF
--- a/sematic/ui/packages/main/src/components/RunTime.tsx
+++ b/sematic/ui/packages/main/src/components/RunTime.tsx
@@ -1,13 +1,34 @@
 import { Typography } from "@mui/material";
 import { Run } from "@sematic/common/src/Models";
 
+function InstantRunTime({ prefix }: { prefix?: string}) {
+  return (
+    <Typography fontSize="small" color="GrayText">
+      {`${prefix} <1s`}
+    </Typography>
+  );
+}
+
+function UnkownRunTime() {
+  return (
+    <Typography fontSize="small" color="GrayText">
+      {"Unknown duration"}
+    </Typography>
+  );
+}
+
 export function RunTime(props: { run: Run; prefix?: string }) {
   const { run, prefix = "" } = props;
   let startedAt = new Date(run.started_at || run.created_at);
   let endedAt = new Date();
+  if (run.original_run_id !== null) {
+    return <InstantRunTime prefix={prefix} />;
+  }
   let endTimeString = run.failed_at || run.resolved_at;
   if (endTimeString) {
     endedAt = new Date(endTimeString);
+  } else {
+    return <UnkownRunTime />;
   }
 
   let durationS: number = Math.round(


### PR DESCRIPTION
For cloned runs, we fill neither the `failed_at` or `resolved_at` fields. In order to display duration correctly, when we see the run has "original_run_id" field, we hardcode the running duration to "<1s"

This will not fix the issue if `failed_at` or `resolved_at` fields are null for failed or canceled runs. That will be investigated separately.