### PR TITLE
Guard against double-scheduling from resolver

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -261,6 +261,7 @@ class CloudResolver(LocalResolver):
         else:
             try:
                 run = api_client.schedule_run(future.id)
+                logger.info("Scheduled run: %s", run)
             except Exception:
                 logger.error(
                     "Error scheduling run %s. Futures: %s. "

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -247,7 +247,10 @@ class CloudResolver(LocalResolver):
     def _schedule_future(self, future: AbstractFuture) -> None:
         pre_query_run_summary = str(self._runs)
         run = self._get_run(future.id)
-        if run.future_state == FutureState.SCHEDULED.value:
+        if run.future_state not in (
+            FutureState.CREATED.value,
+            FutureState.RETRYING.value,
+        ):
             # It's unclear how we wind up in this situation, but it shouldn't be fatal.
             # Log some info to help diagnose, and move on.
             logger.warning(
@@ -274,7 +277,11 @@ class CloudResolver(LocalResolver):
                     run,
                 )
                 raise
-        self._add_run(run)
+
+        # Why not self._add_run()? Because the relevant change is already
+        # in the DB. And adding it to save again might make it so we overwrite
+        # changes to the run made by the run job itself as it executes.
+        self._runs[run.id] = run
         self._set_future_state(future, FutureState[run.future_state])  # type: ignore
 
     def _wait_for_scheduled_runs(self) -> None:

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -245,7 +245,33 @@ class CloudResolver(LocalResolver):
         return run.id
 
     def _schedule_future(self, future: AbstractFuture) -> None:
-        run = api_client.schedule_run(future.id)
+        run = api_client.get_run(future.id)
+        if run.future_state == FutureState.SCHEDULED.value:
+            # It's unclear how we wind up in this situation, but it shouldn't be fatal.
+            # Log some info to help diagnose, and move on.
+            logger.warning(
+                "Tried to double schedule %s. Futures: %s. "
+                "Runs: %s. Buffer runs: %s. Retrieved run: %s",
+                run.id,
+                self._futures,
+                self._runs,
+                self._buffer_runs,
+                run,
+            )
+        else:
+            try:
+                run = api_client.schedule_run(future.id)
+            except Exception:
+                logger.error(
+                    "Error scheduling run %s. Futures: %s. "
+                    "Runs: %s. Buffer runs: %s. Retrieved run: %s",
+                    run.id,
+                    self._futures,
+                    self._runs,
+                    self._buffer_runs,
+                    run,
+                )
+                raise
         self._runs[run.id] = run
         self._set_future_state(future, FutureState[run.future_state])  # type: ignore
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -245,16 +245,17 @@ class CloudResolver(LocalResolver):
         return run.id
 
     def _schedule_future(self, future: AbstractFuture) -> None:
-        run = api_client.get_run(future.id)
+        pre_query_run_summary = str(self._runs)
+        run = self._get_run(future.id)
         if run.future_state == FutureState.SCHEDULED.value:
             # It's unclear how we wind up in this situation, but it shouldn't be fatal.
             # Log some info to help diagnose, and move on.
             logger.warning(
                 "Tried to double schedule %s. Futures: %s. "
-                "Runs: %s. Buffer runs: %s. Retrieved run: %s",
+                "Runs (before query): %s. Buffer runs: %s. Retrieved run: %s",
                 run.id,
                 self._futures,
-                self._runs,
+                pre_query_run_summary,
                 self._buffer_runs,
                 run,
             )
@@ -273,7 +274,7 @@ class CloudResolver(LocalResolver):
                     run,
                 )
                 raise
-        self._runs[run.id] = run
+        self._add_run(run)
         self._set_future_state(future, FutureState[run.future_state])  # type: ignore
 
     def _wait_for_scheduled_runs(self) -> None:


### PR DESCRIPTION
Some users have reported errors where the resolver tries to schedule a run twice, which fails the resolution. After extensive attempts, we have been unable to reproduce this ourselves. This PR makes it so this occurrence is less likely to be fatal, and adds extra diagnosis information in any case.

Testing
--------
Executed the testing pipeline with:
```
bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --fan-out 10
```
3 times.