### PR TITLE
Fix matplotlib figures serialization

### DIFF
--- a/sematic/types/types/matplotlib/figure.py
+++ b/sematic/types/types/matplotlib/figure.py
@@ -1,18 +1,15 @@
-# Standard Library
-from typing import Any
-
 # Third-party
 import matplotlib.figure  # type: ignore
 from mpld3 import fig_to_dict
 
 # Sematic
-from sematic.types.registry import register_to_json_encodable_summary
+from sematic.types.registry import SummaryOutput, register_to_json_encodable_summary
 
 
 @register_to_json_encodable_summary(matplotlib.figure.Figure)
-def _mpl_figure_summary(value: matplotlib.figure.Figure, _) -> Any:
+def _mpl_figure_summary(value: matplotlib.figure.Figure, _) -> SummaryOutput:
     # Without setting this DPI to 70 (default 100), the fonts on the
     # plot would be too small to see.
     value.set_dpi(70)
     fig_dict = fig_to_dict(value)
-    return {"mpld3": fig_dict}
+    return {"mpld3": fig_dict}, {}


### PR DESCRIPTION
Using the `matplotlib.figure.Figure` type with non-silent resolvers cause a fatal error:

```
$ bazel run sematic/examples/liver_cirrhosis:liver_cirrhosis
```
![image](https://user-images.githubusercontent.com/1894533/228332739-81741501-f2b3-4d66-b194-4de0bdd8e4b5.png)

After the fix:
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/1894533/228332802-8329d324-0b0a-4b2e-8be1-4b1cb1241aec.png">

The issue was caused by unpropagated changes to the `matplotlib` figure serialization code. I quickly checked the entire codebase, and there don't seem to be other impacted types.
