### PR TITLE
Fixes a UI bug that the content of a table cell would explode the table width and disrupt column alignment

### DIFF
--- a/sematic/ui/packages/main/src/components/CalculatorPath.tsx
+++ b/sematic/ui/packages/main/src/components/CalculatorPath.tsx
@@ -3,7 +3,7 @@ import Typography from "@mui/material/Typography";
 function CalculatorPath(props: { calculatorPath: string; component?: string }) {
   return (
     <Typography fontSize="small" color="GrayText" component="span">
-      <code style={{ fontSize: 12 }}>{props.calculatorPath}</code>
+      <code style={{ fontSize: 12, wordWrap: 'break-word' }}>{props.calculatorPath}</code>
     </Typography>
   );
 }

--- a/sematic/ui/packages/main/src/components/RunList.tsx
+++ b/sematic/ui/packages/main/src/components/RunList.tsx
@@ -174,7 +174,7 @@ export function RunList(props: RunListProps) {
 
   return (
     <StyledTableContainer data-cy={"RunList"}>
-      <Table size={props.size} >
+      <Table size={props.size} style={{ 'tableLayout': 'fixed' }}>
         <TableHead>
           <TableRow>
             {columns.map(({name, width}) => (
@@ -184,7 +184,7 @@ export function RunList(props: RunListProps) {
         </TableHead>
       </Table>
       <TBodyScroller>
-        <Table>
+        <Table style={{ 'tableLayout': 'fixed' }}>
           {tableBody}
         </Table>
       </TBodyScroller>


### PR DESCRIPTION
Before:

![capture1](https://user-images.githubusercontent.com/1046489/226705428-3b70ce6d-2e0f-4838-b96e-ee2db2b14531.gif)

After:

<img width="1179" alt="image" src="https://user-images.githubusercontent.com/1046489/226704968-7fc3751a-3463-47b2-8f0b-fd32767bc9c6.png">
