### PR TITLE
Make local Server run with Python 3.10

### DIFF
--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -39,6 +39,9 @@ sematic_py_lib(
         "//sematic/types:init",
         "//sematic/utils:exceptions",
     ],
+    pip_deps = [
+        "gevent",
+    ],
 )
 
 sematic_py_lib(

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -1,10 +1,20 @@
 """
 Sematic Public API
 """
+# Third-party
+import gevent.monkey  # type: ignore
+
+# This enables us to use websockets and standard HTTP requests in the same server locally,
+# which is what we want. If you try to use Gunicorn to do this, gevent will complain about
+# not monkey patching early enough, unless you have the gevent monkey patch applied VERY
+# early (like user/sitecustomize).
+# Monkey patching: https://github.com/gevent/gevent/issues/1235
+gevent.monkey.patch_all()
+
 # Standard Library
-import os
-import platform
-import sys
+import os  # noqa: E402
+import platform  # noqa: E402
+import sys  # noqa: E402
 
 # `urllib` invokes the underlying OS framework to get configured system proxies.
 # On MacOS, this call causes the OS to immediately kill the `gunicorn` WSGI worker because


### PR DESCRIPTION
The local Server does not work when installed and started from the wheel for Python 3.10 only. Running from Bazel is unaffected.

The webserver was not accepting connections at all. The fix was to apply the `gevent` monkey patch as the first thing on importing the `sematic` module.

Tested locally in a virtualenv by starting the Server and submitting a pipeline.
