### PR TITLE
Ensure DB schema dump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,13 @@ commands:
           working_directory: ./sematic/ui
           command: npm run lint
 
+  validate-schemas:
+    description: Validates all dev resource schemas are up-to-date and consistent
+    steps:
+      - run:
+          name: Check DB Schema
+          command: make migrate_up_sqlite && make update-schema && git diff --exit-code
+
   non-coverage-tests:
     description: Do tests without tracking code coverage
     steps:
@@ -61,6 +68,7 @@ commands:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above
           command: PYTHONUNBUFFERED=1 bazel test //sematic/... --test_output=all
+
   installation-tests:
     description: Do a test of installing sematic via wheel
     steps:
@@ -70,17 +78,19 @@ commands:
       - run:
           name: Test pip install
           command: bazel run //sematic/tests/integration:test_pip_install
+
   notify-completion:
     description: Send a notification to Slack about job completion
     steps:
       - slack/notify:
           event: always
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   init:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - checkout
       - install-ci-pip-deps
@@ -94,15 +104,23 @@ jobs:
 
   lint:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - attach_workspace:
           at: /home/circleci
       - do-static-analysis
+
+  schemas:
+    docker:
+      - image: $SEMATIC_CI_IMAGE
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - validate-schemas
       
   unit-tests:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -121,7 +139,7 @@ jobs:
 
   installation:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -137,7 +155,7 @@ jobs:
   
   integration-test:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -161,7 +179,7 @@ jobs:
   
   fe-unit-tests:
     docker:
-      - image: sematicai/sematic-ci:latest
+      - image: $SEMATIC_CI_IMAGE
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -193,6 +211,9 @@ workflows:
       - lint:
           requires:
             - init
+      - schemas:
+          requires:
+            - init
       - unit-tests:
           requires:
             - init
@@ -208,6 +229,8 @@ workflows:
       - finalize:
           requires:
             - lint
+            - schemas
             - unit-tests
             - integration-test
             - fe-unit-tests
+

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ install-dev-deps:
 	pip3 install -r requirements/ci-requirements.txt
 
 pre-commit:
-	bazel run //sematic/db:migrate -- dump --schema-file ${PWD}/sematic/db/schema.sql.sqlite
 	python3 -m flake8
 	python3 -m mypy sematic
 	python3 -m black sematic --check
@@ -31,7 +30,9 @@ fix:
 	isort sematic
 	black sematic
 
-
+.PHONY: update-schema
+update-schema:
+	bazel run //sematic/db:migrate -- dump --schema-file ${PWD}/sematic/db/schema.sql.sqlite
 
 # this is not supported on Mac because some of the dependencies that need to be pulled
 # do not have a release version for Mac

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install-dev-deps:
 	pip3 install -r requirements/ci-requirements.txt
 
 pre-commit:
+	bazel run //sematic/db:migrate -- dump --schema-file ${PWD}/sematic/db/schema.sql.sqlite
 	python3 -m flake8
 	python3 -m mypy sematic
 	python3 -m black sematic --check

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -19,6 +19,18 @@ Guideline for testing changes that might impact resolution:
 - test remotely in non-detached mode
 - test remotely in detached mode
 
+## PR Prerequisites
+
+In order to ensure the PR review goes swiftly, please:
+
+- Add a comprehensive description to your PR
+- Ensure your code is properly formatted and type checked
+  - Make sure you have the dev tools installed by running `make install-dev-deps` (you only ever need to do this once)
+  - Use `make pre-commit` to run the linter and code formatter
+  - Use `make update-schema` to make sure any DB changes you made are accounted for
+- Make sure the CircleCI build passes for your branch (linked in the checks section at the bottom of the GitHub PR page)
+- Add `sematic-ai/staff` as a reviewer, but also try to assign a specific reviewer, such as `neutralino1`
+
 ## Switching profiles
 
 The [user settings](../docs/cli.md#user-settings) are saved to the
@@ -278,3 +290,10 @@ cases, instead of performing the release from the `main` branch, we:
 - follow all the other steps from the [Releasing](#releasing) section
 - switch to the `main` branch, make a commit that contains the previous version
   increases and reconciles the changelog, and merge a PR with this commit
+
+## Updating the CircleCi Image
+
+The image used for most of our CircleCI steps is built using `docker/Dockerfile.ci`.
+After updating it, open a PR with the change, push the image to Dockerhub using the PR
+number as a tag (in order to be able to maintain a history, and revert, if necessary),
+and update the `SEMATIC_CI_IMAGE` env var in the CircleCi project settings.

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -293,7 +293,7 @@ cases, instead of performing the release from the `main` branch, we:
 
 ## Updating the CircleCi Image
 
-The image used for most of our CircleCI steps is built using `docker/Dockerfile.ci`.
+The image used for most of our CircleCi steps is built using `docker/Dockerfile.ci`.
 After updating it, open a PR with the change, push the image to Dockerhub using the PR
 number as a tag (in order to be able to maintain a history, and revert, if necessary),
 and update the `SEMATIC_CI_IMAGE` env var in the CircleCi project settings.

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM cimg/python:3.9.10
+FROM cimg/python:3.10.10
 
 RUN sudo apt install curl gnupg
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
@@ -9,3 +9,4 @@ RUN sudo apt install -y bazel default-jre default-jdk xvfb libgtk-3-0 libgtk-3-0
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 RUN curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
     sudo apt-get install -y nodejs
+RUN sudo apt install sqlite3

--- a/docs/contribute-example.md
+++ b/docs/contribute-example.md
@@ -123,9 +123,10 @@ Requests](https://github.com/sematic-ai/sematic/compare) to create one.
 
 To increase your chances of being merged fast:
 
-* Add a comprehensive description to your pipeline
-* Ensure your code is properly formatted and type checked
-  * Make sure you have the dev tools installed by running `pip3 install -r requirements/ci-requirements.txt` (you only ever need to do this once)
-  * Use `make pre-commit` to run the linter and code formatter
-* Make sure the Circle CI build passes for your branch (linked in the checks section at the bottom of the GitHub PR page)
-* Add a specific committer as a reviewer, such as `neutralino1`
+* Add a comprehensive description to your PR.
+* Ensure your code is properly formatted and type checked.
+  * Make sure you have the dev tools installed by running `make install-dev-deps` (you only ever need to do this once).
+  * Use `make pre-commit` to run the linter and code formatter.
+  * Use `make update-schema` to make sure any DB changes you made are accounted for.
+* Make sure the CircleCI build passes for your branch (linked in the checks section at the bottom of the GitHub PR page).
+* Add `sematic-ai/staff` as a reviewer, but also try to assign a specific reviewer, such as `neutralino1`.

--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -290,7 +290,7 @@ def migrate_down():
     "file",
     type=click.STRING,
     default="schema.sql",
-    help="File to dump the schema to.",
+    help="File into which to dump the new schema.",
 )
 def _dump_schema(env: str, verbose: bool, file: str):
     _apply_common_options(env, verbose)

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -10,13 +10,12 @@ CREATE TABLE runs (
     ended_at timestamp,
     resolved_at timestamp,
     failed_at timestamp,
-    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), external_jobs_json JSONB, resource_requirements_json JSONB, exception_metadata_json JSONB, container_image_uri TEXT, external_exception_metadata_json JSONB, original_run_id character(32), cache_key TEXT, user_id character(32) REFERENCES users(id),
+    parent_id character(32), description TEXT, tags TEXT, source_code TEXT, root_id character(32), nested_future_id character(32), exception TEXT, external_jobs_json JSONB, resource_requirements_json JSONB, exception_metadata_json JSONB, container_image_uri TEXT, external_exception_metadata_json JSONB, original_run_id character(32), cache_key TEXT, user_id character(32) REFERENCES users(id),
 
     PRIMARY KEY (id)
 );
 CREATE TABLE artifacts (
-    -- sha1 hex digest are 40 characters
-    id character(40) NOT NULL,
+        id character(40) NOT NULL,
     json_summary JSONB NOT NULL,
     created_at timestamp NOT NULL,
     updated_at timestamp NOT NULL, type_serialization JSONB,
@@ -143,7 +142,6 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20221025201847'),
   ('20221027233641'),
   ('20221202221000'),
-  ('20221208183307'),
   ('20221212110018'),
   ('20221214142609'),
   ('20221215212459'),
@@ -155,5 +153,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20230221004041'),
   ('20230222013045'),
   ('20230223020405'),
-  ('20230307230950'),
-  ('20230314141123');
+  ('20230314141123'),
+  ('20230324182512');


### PR DESCRIPTION
Recently some migration files were omitted from the `sqlite` schema file dump. The effect is that fresh local installations can be created in inconsistent states, that might result in un-applicable subsequent migrations.

To avoid this situation, this PR makes it so the schema is dumped in the pre-commit Make target, which we realistically always run.

Also, this PR includes a dump from a fresh and empty copy of the schema. During development, we might apply migrations which do not end up in main (most often due to changes in their timestamp name component). The result is that developers' local `sqlite` DBs are polluted with dev migrations, which do not actually exist in the codebase.
