### PR TITLE
Remove v1 logs support

### DIFF
--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -25,7 +25,6 @@ from sematic.log_reader import (
     line_stream_from_log_directory,
     load_log_lines,
     log_prefix,
-    v1_log_prefix,
 )
 from sematic.resolvers.cloud_resolver import (
     END_INLINE_RUN_INDICATOR,
@@ -207,14 +206,6 @@ def test_get_log_lines_from_line_stream_filter():
     )
 
 
-def prepare_logs_v1(run_id, text_lines, mock_storage, job_type):  # noqa: F811
-    log_file_contents = bytes("\n".join(text_lines), encoding="utf8")
-    prefix = v1_log_prefix(run_id, job_type)
-    key = f"{prefix}12345.log"
-    mock_storage.set(key, log_file_contents)
-    return prefix
-
-
 def prepare_logs_v2(
     run_id,
     text_lines,
@@ -243,10 +234,7 @@ def prepare_logs_v2(
 
 @pytest.mark.parametrize(
     "log_preparation_function",
-    (
-        prepare_logs_v1,
-        prepare_logs_v2,
-    ),
+    (prepare_logs_v2,),
 )
 def test_load_non_inline_logs(
     test_db,  # noqa: F811
@@ -368,10 +356,7 @@ def test_line_stream_from_log_directory(
 
 @pytest.mark.parametrize(
     "log_preparation_function",
-    (
-        prepare_logs_v1,
-        prepare_logs_v2,
-    ),
+    (prepare_logs_v2,),
 )
 def test_load_inline_logs(
     mock_storage,  # noqa: F811
@@ -478,10 +463,7 @@ def test_load_inline_logs(
 
 @pytest.mark.parametrize(
     "log_preparation_function",
-    (
-        prepare_logs_v1,
-        prepare_logs_v2,
-    ),
+    (prepare_logs_v2,),
 )
 def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noqa: F811
     run = make_run(future_state=FutureState.CREATED)
@@ -590,10 +572,7 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
 
 @pytest.mark.parametrize(
     "log_preparation_function",
-    (
-        prepare_logs_v1,
-        prepare_logs_v2,
-    ),
+    (prepare_logs_v2,),
 )
 def test_load_cloned_run_log_lines(
     mock_storage, test_db, log_preparation_function  # noqa: F811


### PR DESCRIPTION
Closes #334

We no longer need to maintain support for reading logs written in the V1 format. This PR removes the source code that supported such reads.

Testing
-------
```
bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --spam-logs 50000
```
In UI, jumped to end for the spam logs run

```
bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --sleep 600
```
followed the logs for the sleep run as the run progressed