### PR TITLE
Ensure canceled Runs have and end time

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -345,5 +345,6 @@ def _cancel_non_terminal_runs(root_id):
         run.external_jobs = jobs
 
         run.future_state = FutureState.CANCELED
+        run.failed_at = datetime.utcnow()
 
     save_graph(unfinished_runs, [], [])


### PR DESCRIPTION
This is a follow-up to #682. That PR made displaying cases when a Run did not have a set ending time more user-friendly. This PR fixes a case when this might happen.

When pipelines are canceled, the Server marks all Runs as failed, but does not set any of the two timestamps we interpret as ending times: `failed_at` or `resolved_at`. This PR sets `failed_at` for canceled Runs, as `resolved_at` would suggest an Artifact exists, which is false.

## Testing

No unit tests existed for validating the state of Runs after specific operations, so did not introduce any here.

Manually tested that the timestamp is set, reaches the Dashboard, and is rendered correctly.

**Before:**

Server response payload snippet:
```
      "created_at": "2023-03-30T17:20:07.708873+00:00",
      "description": "Adds all the numbers in the list.",
      "ended_at": null,                       # look here!
      "exception_metadata_json": null,
      "external_exception_metadata_json": null,
      "external_jobs_json": [],
      "failed_at": null,                      # look here!
      "future_state": "CANCELED",
      "id": "3a019085930d44eeaf29748bd053c4cf",
      "name": "add_all",
      "nested_future_id": null,
      "original_run_id": null,
      "parent_id": "53773ea7baec478899c5975f533b2163",
      "resolved_at": null,                    # look here!
```
Rendering:
![image](https://user-images.githubusercontent.com/1894533/228931274-f515c21c-fb6b-4b0c-aee5-05dc7906a876.png)

**After:**

Server response payload snippet:
```
"created_at": "2023-03-30T18:18:22.176414+00:00",
      "description": "Adds all the numbers in the list.",
      "ended_at": null,
      "exception_metadata_json": null,
      "external_exception_metadata_json": null,
      "external_jobs_json": [],
      "failed_at": "2023-03-30T18:18:51.641485+00:00", # look here!
      "future_state": "CANCELED",
      "id": "7cf44564548e48e689b8306a52d33d6c",
      "name": "add_all",
      "nested_future_id": null,
      "original_run_id": null,
      "parent_id": "b33087e71ffd4002afc7857541b3ac82",
      "resolved_at": null,
```
Rendering:
![image](https://user-images.githubusercontent.com/1894533/228931718-624b7249-3798-4ddb-b024-545ff512fad7.png)

