### PR TITLE
Use `Image` to support `matplotlib.figure.Figure`

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -67,9 +67,6 @@ python-magic
 kubernetes
 boto3
 
-# Matplotlib
-mpld3
-
 # External Resource Plugins
 ## Ray
 # Note: just because we depend on ray[air] here does NOT

--- a/sematic/types/types/image.py
+++ b/sematic/types/types/image.py
@@ -63,7 +63,7 @@ class Image:
 
 
 @register_to_json_encodable_summary(Image)
-def _image_to_summary(value: Image, _) -> SummaryOutput:
+def image_to_summary(value: Image, _) -> SummaryOutput:
 
     if magic_import_error is not None:
         _log_magic_import_error(magic_import_error, fatal=True)

--- a/sematic/types/types/matplotlib/BUILD
+++ b/sematic/types/types/matplotlib/BUILD
@@ -1,10 +1,6 @@
 sematic_py_lib(
     name = "figure",
     srcs = ["figure.py"],
-    pip_deps = [
-        # Do not add matplotlib here
-        "mpld3",
-    ],
     deps = [
         "//sematic/types:registry",
     ],

--- a/sematic/types/types/matplotlib/__init__.py
+++ b/sematic/types/types/matplotlib/__init__.py
@@ -2,9 +2,7 @@ try:
     # Third-party
     import matplotlib  # noqa: F401
 except ImportError:
-    print("NO MATPLOTLIB")
     pass
 else:
-    print("YES MATPLOTLIB")
     # Sematic
     import sematic.types.types.matplotlib.figure  # noqa: F401

--- a/sematic/types/types/matplotlib/__init__.py
+++ b/sematic/types/types/matplotlib/__init__.py
@@ -2,7 +2,9 @@ try:
     # Third-party
     import matplotlib  # noqa: F401
 except ImportError:
+    print("NO MATPLOTLIB")
     pass
 else:
+    print("YES MATPLOTLIB")
     # Sematic
     import sematic.types.types.matplotlib.figure  # noqa: F401

--- a/sematic/types/types/matplotlib/figure.py
+++ b/sematic/types/types/matplotlib/figure.py
@@ -1,15 +1,20 @@
+# Standard Library
+from io import BytesIO
+
 # Third-party
 import matplotlib.figure  # type: ignore
-from mpld3 import fig_to_dict
 
 # Sematic
 from sematic.types.registry import SummaryOutput, register_to_json_encodable_summary
+from sematic.types.types.image import Image, image_to_summary
 
 
 @register_to_json_encodable_summary(matplotlib.figure.Figure)
 def _mpl_figure_summary(value: matplotlib.figure.Figure, _) -> SummaryOutput:
-    # Without setting this DPI to 70 (default 100), the fonts on the
-    # plot would be too small to see.
-    value.set_dpi(70)
-    fig_dict = fig_to_dict(value)
-    return {"mpld3": fig_dict}, {}
+    file_obj = BytesIO()
+    value.savefig(file_obj)
+    file_obj.flush()
+    file_obj.seek(0)
+    image = Image(bytes=file_obj.read())
+
+    return image_to_summary(image, Image)

--- a/sematic/types/types/matplotlib/tests/BUILD
+++ b/sematic/types/types/matplotlib/tests/BUILD
@@ -1,0 +1,11 @@
+pytest_test(
+    name = "test_figure",
+    srcs = ["test_figure.py"],
+    pip_deps = ["matplotlib"],
+    deps = [
+        "//sematic/types:init",
+        "//sematic/types:serialization",
+        "//sematic/types/types:image",
+        "//sematic/types/types/matplotlib:figure",
+    ],
+)

--- a/sematic/types/types/matplotlib/tests/test_figure.py
+++ b/sematic/types/types/matplotlib/tests/test_figure.py
@@ -1,0 +1,30 @@
+# Standard Library
+from io import BytesIO
+
+# Third-party
+import matplotlib.figure  # type: ignore
+import matplotlib.pyplot as plt
+
+# Sematic
+from sematic.types.serialization import get_json_encodable_summary
+from sematic.types.types.image import Image
+
+
+def test_figure_summary():
+    figure = plt.figure()
+    plt.plot(range(100))
+
+    figure_summary, figure_blobs = get_json_encodable_summary(
+        figure, matplotlib.figure.Figure
+    )
+
+    file_obj = BytesIO()
+    figure.savefig(file_obj)
+    file_obj.flush()
+    file_obj.seek(0)
+    image = Image(bytes=file_obj.read())
+
+    _, image_blobs = get_json_encodable_summary(image, Image)
+
+    assert figure_summary["mime_type"] == "image/png"
+    assert list(figure_blobs.values()) == list(image_blobs.values())

--- a/sematic/ui/packages/main/src/types/image.tsx
+++ b/sematic/ui/packages/main/src/types/image.tsx
@@ -3,11 +3,12 @@ import { useMemo } from "react";
 import { CommonValueViewProps } from "src/types/common";
 import { base64ArrayBuffer } from "src/base64ArrayBuffer";
 import useFetchBlob from "src/hooks/blobHooks";
+import Zoom from "react-medium-image-zoom";
 
 export default function ImageValueView(props: CommonValueViewProps) {
   const { valueSummary } = props;
   const { bytes, mime_type } = valueSummary;
- 
+
   const [arrayBuffer, loading, error] = useFetchBlob(bytes.blob);
 
   const imageBase64 = useMemo<string | undefined>(() => {
@@ -16,19 +17,23 @@ export default function ImageValueView(props: CommonValueViewProps) {
   }, [arrayBuffer]);
 
   if (error) {
-    return <Typography>Unable to load image: {error.message}.</Typography>
+    return <Typography>Unable to load image: {error.message}.</Typography>;
   }
 
   if (loading) {
-    return <Skeleton variant="rectangular" width={210} height={60} />
+    return <Skeleton variant="rectangular" width={210} height={60} />;
   }
 
   if (arrayBuffer) {
-    return <img
-      src={`data:${mime_type};base64,${imageBase64}`}
-      alt="Artifact rendering"
-      style={{maxWidth: "600px"}}
-    />
+    return (
+      <Zoom>
+        <img
+          src={`data:${mime_type};base64,${imageBase64}`}
+          alt="Artifact rendering"
+          style={{ maxWidth: "900px" }}
+        />
+      </Zoom>
+    );
   }
 
   return <></>;

--- a/sematic/ui/packages/main/src/types/matplot.tsx
+++ b/sematic/ui/packages/main/src/types/matplot.tsx
@@ -1,26 +1,13 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { CommonValueViewProps } from "./common";
-import Zoom from "react-medium-image-zoom";
 import { useMatplotLib } from "../hooks/useMatplotLib";
 import { v4 as uuidv4 } from "uuid";
 import useMeasure from "react-use/lib/useMeasure";
 import "react-medium-image-zoom/dist/styles.css";
-
-interface MatplotlibFigureValueImageProps {
-  path: string
-}
-
-function MatplotlibFigureValueImage(props: MatplotlibFigureValueImageProps) {
-  const { path } = props;
-  return (
-    <Zoom>
-      <img src={path} width={"100%"} alt="matplotlib figure" />
-    </Zoom>
-  );
-}
+import ImageValueView from "src/types/image";
 
 interface MatplotlibFigureValueFigureProps {
-  spec: any
+  spec: any;
 }
 
 function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
@@ -31,10 +18,11 @@ function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
 
   const [figDivRef, { width, height }] = useMeasure<HTMLDivElement>();
 
-  const hasFigureRendered = useRef(false)
+  const hasFigureRendered = useRef(false);
 
   const [scaleAndTranslate, setScaleAndTranslate] = useState({
-    scale: 1, translate: { x: 0, y: 0 }
+    scale: 1,
+    translate: { x: 0, y: 0 },
   });
 
   const [scaledHeight, setScaleHeight] = useState(0);
@@ -44,10 +32,10 @@ function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
     if (!hasFigureRendered.current && width > 0) {
       const spec = {
         ...specProp,
-        plugins: []
+        plugins: [],
       };
 
-      const scaledHeight = width / spec.width * spec.height;
+      const scaledHeight = (width / spec.width) * spec.height;
 
       drawFigure(spec);
 
@@ -58,29 +46,44 @@ function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
         scale: scale,
         translate: {
           x: (width - spec.width) / 2,
-          y: (scaledHeight - spec.height) / 2
-        }
-      })
+          y: (scaledHeight - spec.height) / 2,
+        },
+      });
 
       hasFigureRendered.current = true;
     }
   }, [width, height, drawFigure, figureId, specProp]);
 
-  return <div ref={figDivRef} style={{ width: "100%", height: `${scaledHeight}px` }} >
-    <div id={figureId} style={{
-      width: "100%", height: '100%',
-      transform: `scale(${scaleAndTranslate.scale})` +
-        ` translate(${scaleAndTranslate.translate.x}px, ${scaleAndTranslate.translate.y}px)`
-    }} />
-  </div>
+  return (
+    <div ref={figDivRef} style={{ width: "100%", height: `${scaledHeight}px` }}>
+      <div
+        id={figureId}
+        style={{
+          width: "100%",
+          height: "100%",
+          transform:
+            `scale(${scaleAndTranslate.scale})` +
+            ` translate(${scaleAndTranslate.translate.x}px, ${scaleAndTranslate.translate.y}px)`,
+        }}
+      />
+    </div>
+  );
 }
 
 export default function MatplotlibFigureValueView(props: CommonValueViewProps) {
   let { valueSummary } = props;
 
-  const hasFigureJsonData = useMemo(() => !!valueSummary['mpld3'], [valueSummary]);
+  const hasFigureJsonData = useMemo(
+    () => !!valueSummary["mpld3"],
+    [valueSummary]
+  );
 
-  return hasFigureJsonData ?
-    <MatplotlibFigureValueFigure key={valueSummary['mpld3']['id']} spec={valueSummary['mpld3']} />
-    : <MatplotlibFigureValueImage path={valueSummary['path']} />;
+  return hasFigureJsonData ? (
+    <MatplotlibFigureValueFigure
+      key={valueSummary["mpld3"]["id"]}
+      spec={valueSummary["mpld3"]}
+    />
+  ) : (
+    <ImageValueView valueSummary={valueSummary} />
+  );
 }

--- a/sematic/ui/packages/main/src/types/matplot.tsx
+++ b/sematic/ui/packages/main/src/types/matplot.tsx
@@ -70,6 +70,8 @@ function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
   );
 }
 
+// This component can be entirely removed and replaced with ImageValueView
+// a couple of releases after 0.28.0
 export default function MatplotlibFigureValueView(props: CommonValueViewProps) {
   let { valueSummary } = props;
 

--- a/sematic/ui/packages/main/src/types/matplot.tsx
+++ b/sematic/ui/packages/main/src/types/matplot.tsx
@@ -72,6 +72,7 @@ function MatplotlibFigureValueFigure(props: MatplotlibFigureValueFigureProps) {
 
 // This component can be entirely removed and replaced with ImageValueView
 // a couple of releases after 0.28.0
+// TODO: https://github.com/sematic-ai/sematic/issues/700
 export default function MatplotlibFigureValueView(props: CommonValueViewProps) {
   let { valueSummary } = props;
 

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -10,6 +10,11 @@ logger = logging.getLogger(__name__)
 # as well as the version for the sematic wheel in wheel_constants.bzl
 CURRENT_VERSION = (0, 27, 0)
 
+# TO DEPRECATE
+# 0.30.0
+# - https://github.com/sematic-ai/sematic/issues/700
+
+
 # Represents the smallest client version that works with the server
 # at the CURRENT_VERSION. Should be updated any time a breaking change
 # is made to the web API. If there is a breaking change, there should


### PR DESCRIPTION
This PR gets rid of the mpld3 dependency to support `matplotlib.figure.Figure` and instead relies on the `Image` type.

![Screenshot 2023-03-28 at 4 31 15 PM](https://user-images.githubusercontent.com/429433/228389659-f819ac01-b4b9-4af4-ac9b-1a1d9b8477a9.png)