### PR TITLE
Ensure terminated Runs have an end time

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -1,4 +1,5 @@
 # Standard Library
+import datetime
 import logging
 import time
 from typing import Any, Dict, List, Optional
@@ -296,9 +297,13 @@ class CloudResolver(LocalResolver):
             and run.exception_metadata is None
         ):
             run.exception_metadata = format_exception_for_run()
+
         run.future_state = failed_future.state
+        run.failed_at = datetime.datetime.utcnow()
+
         self._add_run(run)
         self._save_graph()
+
         if failed_future.state == FutureState.NESTED_FAILED:
             super()._future_did_fail(failed_future)
 

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -504,6 +504,7 @@ class LocalResolver(SilentResolver):
 
         run = self._get_run(failed_future.id)
         run.future_state = failed_future.state
+        run.failed_at = datetime.datetime.utcnow()
 
         # We do not propagate exceptions to parent runs
         logger.info(
@@ -529,7 +530,6 @@ class LocalResolver(SilentResolver):
                     f"{failed_future.state} when it should have been already processed"
                 )
 
-        run.failed_at = datetime.datetime.utcnow()
         self._add_run(run)
         self._save_graph()
 
@@ -578,6 +578,8 @@ class LocalResolver(SilentResolver):
             else:
                 run.future_state = FutureState.CANCELED
 
+            run.failed_at = datetime.datetime.utcnow()
+
             if run.exception_metadata is None:
                 run.exception_metadata = ExceptionMetadata(
                     repr=reason,
@@ -587,6 +589,7 @@ class LocalResolver(SilentResolver):
                 )
 
             self._add_run(run)
+
         self._save_graph()
 
     def _update_resolution_status(self, status: ResolutionStatus):


### PR DESCRIPTION
This is a follow-up to #703 that ensures all Run terminal state transitions are accompanied by setting the `failed_at` field, after a user had reported that there are other situations other than that covered by #703 that result in an incorrect duration being displayed in the Dashboard.
