### PR TITLE
Use react hooks in story components

### DIFF
--- a/sematic/ui/packages/common/src/reactHooks.ts
+++ b/sematic/ui/packages/common/src/reactHooks.ts
@@ -1,0 +1,1 @@
+export { useState, useCallback, useEffect, useRef } from "react";

--- a/sematic/ui/packages/common/src/reactHooks.ts
+++ b/sematic/ui/packages/common/src/reactHooks.ts
@@ -1,1 +1,3 @@
+// These exports are meant to be used by the `storybook` packages, so that they
+// can use the same version of React as this package.
 export { useState, useCallback, useEffect, useRef } from "react";

--- a/sematic/ui/packages/storybook/src/stories/Tree.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Tree.stories.tsx
@@ -4,6 +4,7 @@ import RunTreeComponent from '@sematic/common/src/component/RunTree';
 import theme from '@sematic/common/src/theme/new';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { useState } from '@sematic/common/src/reactHooks';
 
 export default {
   title: 'Sematic/Tree',
@@ -36,56 +37,47 @@ const commonArgTypes = {
   onChange: { action: 'value changed' }
 };
 
-class RunTreeStory extends React.Component<StoryProps, {
-  selectedValue: string | undefined
-}> {
-  constructor(props: StoryProps) {
-    super(props);
-    this.state = {
-      selectedValue: undefined
-    };
-  }
 
-  render() {
-    const { width, onChange } = this.props;
+const RunTreeStory: React.FC<StoryProps> = (props) => {
+  const [selectedValue, setSelectedValue] = useState<string>();
 
-    const widthValue = width ? sizeOptions[width] : 200;
+  const { width, onChange } = props;
 
-    const valueExpander = (value: string) => ({
-      value,
-      selected: this.state.selectedValue === value
-    })
+  const widthValue = width ? sizeOptions[width] : 200;
 
-    const ExampleTreeData = [
-      {
-        ...valueExpander('MNIST PyTorch Example'), children: [
-          { ...valueExpander('Load train dataset'), children: [] as any },
-          { ...valueExpander('Load test dataset'), children: [] as any },
-          { ...valueExpander('get_dataloader'), children: [] as any },
-          { ...valueExpander('get_dataloader_ctd'), children: [] as any },
-          {
-            ...valueExpander('train_eval'), children: [
-              { ...valueExpander('train_model'), children: [] as any },
-              { ...valueExpander('evaluate_model'), children: [] as any }
-            ] as any
-          },
-        ] as any
-      }
-    ]
+  const valueExpander = (value: string) => ({
+    value,
+    selected: selectedValue === value
+  })
 
-    return <div style={{ maxWidth: widthValue }}>
-      <RunTreeComponent runTreeNodes={ExampleTreeData} onSelect={(value) => {
-        onChange(value);
-        this.setState({ selectedValue: value });
-      }} />
-    </div>;
-  }
+  const ExampleTreeData = [
+    {
+      ...valueExpander('MNIST PyTorch Example'), children: [
+        { ...valueExpander('Load train dataset'), children: [] as any },
+        { ...valueExpander('Load test dataset'), children: [] as any },
+        { ...valueExpander('get_dataloader'), children: [] as any },
+        { ...valueExpander('get_dataloader_ctd'), children: [] as any },
+        {
+          ...valueExpander('train_eval'), children: [
+            { ...valueExpander('train_model'), children: [] as any },
+            { ...valueExpander('evaluate_model'), children: [] as any }
+          ] as any
+        },
+      ] as any
+    }
+  ]
 
+  return <div style={{ maxWidth: widthValue }}>
+    <RunTreeComponent runTreeNodes={ExampleTreeData} onSelect={(value) => {
+      onChange(value);
+      setSelectedValue(value);
+    }} />
+  </div>;
 }
 
 export const RunTree: StoryObj<StoryProps> = {
   render: (props) => {
     return <RunTreeStory {...props} />
-  }
+  },
+  argTypes: commonArgTypes
 };
-RunTree.argTypes = commonArgTypes;


### PR DESCRIPTION
Back in [PR 702](https://github.com/sematic-ai/sematic/pull/702) I introduced stories for the RunTree component. There I used a class component for the story because I had trouble using functional components and hooks. 

Later investigation indicates that we saw the issue with hooks because, in Storybook's setup, we had two copies of React (despite the same version). The official React manual [here](https://legacy.reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) explains that.

My solution is to reimport the same react hooks used in the `common` package and consume them in the storybook package. This approach is easier to manipulate than symbolic linking the react dependency from the storybook, which will also have the bundler (webpack) treat the two references to the react npm module from `common` and `storybook` packages the same. 

This PR also converted the class component into the functional component in the storybook for the sake of being streamlined.