### PR TITLE
Use URL parameter to construct redirects

### DIFF
--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -89,14 +89,11 @@ sematic_py_lib(
     deps = [
         ":auth",
         ":request_parameters",
-        ":storage",
         "//sematic/api:app",
         "//sematic/db:db",
         "//sematic/db:queries",
         "//sematic/db/models:artifact",
         "//sematic/db/models:user",
-        "//sematic/plugins:abstract_storage",
-        "//sematic/plugins/storage:local_storage",
     ],
 )
 

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -14,13 +14,10 @@ from sematic.api.endpoints.request_parameters import (
     get_request_parameters,
     jsonify_error,
 )
-from sematic.api.endpoints.storage import get_stored_data_redirect
 from sematic.db.db import db
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.user import User
 from sematic.db.queries import get_artifact
-from sematic.plugins.abstract_storage import get_storage_plugins
-from sematic.plugins.storage.local_storage import LocalStorage
 
 logger = logging.getLogger(__name__)
 

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -73,36 +73,3 @@ def get_artifact_endpoint(user: Optional[User], artifact_id: str) -> flask.Respo
     payload = dict(content=artifact.to_json_encodable())
 
     return flask.jsonify(payload)
-
-
-# Kept for backward compatibility with 0.23.0
-@sematic_api.route("/api/v1/artifacts/<artifact_id>/location", methods=["GET"])
-@authenticate
-def get_artifact_location_endpoint(user: Optional[User], artifact_id: str):
-    try:
-        storage_plugin = get_storage_plugins([LocalStorage])[0]
-    except Exception as e:
-        logger.exception("Unable to load the storage plugin: %s", str(e))
-
-        return jsonify_error(
-            "Incorrect storage plugin scope", HTTPStatus.INTERNAL_SERVER_ERROR
-        )
-
-    destination = storage_plugin().get_write_destination("artifacts", artifact_id, user)
-
-    location = destination.url
-
-    # If this is a Sematic URL, older clients expect the relative path and will add
-    # auth headers on their own
-    url_parts = location.split("/api/v1")
-    if len(url_parts) > 1:
-        location = url_parts[1]
-
-    return flask.jsonify(dict(location=location))
-
-
-# Kept for backward compatibility with 0.23.0
-@sematic_api.route("/api/v1/artifacts/<artifact_id>/data", methods=["GET"])
-@authenticate
-def get_artifact_data_endpoint(user: Optional[User], artifact_id: str):
-    return get_stored_data_redirect(user, "artifacts", artifact_id)

--- a/sematic/api/endpoints/storage.py
+++ b/sematic/api/endpoints/storage.py
@@ -10,6 +10,7 @@ import flask
 from sematic.api.app import sematic_api
 from sematic.api.endpoints.auth import authenticate
 from sematic.api.endpoints.request_parameters import jsonify_error
+from sematic.config.config import get_config
 from sematic.db.models.user import User
 from sematic.plugins.abstract_storage import StorageDestination, get_storage_plugins
 from sematic.plugins.storage.local_storage import LocalStorage
@@ -101,6 +102,8 @@ def _get_storage_destination_url(
         return destination.url
 
     if destination.path is not None:
-        return f"{flask.request.host_url}{destination.path}"
+        host = request.args.get("origin", get_config().server_url)
+
+        return f"{host}{destination.path}"
 
     raise RuntimeError("Missing path or url")

--- a/sematic/api/endpoints/storage.py
+++ b/sematic/api/endpoints/storage.py
@@ -11,7 +11,7 @@ from sematic.api.app import sematic_api
 from sematic.api.endpoints.auth import authenticate
 from sematic.api.endpoints.request_parameters import jsonify_error
 from sematic.db.models.user import User
-from sematic.plugins.abstract_storage import get_storage_plugins
+from sematic.plugins.abstract_storage import StorageDestination, get_storage_plugins
 from sematic.plugins.storage.local_storage import LocalStorage
 
 logger = logging.getLogger(__name__)
@@ -47,9 +47,11 @@ def get_storage_location(
 
     destination = storage_plugin().get_write_destination(namespace, key, user)
 
+    url = _get_storage_destination_url(destination, flask.request)
+
     return flask.jsonify(
         dict(
-            url=destination.url,
+            url=url,
             request_headers=destination.request_headers,
         )
     )
@@ -80,7 +82,8 @@ def get_stored_data_redirect(user: Optional[User], namespace: str, key: str):
 
     destination = storage_plugin().get_read_destination(namespace, key, user)
 
-    response = flask.redirect(destination.url, code=HTTPStatus.FOUND)
+    url = _get_storage_destination_url(destination, flask.request)
+    response = flask.redirect(url, code=HTTPStatus.FOUND)
 
     for key, value in destination.request_headers.items():
         response.headers.set(key, value)
@@ -89,3 +92,15 @@ def get_stored_data_redirect(user: Optional[User], namespace: str, key: str):
     # response.headers.set("Cache-Control", "max-age=31536000, immutable, private")
 
     return response
+
+
+def _get_storage_destination_url(
+    destination: StorageDestination, request: flask.Request
+) -> str:
+    if destination.url is not None:
+        return destination.url
+
+    if destination.path is not None:
+        return f"{flask.request.host_url}{destination.path}"
+
+    raise RuntimeError("Missing path or url")

--- a/sematic/api/endpoints/storage.py
+++ b/sematic/api/endpoints/storage.py
@@ -2,6 +2,7 @@
 import logging
 from http import HTTPStatus
 from typing import Optional
+from urllib.parse import urlparse
 
 # Third-party
 import flask
@@ -98,12 +99,10 @@ def get_stored_data_redirect(user: Optional[User], namespace: str, key: str):
 def _get_storage_destination_url(
     destination: StorageDestination, request: flask.Request
 ) -> str:
-    if destination.url is not None:
-        return destination.url
+    parsed_url = urlparse(destination.uri)
 
-    if destination.path is not None:
+    if parsed_url.scheme == "sematic":
         host = request.args.get("origin", get_config().server_url)
+        return f"{host}{parsed_url.path}"
 
-        return f"{host}{destination.path}"
-
-    raise RuntimeError("Missing path or url")
+    return destination.uri

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -128,7 +128,9 @@ def store_payloads(payloads: Iterable[UploadPayload]) -> None:
 
 @retry(tries=3, delay=10, jitter=1)
 def _store_bytes(namespace: str, key: str, bytes_: bytes) -> None:
-    response = _get(f"/storage/{namespace}/{key}/location")
+    origin = get_config().server_url
+
+    response = _get(f"/storage/{namespace}/{key}/location?origin={origin}")
 
     url: str = response["url"]
     headers: Dict[str, str] = response["request_headers"]
@@ -146,7 +148,12 @@ def get_future_bytes(future_id: str) -> bytes:
 
 @retry(tries=3, delay=10, jitter=1)
 def _get_stored_bytes(namespace: str, key: str) -> bytes:
-    return _get(f"/storage/{namespace}/{key}/data", decode_json=False)
+    origin = get_config().server_url
+
+    return _get(
+        f"/storage/{namespace}/{key}/data?origin={origin}",
+        decode_json=False,
+    )
 
 
 def get_run(run_id: str) -> Run:

--- a/sematic/plugins/abstract_storage.py
+++ b/sematic/plugins/abstract_storage.py
@@ -11,8 +11,13 @@ from sematic.db.models.user import User
 
 @dataclass
 class StorageDestination:
-    url: str
+    url: Optional[str] = None
+    path: Optional[str] = None
     request_headers: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.url is None and self.path is None:
+            raise ValueError("Either path or url must be specified.")
 
 
 class AbstractStorage(abc.ABC):

--- a/sematic/plugins/abstract_storage.py
+++ b/sematic/plugins/abstract_storage.py
@@ -11,13 +11,8 @@ from sematic.db.models.user import User
 
 @dataclass
 class StorageDestination:
-    url: Optional[str] = None
-    path: Optional[str] = None
+    uri: str
     request_headers: Dict[str, str] = field(default_factory=dict)
-
-    def __post_init__(self):
-        if self.url is None and self.path is None:
-            raise ValueError("Either path or url must be specified.")
 
 
 class AbstractStorage(abc.ABC):

--- a/sematic/plugins/storage/local_storage.py
+++ b/sematic/plugins/storage/local_storage.py
@@ -41,7 +41,7 @@ class LocalStorage(AbstractStorage, AbstractPlugin):
     ) -> StorageDestination:
 
         return StorageDestination(
-            path=f"/api/v1/storage/{namespace}/{key}/local",
+            uri=f"sematic:///api/v1/storage/{namespace}/{key}/local",
             request_headers=_make_headers(user),
         )
 
@@ -49,7 +49,7 @@ class LocalStorage(AbstractStorage, AbstractPlugin):
         self, namespace: str, key: str, user: Optional[User]
     ) -> StorageDestination:
         return StorageDestination(
-            path=f"/api/v1/storage/{namespace}/{key}/local",
+            uri=f"sematic:///api/v1/storage/{namespace}/{key}/local",
             request_headers=_make_headers(user),
         )
 

--- a/sematic/plugins/storage/local_storage.py
+++ b/sematic/plugins/storage/local_storage.py
@@ -41,7 +41,7 @@ class LocalStorage(AbstractStorage, AbstractPlugin):
     ) -> StorageDestination:
 
         return StorageDestination(
-            url=f"{get_config().api_url}/storage/{namespace}/{key}/local",
+            path=f"/api/v1/storage/{namespace}/{key}/local",
             request_headers=_make_headers(user),
         )
 
@@ -49,7 +49,7 @@ class LocalStorage(AbstractStorage, AbstractPlugin):
         self, namespace: str, key: str, user: Optional[User]
     ) -> StorageDestination:
         return StorageDestination(
-            url=f"{get_config().api_url}/storage/{namespace}/{key}/local",
+            path=f"/api/v1/storage/{namespace}/{key}/local",
             request_headers=_make_headers(user),
         )
 

--- a/sematic/plugins/storage/memory_storage.py
+++ b/sematic/plugins/storage/memory_storage.py
@@ -10,7 +10,6 @@ from sematic.abstract_plugin import SEMATIC_PLUGIN_AUTHOR, AbstractPlugin, Plugi
 from sematic.api.app import sematic_api
 from sematic.api.endpoints.auth import API_KEY_HEADER, authenticate
 from sematic.api.endpoints.request_parameters import jsonify_error
-from sematic.config.config import get_config
 from sematic.db.models.user import User
 from sematic.plugins.abstract_storage import (
     AbstractStorage,
@@ -54,7 +53,7 @@ class MemoryStorage(AbstractStorage, AbstractPlugin):
         self, namespace: str, key: str, user: Optional[User]
     ) -> StorageDestination:
         return StorageDestination(
-            url=f"{get_config().api_url}/storage/{namespace}/{key}/memory",
+            uri=f"sematic:///api/v1/storage/{namespace}/{key}/memory",
             request_headers=_make_headers(user),
         )
 
@@ -62,7 +61,7 @@ class MemoryStorage(AbstractStorage, AbstractPlugin):
         self, namespace: str, key: str, user: Optional[User]
     ) -> StorageDestination:
         return StorageDestination(
-            url=f"{get_config().api_url}/storage/{namespace}/{key}/memory",
+            uri=f"sematic:///api/v1/storage/{namespace}/{key}/memory",
             request_headers=_make_headers(user),
         )
 

--- a/sematic/plugins/storage/s3_storage.py
+++ b/sematic/plugins/storage/s3_storage.py
@@ -90,12 +90,12 @@ class S3Storage(AbstractStorage, AbstractPlugin):
 
     def get_write_destination(self, namespace: str, key: str, _) -> StorageDestination:
         return StorageDestination(
-            url=self._make_presigned_url(S3ClientMethod.PUT, f"{namespace}/{key}")
+            uri=self._make_presigned_url(S3ClientMethod.PUT, f"{namespace}/{key}")
         )
 
     def get_read_destination(self, namespace: str, key: str, _) -> StorageDestination:
         return StorageDestination(
-            url=self._make_presigned_url(S3ClientMethod.GET, f"{namespace}/{key}")
+            uri=self._make_presigned_url(S3ClientMethod.GET, f"{namespace}/{key}")
         )
 
     @retry(tries=3, delay=5)

--- a/sematic/plugins/storage/tests/test_local_storage.py
+++ b/sematic/plugins/storage/tests/test_local_storage.py
@@ -24,12 +24,12 @@ def test_upload_download(
             "sematic.plugins.storage.local_storage._get_data_dir", return_value=tempdir
         ):
             destination = local_storage.get_write_destination("artifacts", "123", None)
-            response = test_client.put(destination.url, data=value)
+            response = test_client.put(destination.path, data=value)
 
             assert response.status_code == 200
 
             destination = local_storage.get_read_destination("artifacts", "123", None)
 
-            response = test_client.get(destination.url)
+            response = test_client.get(destination.path)
 
             assert response.data == value

--- a/sematic/plugins/storage/tests/test_local_storage.py
+++ b/sematic/plugins/storage/tests/test_local_storage.py
@@ -1,6 +1,7 @@
 # Standard Library
 import tempfile
 from unittest import mock
+from urllib.parse import urlparse
 
 # Third-party
 import flask.testing
@@ -24,12 +25,19 @@ def test_upload_download(
             "sematic.plugins.storage.local_storage._get_data_dir", return_value=tempdir
         ):
             destination = local_storage.get_write_destination("artifacts", "123", None)
-            response = test_client.put(destination.path, data=value)
+            parsed_url = urlparse(destination.uri)
+
+            assert parsed_url.scheme == "sematic"
+
+            response = test_client.put(parsed_url.path, data=value)
 
             assert response.status_code == 200
 
             destination = local_storage.get_read_destination("artifacts", "123", None)
+            parsed_url = urlparse(destination.uri)
 
-            response = test_client.get(destination.path)
+            assert parsed_url.scheme == "sematic"
+
+            response = test_client.get(parsed_url.path)
 
             assert response.data == value

--- a/sematic/plugins/storage/tests/test_memory_storage.py
+++ b/sematic/plugins/storage/tests/test_memory_storage.py
@@ -1,3 +1,6 @@
+# Standard Library
+from urllib.parse import urlparse
+
 # Third-party
 import flask.testing
 
@@ -16,13 +19,19 @@ def test_upload(
     memory_storage = MemoryStorage()
 
     destination = memory_storage.get_write_destination("artifacts", "123", None)
+    parsed_url = urlparse(destination.uri)
 
-    response = test_client.put(destination.url, data=value)
+    assert parsed_url.scheme == "sematic"
+
+    response = test_client.put(parsed_url.path, data=value)
 
     assert response.status_code == 200
 
     destination = memory_storage.get_read_destination("artifacts", "123", None)
+    parsed_url = urlparse(destination.uri)
 
-    response = test_client.get(destination.url)
+    assert parsed_url.scheme == "sematic"
+
+    response = test_client.get(parsed_url.path)
 
     assert response.data == value

--- a/sematic/plugins/storage/tests/test_s3_storage.py
+++ b/sematic/plugins/storage/tests/test_s3_storage.py
@@ -22,8 +22,8 @@ def test_upload_download(
     ):
         destination = s3_storage.get_write_destination("artifacts", "123", None)
 
-        assert destination.url == "https://presigned-url"
+        assert destination.uri == "https://presigned-url"
 
         destination = s3_storage.get_read_destination("artifacts", "123", None)
 
-        assert destination.url == "https://presigned-url"
+        assert destination.uri == "https://presigned-url"

--- a/sematic/ui/packages/main/src/hooks/blobHooks.ts
+++ b/sematic/ui/packages/main/src/hooks/blobHooks.ts
@@ -10,7 +10,7 @@ export default function useFetchBlob(blobId: string): [
 
   const {value, loading, error} = useAsync(async () => {
     const response  = await fetch({
-        url: `/api/v1/storage/blobs/${blobId}/data`
+        url: `/api/v1/storage/blobs/${blobId}/data?origin=${window.location.origin}`
     });
     return ((await response.arrayBuffer()) as ArrayBuffer);
   }, [blobId]);


### PR DESCRIPTION
Depending on where the client is making a request (in-cluster, browser, local dev box), the host and scheme of a redirect URL are different.

If we controlled a single deployment we could make sure the correct headers are forwarded so as to reconstruct the origin host, but because we don't control every deployment environments, we must use some other mechanism.
In this PR, an `origin` URL parameter is added to queries to store and retrieve stored data.