### PR TITLE
Fix corner case sqlite version comparison

### DIFF
--- a/sematic/config/config.py
+++ b/sematic/config/config.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 from sematic.config.config_dir import get_config_dir
 from sematic.config.settings import MissingSettingsError
 from sematic.config.user_settings import UserSettingsVar, get_user_setting
-from sematic.versions import version_as_string
+from sematic.versions import string_version_to_tuple, version_as_string
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +20,8 @@ MIN_SQLITE_VERSION = (3, 35, 0)
 
 
 def _check_sqlite_version():
-    version_tuple = sqlite3.sqlite_version.split(".")
-
-    # get major/minor as ints. Patch can sometimes have non-digit chars
-    major, minor = int(version_tuple[0]), int(version_tuple[1])
-    if (major, minor) < MIN_SQLITE_VERSION:
+    version_tuple = string_version_to_tuple(sqlite3.sqlite_version)
+    if version_tuple < MIN_SQLITE_VERSION:
         # TODO #302: implement sustainable way to upgrade sqlite3 DBs
         logger.warning(
             "Sematic will soon require the sqlite3 version to be at least %s, but your "

--- a/sematic/tests/test_versions.py
+++ b/sematic/tests/test_versions.py
@@ -71,3 +71,9 @@ def test_string_version_to_tuple():
     as_tuple = (1, 2, 3)
     assert version_as_string(as_tuple) == as_string
     assert string_version_to_tuple(as_string) == as_tuple
+
+
+def test_exotic_string_version_to_tuple():
+    as_string = "1.2.3+arch"
+    as_tuple = (1, 2, 3)
+    assert string_version_to_tuple(as_string) == as_tuple

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -1,5 +1,6 @@
 # Standard Library
 import logging
+import re
 import typing
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,16 @@ def string_version_to_tuple(version_string: str) -> typing.Tuple[int, int, int]:
         raise ValueError(
             f"Version strings should have at least three digits. Got: {version_string}"
         )
-    return tuple(int(v) for v in string_components[:3])  # type: ignore
+    return (
+        int(string_components[0]),
+        int(string_components[1]),
+        _consume_number(string_components[2]),
+    )
+
+
+def _consume_number(s: str) -> int:
+    match = re.search(r"\d+", s)
+    return 0 if match is None else int(match.group())
 
 
 CURRENT_VERSION_STR = version_as_string(CURRENT_VERSION)


### PR DESCRIPTION
Fixes #554, which was caused by not comparing the patch version of the `sqlite` version string.