### PR TITLE
Show cases some of the new components

### DIFF
--- a/sematic/ui/packages/common/src/component/GitInfo.tsx
+++ b/sematic/ui/packages/common/src/component/GitInfo.tsx
@@ -24,7 +24,13 @@ const StyledBox = styled(Box)`
     }
 `;
 
-const GitInfoBox = () => {
+interface GitInfoBoxProps {
+    hasUncommittedChanges?: boolean;
+}
+
+const GitInfoBox = (prop: GitInfoBoxProps) => {
+    const { hasUncommittedChanges = false } = prop;
+
     return <>
         <StyledBox>
             <RiGitBranchLine />
@@ -36,12 +42,12 @@ const GitInfoBox = () => {
             <Link>pf49df3</Link>
             <CopyButton text={"pf49df3"} />
         </StyledBox>
-        <StyledBox>
+        {!!hasUncommittedChanges && <StyledBox>
             <Code />
             <Tooltip title={"This run used code with uncommitted changed on top of the above commit."} arrow={true} >
                 <Typography>Uncommited changes</Typography>
             </Tooltip>            
-        </StyledBox>
+        </StyledBox>}
     </>
 };
 

--- a/sematic/ui/packages/common/src/component/GitInfo.tsx
+++ b/sematic/ui/packages/common/src/component/GitInfo.tsx
@@ -40,7 +40,7 @@ const GitInfoBox = (prop: GitInfoBoxProps) => {
         <StyledBox>
             <RiGitCommitLine />
             <Link>pf49df3</Link>
-            <CopyButton text={"pf49df3"} />
+            <CopyButton text={"pf49df36ae2e09b5f5780b38140f83cfe9f866b5"} />
         </StyledBox>
         {!!hasUncommittedChanges && <StyledBox>
             <Code />

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -1,12 +1,14 @@
-import { Check } from "@mui/icons-material";
-import React, { useMemo } from "react";
-
+import BoltIcon from '@mui/icons-material/Bolt';
+import Check from "@mui/icons-material/Check";
+import ClearIcon from '@mui/icons-material/Clear';
+import StopIcon from '@mui/icons-material/Stop';
+import { useMemo } from "react";
 interface StateChipBaseProps {
-    size: "small" | "medium" | "large";
+    size?: "small" | "medium" | "large";
 }
 
 const useStylesHook = (props: StateChipBaseProps) => {
-    const { size } = props;
+    const { size = "small" } = props;
 
     const styles = useMemo(() => {
         const sizeMap = {
@@ -20,12 +22,34 @@ const useStylesHook = (props: StateChipBaseProps) => {
             height: sizeValue,
         };
     }, [size]);
-    
+
     return styles;
 };
 
 
 export const SuccessStateChip = (props: StateChipBaseProps) => {
-    const styles = useStylesHook({ size: "small" });
+    const { size } = props;
+    const styles = useStylesHook({ size });
     return <Check color={"success"} style={styles} />;
 }
+
+export const FailedStateChip = (props: StateChipBaseProps) => {
+    const { size } = props;
+    const styles = useStylesHook({ size });
+    return <ClearIcon color={"error"} style={styles} />;
+}
+
+export const RunningStateChip = (props: StateChipBaseProps) => {
+    const { size } = props;
+    const styles = useStylesHook({ size });
+    return <BoltIcon color={"primary"} style={styles} />;
+}
+
+export const CanceledStateChip = (props: StateChipBaseProps) => {
+    const { size } = props;
+    const styles = useStylesHook({ size });
+    return <StopIcon color={"error"} style={styles} />;
+}
+
+
+

--- a/sematic/ui/packages/common/src/component/RunTree.tsx
+++ b/sematic/ui/packages/common/src/component/RunTree.tsx
@@ -27,15 +27,19 @@ interface ChildrenList<T> {
     children: Array<ChildrenList<T>>;
 }
 
-const RunTree = (props: {
+interface RunTreeProps {
     runTreeNodes: Array<ChildrenList<string>>;
-}) => {
-    const { runTreeNodes } = props;
+    onSelect?: (value: string) => void;
+}
+
+const RunTree = (props: RunTreeProps) => {
+    const { runTreeNodes, onSelect } = props;
 
     return <StyledList>
         {runTreeNodes.map(({ value, children, selected }, index) => (
-            <Fragment key={index} >
-                <ListItemButton className={selected ? 'selected': ''}>
+            <Fragment key={`${index}---${value}`} >
+                <ListItemButton className={selected ? 'selected' : ''}
+                    onClick={() => onSelect?.(value)}>
                     <ListItemIcon sx={{ minWidth: "20px" }}>
                         <SuccessStateChip size={"small"} />
                     </ListItemIcon>
@@ -44,7 +48,7 @@ const RunTree = (props: {
                 {
                     children.length > 0 && (
                         <Box marginLeft={1.8}>
-                            <RunTree runTreeNodes={children} />
+                            <RunTree runTreeNodes={children} onSelect={onSelect} />
                         </Box>
                     )
                 }

--- a/sematic/ui/packages/common/src/component/RunsDropdown.tsx
+++ b/sematic/ui/packages/common/src/component/RunsDropdown.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
 import Select, {selectClasses} from '@mui/material/Select';
 import Typography, { typographyClasses } from '@mui/material/Typography';
 import { useCallback } from "react";
@@ -16,9 +17,12 @@ const StyledSelect = styled(Select)`
     }
 `;
 
-const StyledMenuItem = styled(MenuItem)`
+const StyledBox = styled(Box)`
     color: ${theme.palette.lightGrey.main};
     padding-left: 8px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 
     & .${svgIconClasses.root} {
         width: 15px;
@@ -31,28 +35,44 @@ const StyledMenuItem = styled(MenuItem)`
     }
 `;
 
+const StyledMenuItem = styled(MenuItem)`
+    padding-left: 0;
+`;
+
 interface ValuePresentationProps {
     value: any;
 }
 const ValuePresentation = (props: ValuePresentationProps) => {
     const { value } = props;
-    return <StyledMenuItem value={value}>
+    return <StyledBox {...props}>
         <SuccessStateChip size="small" />
-        <Typography variant="code">02wqdf5</Typography>
+        <Typography variant="code">{`02wqdf5-${value}`}</Typography>
         <Typography variant="small">2d ago</Typography>
-    </StyledMenuItem>
+    </StyledBox>
 }
 
-const RunsDropdown = () => {
+interface RunsDropdownProps {
+    onChange?: (value: unknown) => void;
+}
+
+const RunsDropdown = (prop: RunsDropdownProps) => {
+    const { onChange } = prop;
+
     const renderValue = useCallback((value: unknown) => {
-        return <ValuePresentation value={value} />;
+        return <ValuePresentation value={value as string} />;
     }, []);
 
     return <FormControl style={{ width: '100%' }} size="small">
-        <StyledSelect defaultValue={"1"} renderValue={renderValue} >
-            <ValuePresentation value="1" />
-            <ValuePresentation value="2" />
-            <ValuePresentation value="3" />
+        <StyledSelect defaultValue={"1"} renderValue={renderValue} onChange={onChange}>
+            <StyledMenuItem value="1">
+                <ValuePresentation value="1" />
+            </StyledMenuItem>
+            <StyledMenuItem value="2">
+                <ValuePresentation value="2" />
+            </StyledMenuItem>
+            <StyledMenuItem value="3">
+                <ValuePresentation value="3" />
+            </StyledMenuItem>
         </StyledSelect>
     </FormControl>;
 }

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -7,9 +7,10 @@ import theme from 'src/theme/new';
 const StyledBox = styled(Box)`
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
 
-    & .${chipClasses.root}:not(*:first-of-type) {
-        margin-left: ${theme.spacing(1)};
+    & .${chipClasses.root}:not(*:last-of-type) {
+        margin-right: ${theme.spacing(1)};
     }
 
     & .${buttonClasses.root} {
@@ -21,13 +22,15 @@ const StyledBox = styled(Box)`
 
 interface TagsListProps {
     tags: string[];
+    onClick?: (tag: string) => void;
+    onAddTag?: () => void;
 }
 
 const TagsList = (props: TagsListProps) => {
-    const { tags = [] } = props;
+    const { tags = [], onClick, onAddTag } = props;
     return <StyledBox>
-        {tags.map(tag => <Chip key={tag} label={tag} />)}
-        <Button variant={"text"}>add tags</Button>
+        {tags.map(tag => <Chip key={tag} label={tag} onClick={() => onClick?.(tag)} />)}
+        <Button variant={"text"} onClick={onAddTag}>add tags</Button>
     </StyledBox>;
 }
 

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -18,6 +18,13 @@ const StyledBox = styled(Box)`
         padding: ${theme.spacing(1)};
         height: 25px;
     }
+
+    & > .${chipClasses.root}, & > .${buttonClasses.root}{
+        margin-bottom: ${theme.spacing(1)};
+    }
+
+    // This is to offset the margin-bottom set to the last row of elements
+    margin-bottom: -${theme.spacing(1)}; 
 `;
 
 interface TagsListProps {

--- a/sematic/ui/packages/common/src/context/SnackBarProvider.tsx
+++ b/sematic/ui/packages/common/src/context/SnackBarProvider.tsx
@@ -3,15 +3,16 @@ import { useCallback } from "react";
 
 interface SnackBarProviderProps {
     children: React.ReactNode;
+    setSnackMessageOverride?: (message: string) => void;
 }
 
 /**
  * This is a temporary solution to show snack messages. It will be replaced with a proper snack bar component.
  */
-const SnackBarProvider = ({ children }: SnackBarProviderProps) => {
+const SnackBarProvider = ({ children, setSnackMessageOverride }: SnackBarProviderProps) => {
     const setSnackMessage = useCallback((message: string) => {
-        console.log(message);
-    }, [])
+        (setSnackMessageOverride || console.log)(message);
+    }, [setSnackMessageOverride])
 
     return <SnackBarContext.Provider value={{ setSnackMessage }}>
         {children}

--- a/sematic/ui/packages/common/src/pages/RunDetails/GitSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/GitSection.tsx
@@ -14,7 +14,7 @@ const StyledSection = styled(Section)`
 const GitSection = () => {
     return <StyledSection>
         <Headline>Git</Headline>
-        <GitInfoBox />
+        <GitInfoBox hasUncommittedChanges={true}/>
     </StyledSection>;
 }
 

--- a/sematic/ui/packages/storybook/src/stories/Dropdown.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,47 @@
+import { ThemeProvider } from "@mui/material/styles";
+import RunsDropdownComponent from '@sematic/common/src/component/RunsDropdown';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryObj } from '@storybook/react';
+import CssBaseline from '@mui/material/CssBaseline';
+
+export default {
+  title: 'Sematic/Dropdown',
+  component: RunsDropdownComponent,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  width: keyof typeof sizeOptions;
+  onChange: () => void;
+}
+
+const sizeOptions = {
+  "200px (small)": 200,
+  "400px (medium)": 400,
+  "800px (large)": 800
+}
+
+const commonArgTypes = {
+  width: {
+    control: 'select', options: Object.keys(sizeOptions)
+  },
+  onChange: { action: 'value changed' }
+};
+
+export const RunsDropdown : StoryObj<StoryProps> = {
+  render: (props) => {
+    const { width, onChange } = props;
+
+    const widthValue = width ? sizeOptions[width] : 200;
+
+    return <div style={{maxWidth: widthValue}}><RunsDropdownComponent onChange={onChange} /></div>;
+  }
+};
+RunsDropdown.argTypes = commonArgTypes;

--- a/sematic/ui/packages/storybook/src/stories/GitInfo.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/GitInfo.stories.tsx
@@ -1,0 +1,41 @@
+import { ThemeProvider } from "@mui/material/styles";
+import GitInfoComponent from '@sematic/common/src/component/GitInfo';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryObj } from '@storybook/react';
+import CssBaseline from '@mui/material/CssBaseline';
+import SnackBarProvider from "@sematic/common/src/context/SnackBarProvider";
+
+export default {
+  title: 'Sematic/GitInfo',
+  component: GitInfoComponent,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  ["has uncommited changes"]: boolean;
+  onCopied: () => void;
+}
+
+
+export const GitInfo: StoryObj<StoryProps> = {
+  render: (props) => {
+    const { "has uncommited changes": hasUncommitedChanges,
+      onCopied } = props;
+
+    return <SnackBarProvider setSnackMessageOverride={onCopied}>
+      <GitInfoComponent hasUncommittedChanges={hasUncommitedChanges} />
+    </SnackBarProvider>
+  },
+  argTypes: {
+    "has uncommited changes": { control: 'boolean' },
+    onCopied: { action: 'onCopied' }
+  }
+};
+

--- a/sematic/ui/packages/storybook/src/stories/RunStateChip.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunStateChip.stories.tsx
@@ -1,0 +1,69 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { SuccessStateChip as SuccessStateChipComponent, 
+  FailedStateChip as FailedStateChipComponent,
+  RunningStateChip as RunningStateChipComponent,
+  CanceledStateChip as CanceledStateChipComponent
+ } from '@sematic/common/src/component/RunStateChips';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryFn } from '@storybook/react';
+import CssBaseline from '@mui/material/CssBaseline';
+
+const sizeOptions = ["small", "medium", "large"] as const;
+
+const typeOptions = {
+  "Success": SuccessStateChipComponent,
+  "Failed": FailedStateChipComponent,
+  "Running": RunningStateChipComponent,
+  "Canceled": CanceledStateChipComponent
+}
+
+export default {
+  title: 'Sematic/RunStateChip',
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  argTypes: {
+    type: {
+      control: 'select', options: Object.keys(typeOptions),
+    },
+    size: {
+      control: 'select', options: sizeOptions
+    }
+  }
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  type: keyof typeof typeOptions;
+  size: (typeof sizeOptions)[number];
+}
+
+const Template: StoryFn<StoryProps> = (props: StoryProps) => {
+    const { type, size = "large" } = props;
+    const Component = typeOptions[type];
+    return <Component size={size}/>
+  };
+
+export const SuccessStateChip = Template.bind({});
+SuccessStateChip.args = {
+  type: "Success",
+}
+
+export const FailedStateChip = Template.bind({});
+FailedStateChip.args = {
+  type: "Failed",
+}
+
+export const RunningStateChip = Template.bind({});
+RunningStateChip.args = {
+  type: "Running",
+}
+
+export const CanceledStateChip = Template.bind({});
+CanceledStateChip.args = {
+  type: "Canceled",
+}

--- a/sematic/ui/packages/storybook/src/stories/Tags.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Tags.stories.tsx
@@ -1,0 +1,56 @@
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from "@mui/material/styles";
+import TagsListComponent from '@sematic/common/src/component/TagsList';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'Sematic/Tags',
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  width: keyof typeof sizeOptions;
+  onTagClick: (value: string) => void;
+  onAddTag: () => void;
+}
+
+const sizeOptions = {
+  "100px (small)": 100,
+  "200px (medium)": 200,
+  "400px (large)": 400
+}
+
+const commonArgTypes = {
+  width: {
+    name: 'Container Width',
+    control: {
+      type: 'range',
+      min: 100,
+      max: 300,
+      step: 1
+    }
+
+  },
+  onTagClick: { action: 'tag clicked' },
+  onAddTag: { action: 'add new tag' }
+};
+
+export const TagsList: StoryObj<StoryProps> = {
+  render: (props) => {
+    const { width, onTagClick, onAddTag } = props;
+
+    return <div style={{ maxWidth: width }}>
+      <TagsListComponent tags={['example', 'torch', 'mnist']}
+        onClick={onTagClick} onAddTag={onAddTag} />
+    </div>;
+  }
+};
+TagsList.argTypes = commonArgTypes;

--- a/sematic/ui/packages/storybook/src/stories/TooltipManager.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/TooltipManager.stories.tsx
@@ -1,0 +1,67 @@
+import { ThemeProvider } from "@mui/material/styles";
+import ImportPathComponent from '@sematic/common/src/component/ImportPath';
+import PipelineTitleComponent from '@sematic/common/src/component/PipelineTitle';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryFn } from '@storybook/react';
+import CssBaseline from '@mui/material/CssBaseline';
+import React from "react";
+
+export default {
+  title: 'Sematic/TooltipManager',
+  component: ImportPathComponent,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  text: string;
+  width: keyof typeof sizeOptions;
+  children?: any;
+}
+
+const sizeOptions = {
+  "50px (small)": 50,
+  "250px (medium)": 250,
+  "500px (large)": 500
+}
+
+const commonArgTypes = {
+  width: {
+    control: 'select', options: Object.keys(sizeOptions)
+  },
+  text: { control: 'text' }
+};
+
+const Template: (Component: React.FunctionComponent<any>, defaultText: string ) => StoryFn<StoryProps> 
+= (Component, defaultText) => (props: StoryProps) => {
+  const { text, width } = props;
+
+  const widthValue = width ? sizeOptions[width] : 250;
+
+  return <><div style={{ maxWidth: `${widthValue}px` }}>
+    <Component >
+      {text || defaultText}
+    </Component>
+  </div>
+    <h2 style={{ position: 'absolute', bottom: "3em" }}>
+      Notice: Tooltip will not show if there is enough room to display the text
+    </h2>
+  </>
+};
+
+export const ImportPath = Template(
+  ImportPathComponent, 
+  "sematic.examples.mnist.pipeline.with.very.long.path");
+ImportPath.argTypes = commonArgTypes;
+
+export const PipelineTitle = Template(
+  PipelineTitleComponent,
+  "Pipeline with very long name"
+);
+PipelineTitle.argTypes = commonArgTypes;

--- a/sematic/ui/packages/storybook/src/stories/Tree.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Tree.stories.tsx
@@ -1,0 +1,91 @@
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from "@mui/material/styles";
+import RunTreeComponent from '@sematic/common/src/component/RunTree';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+export default {
+  title: 'Sematic/Tree',
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  runTreeNodes: keyof typeof sizeOptions;
+  width: keyof typeof sizeOptions;
+  onChange: (value: string) => void;
+}
+
+const sizeOptions = {
+  "200px (small)": 200,
+  "400px (medium)": 400,
+  "800px (large)": 800
+}
+
+const commonArgTypes = {
+  width: {
+    control: 'select', options: Object.keys(sizeOptions)
+  },
+  onChange: { action: 'value changed' }
+};
+
+class RunTreeStory extends React.Component<StoryProps, {
+  selectedValue: string | undefined
+}> {
+  constructor(props: StoryProps) {
+    super(props);
+    this.state = {
+      selectedValue: undefined
+    };
+  }
+
+  render() {
+    const { width, onChange } = this.props;
+
+    const widthValue = width ? sizeOptions[width] : 200;
+
+    const valueExpander = (value: string) => ({
+      value,
+      selected: this.state.selectedValue === value
+    })
+
+    const ExampleTreeData = [
+      {
+        ...valueExpander('MNIST PyTorch Example'), children: [
+          { ...valueExpander('Load train dataset'), children: [] as any },
+          { ...valueExpander('Load test dataset'), children: [] as any },
+          { ...valueExpander('get_dataloader'), children: [] as any },
+          { ...valueExpander('get_dataloader_ctd'), children: [] as any },
+          {
+            ...valueExpander('train_eval'), children: [
+              { ...valueExpander('train_model'), children: [] as any },
+              { ...valueExpander('evaluate_model'), children: [] as any }
+            ] as any
+          },
+        ] as any
+      }
+    ]
+
+    return <div style={{ maxWidth: widthValue }}>
+      <RunTreeComponent runTreeNodes={ExampleTreeData} onSelect={(value) => {
+        onChange(value);
+        this.setState({ selectedValue: value });
+      }} />
+    </div>;
+  }
+
+}
+
+export const RunTree: StoryObj<StoryProps> = {
+  render: (props) => {
+    return <RunTreeStory {...props} />
+  }
+};
+RunTree.argTypes = commonArgTypes;


### PR DESCRIPTION
1. Ensure that the following new components of `GitInfoBoxProps`, `RunTree`, `RunsDropdown` and `TagsList` can handle different input properties and support basic interactivity.

2. Add the complete types for the `RunStateChip` set. 

3. Create new storybook stories for the components mentioned above. 

The change is deployed to 

https://story.dev-usw2-sematic0.sematic.cloud/?path=/story/sematic-gitinfo--git-info&args=has+uncommited+changes:!false

for preview.


![capture1](https://user-images.githubusercontent.com/1046489/228688339-eb7bb01c-058c-4401-8f01-5e611b3ee4fb.gif)

