### PR TITLE
Ensure different users can rerun Resolutions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,11 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
-    * Support setting and memorizing debug flag for the dashboard. 
+    * [feature] Added support for setting and memorizing a dev debug flag for the Dashboard
+    * [improvement] Several minor logging improvements and fixes
+    * [bugfix] Ensured different users can rerun a pipeline
+    * [bugfix] Ensured pipeline reruns use the submitting user's credentials
+    * [bugfix] Fixed a bug where the Resolver Socket.io client would not be cleanly closed
 * [0.27.0](https://pypi.org/project/sematic/0.27.0/)
     * [feature] Added new S3Location and S3Bucket types that render S3 links in the Dashboard, and
       documented them

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -6,7 +6,7 @@ Module keeping all /api/v*/runs/* API endpoints.
 import logging
 from datetime import datetime
 from http import HTTPStatus
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 # Third-party
 import flask
@@ -24,6 +24,7 @@ from sematic.api.endpoints.events import (
 )
 from sematic.api.endpoints.payloads import get_resolution_payload
 from sematic.api.endpoints.request_parameters import jsonify_error
+from sematic.config.user_settings import UserSettingsVar
 from sematic.db.models.factories import clone_resolution, clone_root_run
 from sematic.db.models.resolution import InvalidResolution, Resolution, ResolutionStatus
 from sematic.db.models.run import Run
@@ -82,14 +83,16 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
 
     resolution_json_encodable = flask.request.json["resolution"]
     resolution = Resolution.from_json_encodable(resolution_json_encodable)
-    logger.info(
-        "Attempting to update resolution %s. Status: %s",
-        resolution.root_id,
-        resolution.status,
-    )
 
     if user is not None:
         resolution.user_id = user.id
+
+    logger.info(
+        "Attempting to update resolution %s; status: %s; user: %s",
+        resolution.root_id,
+        resolution.status,
+        resolution.user_id,
+    )
 
     if not resolution.root_id == resolution_id:
         message = (
@@ -97,10 +100,7 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
             f"the one from the endpoint called ({resolution_id})"
         )
         logger.warning(message)
-        return jsonify_error(
-            message,
-            HTTPStatus.BAD_REQUEST,
-        )
+        return jsonify_error(message, HTTPStatus.BAD_REQUEST)
 
     try:
         root_run = get_run(resolution_id)
@@ -153,16 +153,17 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
             was_remote = (
                 count_jobs_by_run_id(resolution.root_id, kind=JobKind.resolver) > 0
             )
-            duration_seconds = None
+            duration_seconds: Union[float, str] = "UNKNOWN"
             if root_run.started_at is not None:
                 duration_seconds = (
                     datetime.utcnow() - root_run.started_at
                 ).total_seconds()
+
             logger.info(
                 "%s resolution %s for pipeline %s terminated with "
                 "root run in state %s. The duration was %s seconds. "
-                "Git dirty: %s . Git branch: '%s'"
-                "The root run had tags: %s",
+                "Git dirty: %s . Git branch: '%s' . "
+                "The root run had tags: %s .",
                 "Remote" if was_remote else "Local",
                 resolution.root_id,
                 root_run.calculator_path,
@@ -175,7 +176,7 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
         try:
             _cancel_non_terminal_runs(resolution.root_id)
         except Exception as e:
-            logger.exception("Error when trying to cancel runs in resolution: %s", e)
+            logger.exception("Error when trying to cancel runs in resolution:", e)
 
     save_resolution(resolution)
     _publish_resolution_event(resolution)
@@ -205,16 +206,21 @@ def schedule_resolution_endpoint(
             f"Resolution {resolution_id} was already scheduled",
             status=HTTPStatus.BAD_REQUEST,
         )
+
+    resolution, updated = _update_resolution_user(resolution=resolution, user=user)
+    if updated:
+        logger.debug(
+            "Updated Resolution %s User to %s", resolution.root_id, resolution.user_id
+        )
+        save_resolution(resolution)
+
     resolution, post_schedule_job = schedule_resolution(
         resolution=resolution,
         max_parallelism=max_parallelism,
         rerun_from=rerun_from,
     )
-    logger.info(
-        "Scheduled resolution with job %s",
-        post_schedule_job.identifier(),
-    )
 
+    logger.info("Scheduled resolution with job %s", post_schedule_job.identifier())
     save_resolution(resolution)
     save_job(post_schedule_job)
 
@@ -256,13 +262,17 @@ def rerun_resolution_endpoint(
 
     save_graph(runs=[root_run], edges=edges, artifacts=[])
 
-    resolution = clone_resolution(original_resolution, root_id=root_run.id)
+    resolution = clone_resolution(resolution=original_resolution, root_id=root_run.id)
 
-    if user is not None:
-        resolution.user_id = user.id
+    resolution, updated = _update_resolution_user(resolution=resolution, user=user)
+    if updated:
+        logger.debug(
+            "Updated resolution %s user to %s", resolution.root_id, resolution.user_id
+        )
+        save_resolution(resolution)
 
     resolution, post_schedule_job = schedule_resolution(
-        resolution, rerun_from=rerun_from
+        resolution=resolution, rerun_from=rerun_from
     )
 
     save_resolution(resolution)
@@ -371,3 +381,28 @@ def _cancel_non_terminal_runs(root_id):
         for job in get_jobs_by_run_id(run.id):
             logger.info("Canceling %s", job.identifier())
             save_job(cancel_job(job))
+
+def _update_resolution_user(
+    resolution: Resolution, user: Optional[User]
+) -> Tuple[Resolution, bool]:
+    """
+    Updates the Resolution's User details, returning the updated Resolution, and whether
+    any changes were actually made.
+    """
+    var_key = str(UserSettingsVar.SEMATIC_API_KEY.value)
+
+    if user is None:
+        if resolution.user_id is None:
+            return resolution, False
+
+        resolution.user_id = None
+        del resolution.settings_env_vars[var_key]
+        return resolution, True
+
+    if user.id == resolution.user_id:
+        return resolution, False
+
+    resolution.user_id = user.id
+    resolution.settings_env_vars[var_key] = user.api_key
+
+    return resolution, True

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -60,9 +60,7 @@ def get_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
             HTTPStatus.NOT_FOUND,
         )
 
-    payload = dict(
-        content=get_resolution_payload(resolution),
-    )
+    payload = dict(content=get_resolution_payload(resolution))
 
     return flask.jsonify(payload)
 
@@ -84,8 +82,11 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
     resolution_json_encodable = flask.request.json["resolution"]
     resolution = Resolution.from_json_encodable(resolution_json_encodable)
 
-    if user is not None:
-        resolution.user_id = user.id
+    resolution, updated = _update_resolution_user(resolution=resolution, user=user)
+    if updated:
+        logger.debug(
+            "Updated Resolution %s User to %s", resolution.root_id, resolution.user_id
+        )
 
     logger.info(
         "Attempting to update resolution %s; status: %s; user: %s",
@@ -224,9 +225,7 @@ def schedule_resolution_endpoint(
     save_resolution(resolution)
     save_job(post_schedule_job)
 
-    payload = dict(
-        content=get_resolution_payload(resolution),
-    )
+    payload = dict(content=get_resolution_payload(resolution))
 
     return flask.jsonify(payload)
 
@@ -278,9 +277,7 @@ def rerun_resolution_endpoint(
     save_resolution(resolution)
     save_job(post_schedule_job)
 
-    payload = dict(
-        content=get_resolution_payload(resolution),
-    )
+    payload = dict(content=get_resolution_payload(resolution))
 
     broadcast_pipeline_update(calculator_path=root_run.calculator_path, user=user)
 
@@ -329,7 +326,9 @@ def cancel_resolution_endpoint(
         root_id=resolution.root_id, calculator_path=root_run.calculator_path, user=user
     )
 
-    return flask.jsonify(dict(content=get_resolution_payload(resolution)))
+    payload = dict(content=get_resolution_payload(resolution))
+
+    return flask.jsonify(payload)
 
 
 @sematic_api.route(
@@ -381,6 +380,7 @@ def _cancel_non_terminal_runs(root_id):
         for job in get_jobs_by_run_id(run.id):
             logger.info("Canceling %s", job.identifier())
             save_job(cancel_job(job))
+
 
 def _update_resolution_user(
     resolution: Resolution, user: Optional[User]

--- a/sematic/api/endpoints/tests/BUILD
+++ b/sematic/api/endpoints/tests/BUILD
@@ -26,6 +26,7 @@ pytest_test(
         "//sematic/db:queries",
         "//sematic/db/models:resolution",
         "//sematic/db/models:run",
+        "//sematic/db/models:user",
         "//sematic/db/tests:fixtures",
         "//sematic/plugins:abstract_publisher",
         "//sematic/scheduling:kubernetes",

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -289,7 +289,7 @@ def test_get_resolution_404(
     assert payload == dict(error="No resolutions with id 'unknownid'")
 
 
-def test_schedule_resolution_endpoint(
+def test_schedule_resolution_endpoint_no_auth(
     mock_auth,  # noqa: F811
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
@@ -300,12 +300,49 @@ def test_schedule_resolution_endpoint(
         json={"max_parallelism": 3, "rerun_from": "rerun_from_run_id"},
     )
 
-    payload = response.json
-    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+    assert response.status_code == HTTPStatus.OK
+
+    payload = typing.cast(typing.Dict[str, typing.Any], response.json)
 
     assert payload["content"]["root_id"] == persisted_resolution.root_id
     assert count_jobs_by_run_id(persisted_resolution.root_id, "resolver") == 1
+    assert payload["content"]["user_id"] is None
+    assert payload["content"]["settings_env_vars"] == {}
     mock_schedule_resolution.assert_called_once()
+
+    scheduled_resolution = mock_schedule_resolution.call_args.kwargs["resolution"]
+    assert isinstance(scheduled_resolution, Resolution)
+    assert scheduled_resolution.root_id == persisted_resolution.root_id
+    assert mock_schedule_resolution.call_args.kwargs["max_parallelism"] == 3
+    assert (
+        mock_schedule_resolution.call_args.kwargs["rerun_from"] == "rerun_from_run_id"
+    )
+
+
+def test_schedule_resolution_endpoint_auth(
+    with_auth,  # noqa: F811
+    persisted_resolution: Resolution,  # noqa: F811
+    persisted_user,  # noqa: F811
+    other_persisted_user,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        "/api/v1/resolutions/{}/schedule".format(persisted_resolution.root_id),
+        json={"max_parallelism": 3, "rerun_from": "rerun_from_run_id"},
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+
+    payload = typing.cast(typing.Dict[str, typing.Any], response.json)
+
+    assert payload["content"]["root_id"] == persisted_resolution.root_id
+    assert count_jobs_by_run_id(persisted_resolution.root_id, "resolver") == 1
+    assert payload["content"]["user_id"] == persisted_user.id
+    assert payload["content"]["settings_env_vars"] == {}
+    mock_schedule_resolution.assert_called_once()
+
     scheduled_resolution = mock_schedule_resolution.call_args.kwargs["resolution"]
     assert isinstance(scheduled_resolution, Resolution)
     assert scheduled_resolution.root_id == persisted_resolution.root_id

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -22,9 +22,11 @@ from sematic.api.tests.fixtures import (  # noqa: F401
     mock_auth,
     mock_requests,
     test_client,
+    with_auth,
 )
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
+from sematic.db.models.user import User
 from sematic.db.queries import (
     count_jobs_by_run_id,
     get_graph,
@@ -39,9 +41,13 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     allow_any_run_state_transition,
     make_job,
     make_resolution,
+    other_persisted_user,
     persisted_external_resource,
     persisted_resolution,
+    persisted_resolution_w_user,
     persisted_run,
+    persisted_run_w_user,
+    persisted_user,
     pg_mock,
     resolution,
     run,
@@ -295,7 +301,7 @@ def test_cancel_resolution(
 
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
-def test_rerun_resolution_endpoint(
+def test_rerun_resolution_endpoint_no_auth(
     mock_broadcast_update: mock.MagicMock,
     persisted_resolution: Resolution,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
@@ -317,11 +323,13 @@ def test_rerun_resolution_endpoint(
     cloned_resolution = get_resolution(payload["content"]["root_id"])
 
     assert cloned_resolution.status == ResolutionStatus.SCHEDULED.value
+    assert cloned_resolution.user_id is None
 
     run = get_run(cloned_resolution.root_id)  # noqa: F811
 
     assert run.parent_id is None
     assert run.future_state == FutureState.CREATED.value
+    assert run.user_id is None
 
     mock_schedule_resolution.assert_called_once()
     assert (
@@ -330,12 +338,111 @@ def test_rerun_resolution_endpoint(
     )
 
 
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_auth_same_user(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution_w_user: Resolution,  # noqa: F811
+    persisted_user: User,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    with_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution_w_user.root_id}/rerun",
+        json={"rerun_from": persisted_resolution_w_user.root_id},
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    mock_broadcast_update.assert_called()
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    cloned_resolution = get_resolution(payload["content"]["root_id"])
+
+    assert cloned_resolution.status == ResolutionStatus.SCHEDULED.value
+    assert cloned_resolution.user_id == persisted_user.id
+
+    run = get_run(cloned_resolution.root_id)  # noqa: F811
+
+    assert run.parent_id is None
+    assert run.future_state == FutureState.CREATED.value
+    assert run.user_id == persisted_user.id
+
+    mock_schedule_resolution.assert_called_once()
+    assert (
+        mock_schedule_resolution.call_args.kwargs["rerun_from"]
+        == persisted_resolution_w_user.root_id
+    )
+
+
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_auth_different_user(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution_w_user: Resolution,  # noqa: F811
+    persisted_user: User,  # noqa: F811
+    other_persisted_user: User,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    with_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution_w_user.root_id}/rerun",
+        json={"rerun_from": persisted_resolution_w_user.root_id},
+        headers=({"X-API-KEY": other_persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    mock_broadcast_update.assert_called()
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    cloned_resolution = get_resolution(payload["content"]["root_id"])
+
+    assert cloned_resolution.status == ResolutionStatus.SCHEDULED.value
+    assert cloned_resolution.user_id == other_persisted_user.id
+
+    run = get_run(cloned_resolution.root_id)  # noqa: F811
+
+    assert run.parent_id is None
+    assert run.future_state == FutureState.CREATED.value
+    assert run.user_id == other_persisted_user.id
+
+    mock_schedule_resolution.assert_called_once()
+    assert (
+        mock_schedule_resolution.call_args.kwargs["rerun_from"]
+        == persisted_resolution_w_user.root_id
+    )
+
+
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_auth_no_user_fails(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution_w_user: Resolution,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    with_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution_w_user.root_id}/rerun",
+        json={"rerun_from": persisted_resolution_w_user.root_id},
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    mock_broadcast_update.assert_not_called()
+
+
 def test_list_external_resources_empty(
     mock_auth, test_client: flask.testing.FlaskClient  # noqa: F811
 ):
     response = test_client.get("/api/v1/resolutions/abc123/external_resources")
-    assert response.status_code == HTTPStatus.OK
 
+    assert response.status_code == HTTPStatus.OK
     assert response.json == dict(external_resources=[])
 
 

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -1,6 +1,7 @@
 # Standard Library
 import time
 import typing
+from copy import copy
 from dataclasses import replace
 from http import HTTPStatus
 from unittest import mock
@@ -24,6 +25,7 @@ from sematic.api.tests.fixtures import (  # noqa: F401
     test_client,
     with_auth,
 )
+from sematic.config.user_settings import UserSettingsVar
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.models.user import User
@@ -123,7 +125,7 @@ def test_get_resolution_endpoint(
     assert payload["content"]["settings_env_vars"] == {}
 
 
-def test_put_resolution_endpoint(
+def test_put_resolution_endpoint_no_auth(
     mock_auth,  # noqa: F811
     persisted_run,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
@@ -137,6 +139,9 @@ def test_put_resolution_endpoint(
     assert response.status_code == HTTPStatus.OK
 
     response = test_client.get("/api/v1/resolutions/{}".format(resolution.root_id))
+
+    assert response.status_code == HTTPStatus.OK
+
     encodable = response.json["content"]  # type: ignore
 
     assert encodable["settings_env_vars"] == {}
@@ -144,6 +149,7 @@ def test_put_resolution_endpoint(
     read = get_resolution(resolution.root_id)
     assert read.settings_env_vars == resolution.settings_env_vars
     assert read.status == ResolutionStatus.SCHEDULED.value
+    assert read.user_id is None
 
     encodable["status"] = ResolutionStatus.COMPLETE.value
     response = test_client.put(
@@ -155,6 +161,7 @@ def test_put_resolution_endpoint(
     assert response.status_code == HTTPStatus.BAD_REQUEST
     read = get_resolution(resolution.root_id)
     assert read.status == ResolutionStatus.SCHEDULED.value
+    assert read.user_id is None
 
     encodable["status"] = ResolutionStatus.RUNNING.value
     response = test_client.put(
@@ -166,6 +173,86 @@ def test_put_resolution_endpoint(
     assert response.status_code == HTTPStatus.OK
     read = get_resolution(resolution.root_id)
     assert read.status == ResolutionStatus.RUNNING.value
+    assert read.user_id is None
+
+
+def test_put_resolution_endpoint_auth(
+    with_auth,  # noqa: F811
+    persisted_run_w_user,  # noqa: F811
+    persisted_user,  # noqa: F811
+    other_persisted_user,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    resolution = make_resolution(root_id=persisted_run_w_user.id)  # noqa: F811
+    expected_env_vars = _get_expected_env_vars(resolution, persisted_user)
+
+    # check the resolution creation succeeds:
+    response = test_client.put(
+        "/api/v1/resolutions/{}".format(resolution.root_id),
+        json={"resolution": resolution.to_json_encodable(redact=False)},
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+
+    response = test_client.get(
+        "/api/v1/resolutions/{}".format(resolution.root_id),
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+
+    encodable = response.json["content"]  # type: ignore
+
+    assert encodable["settings_env_vars"] == {}
+
+    read = get_resolution(resolution.root_id)
+
+    assert read.settings_env_vars == expected_env_vars
+    assert read.status == ResolutionStatus.SCHEDULED.value
+    assert read.user_id == persisted_user.id
+
+    # check an incorrect transition fails:
+    encodable["status"] = ResolutionStatus.COMPLETE.value
+    response = test_client.put(
+        "/api/v1/resolutions/{}".format(resolution.root_id),
+        json={"resolution": encodable},
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    read = get_resolution(resolution.root_id)
+    assert read.settings_env_vars == expected_env_vars
+    assert read.status == ResolutionStatus.SCHEDULED.value
+    assert read.user_id == persisted_user.id
+
+    # check a correct transition succeeds:
+    encodable["status"] = ResolutionStatus.RUNNING.value
+    response = test_client.put(
+        "/api/v1/resolutions/{}".format(resolution.root_id),
+        json={"resolution": encodable},
+        headers=({"X-API-KEY": persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    read = get_resolution(resolution.root_id)
+    assert read.settings_env_vars == expected_env_vars
+    assert read.status == ResolutionStatus.RUNNING.value
+    assert read.user_id == persisted_user.id
+
+    # check updating an immutable field fails:
+    encodable["status"] = ResolutionStatus.COMPLETE.value
+    response = test_client.put(
+        "/api/v1/resolutions/{}".format(resolution.root_id),
+        json={"resolution": encodable},
+        headers=({"X-API-KEY": other_persisted_user.api_key}),
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    read = get_resolution(resolution.root_id)
+    assert read.settings_env_vars == expected_env_vars
+    assert read.status == ResolutionStatus.RUNNING.value
+    assert read.user_id == persisted_user.id
 
 
 def test_resolution_event_publishing(
@@ -463,3 +550,12 @@ def test_list_external_resource_ids(
         for resource in response.json["external_resources"]  # type: ignore
     ]
     assert result_ids == [persisted_external_resource.id]
+
+
+def _get_expected_env_vars(
+    resolution: Resolution, user: User  # noqa: F811
+) -> typing.Dict[str, str]:
+
+    expected_env_vars = copy(resolution.settings_env_vars)
+    expected_env_vars[str(UserSettingsVar.SEMATIC_API_KEY.value)] = user.api_key
+    return expected_env_vars

--- a/sematic/api/tests/fixtures.py
+++ b/sematic/api/tests/fixtures.py
@@ -175,3 +175,9 @@ def mock_socketio():
 def mock_auth():
     with mock_server_settings({ServerSettingsVar.SEMATIC_AUTHENTICATE: "false"}):
         yield
+
+
+@pytest.fixture
+def with_auth():
+    with mock_server_settings({ServerSettingsVar.SEMATIC_AUTHENTICATE: "true"}):
+        yield

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -736,6 +736,7 @@ def _raise_for_response(
         method,
         url,
         response.text,
+        exc_info=exception,
     )
     raise exception
 

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -52,6 +52,8 @@ def make_run_from_future(future: AbstractFuture) -> Run:
         created_at=datetime.datetime.utcnow(),
         updated_at=datetime.datetime.utcnow(),
         cache_key=None,
+        # the user_id is overwritten on the API call based on the user's API key
+        user_id=None,
     )
 
     # Set this outside the constructor because the constructor expects
@@ -93,6 +95,8 @@ def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:
         source_code=run.source_code,
         container_image_uri=run.container_image_uri,
         cache_key=run.cache_key,
+        # the user_id is overwritten on the API call based on the user's API key
+        user_id=None,
     )
 
     # Set this outside the constructor because the constructor expects
@@ -139,6 +143,8 @@ def clone_resolution(resolution: Resolution, root_id: str) -> Resolution:
         container_image_uris=resolution.container_image_uris,
         client_version=resolution.client_version,
         cache_namespace=resolution.cache_namespace,
+        # the user_id is overwritten on the API call based on the user's API key
+        user_id=None,
     )
 
     # Set this outside the constructor because the constructor expects

--- a/sematic/db/models/mixins/has_user_mixin.py
+++ b/sematic/db/models/mixins/has_user_mixin.py
@@ -1,3 +1,6 @@
+# Standard Library
+from typing import Optional
+
 # Third-party
 from sqlalchemy import Column, types
 from sqlalchemy.orm import declarative_mixin
@@ -5,4 +8,4 @@ from sqlalchemy.orm import declarative_mixin
 
 @declarative_mixin
 class HasUserMixin:
-    user_id: str = Column(types.String(), nullable=True)
+    user_id: Optional[str] = Column(types.String(), nullable=True)

--- a/sematic/db/models/tests/test_resolution.py
+++ b/sematic/db/models/tests/test_resolution.py
@@ -35,6 +35,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         None,
     ),
@@ -46,6 +47,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         None,
     ),
@@ -57,6 +59,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         r"Cannot update root_id of resolution abc123 after it has been created.*zzz.*",
     ),
@@ -68,6 +71,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         r"Resolution abc123 cannot be moved from the SCHEDULED state to the "
         r"COMPLETE state.",
@@ -80,6 +84,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         r"Cannot update kind of resolution abc123 after it has been created.*LOCAL.*",
     ),
@@ -91,6 +96,7 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/changed/tag",
             container_image_uris={"my.docker.registry.io/changed/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="some_user",
         ),
         r"Cannot update container_image_uris of resolution abc123 .*changed/tag.*",
     ),
@@ -102,8 +108,22 @@ UPDATE_CASES = [
             container_image_uri="my.docker.registry.io/image/tag",
             container_image_uris={"default": "my.docker.registry.io/image/tag"},
             git_info=GitInfo(remote="r", branch="b", commit="c", dirty=True),
+            user_id="some_user",
         ),
         r"Cannot update git_info_json of resolution abc123 .*\"dirty\": false.*",
+    ),
+    (
+        make_resolution(
+            root_id="abc123",
+            status=ResolutionStatus.SCHEDULED,
+            kind=ResolutionKind.KUBERNETES,
+            container_image_uri="my.docker.registry.io/image/tag",
+            container_image_uris={"default": "my.docker.registry.io/image/tag"},
+            git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+            user_id="another_user",
+        ),
+        r"Cannot update user_id of resolution abc123 after it has been created"
+        r".*another_user.*",
     ),
 ]
 
@@ -117,6 +137,7 @@ def test_updates(update, expected_error):
         container_image_uri="my.docker.registry.io/image/tag",
         container_image_uris={"default": "my.docker.registry.io/image/tag"},
         git_info=GitInfo(remote="r", branch="b", commit="c", dirty=False),
+        user_id="some_user",
     )
     try:
         original.update_with(update)

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -172,6 +172,7 @@ def make_resolution(**kwargs) -> Resolution:
         container_image_uris={"default": "some.uri"},
         container_image_uri="some.uri",
         settings_env_vars={"MY_SETTING": "MY_VALUE"},
+        user_id="some_user",
     )
 
     # Set this outside the constructor because the constructor expects

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -172,7 +172,6 @@ def make_resolution(**kwargs) -> Resolution:
         container_image_uris={"default": "some.uri"},
         container_image_uri="some.uri",
         settings_env_vars={"MY_SETTING": "MY_VALUE"},
-        user_id="some_user",
     )
 
     # Set this outside the constructor because the constructor expects

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -204,7 +204,6 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         help=DETACH_HELP,
-        **_required_by("--rerun-from"),
     )
     parser.add_argument(
         "--rerun-from",

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -236,7 +236,7 @@ class LocalResolver(SilentResolver):
 
     def _disconnect_from_sio_server(self):
         try:
-            retry_call(f=self._sio_client.disconnect(), tries=4)
+            retry_call(f=self._sio_client.disconnect, tries=4)
         except BaseException as e:
             # we are shutting down already, so just warn and continue
             logger.warning(
@@ -339,6 +339,8 @@ class LocalResolver(SilentResolver):
             settings_env_vars=get_active_user_settings_strings(),
             client_version=CURRENT_VERSION_STR,
             cache_namespace=self._cache_namespace_str,
+            # the user_id is overwritten on the API call based on the user's API key
+            user_id=None,
         )
 
         return resolution

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -110,10 +110,14 @@ class StateMachineResolver(Resolver, abc.ABC):
         try:
             yield
         except Exception as e:
+            logger.info(
+                "Resolution %s has failed; starting cleanup; look for details below",
+                self._root_future.id,
+            )
             try:
                 self._resolution_did_fail(error=e)
-            except Exception as ee:
-                logger.error("Unable to fail resolution: %s", ee)
+            except Exception:
+                logger.exception("Unable to fail resolution:")
 
             if isinstance(e, CalculatorError) and hasattr(e, "__cause__"):
                 # this will simplify the stack trace so the user sees less

--- a/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
@@ -164,7 +164,7 @@ export default function PipelineBar() {
         const runs = await reloadRuns();
         if (runs[0].id !== latestRuns[0].id) {
           setSnackMessage({
-            message: "New run available!!!",
+            message: "New run available.",
             actionName: "view",
             autoHide: false,
             closable: true,

--- a/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
@@ -164,7 +164,7 @@ export default function PipelineBar() {
         const runs = await reloadRuns();
         if (runs[0].id !== latestRuns[0].id) {
           setSnackMessage({
-            message: "New run available.",
+            message: "New run available!!!",
             actionName: "view",
             autoHide: false,
             closable: true,


### PR DESCRIPTION
This fixes a regression where pipeline Resolutions could not be rerun by different users compared to the original submitters:
```
2023-03-30T23:44:29.471676245Z stdout F 2023-03-30 23:44:28,929 - ERROR - sematic.api_client: Server returned 400 for PUT http://sematic-server/api/v1/resolutions/46ae1ecf9a0243c580483140c68ba362: {"error": "Cannot update user_id of resolution 46ae1ecf9a0243c580483140c68ba362 after it has been created. Original value: '146161c5594c49c286dd6fb505761d3c', new value: '650ac18ea09f4c36ad69f752e2ff4620' (will not be used)"}
```

This regression actually disabled a previously-existing escalation of privileges vulnerability, where a reran Resolution would execute using the original submitter's API key, instead of the API key of the user who triggered the rerun.

When a Resolution was cloned, it had its user id, and the user id of the root Run updated to the new user's id, but the pod that was created still had the original user's API key in its env variables. The result was that this API key was used to source the identity of the user, which was added to all calls from the Resolver to the Server. On these calls, the Server re-overwrote the user id on the Resolution and on all Runs.

This PR makes it so that the user id and API key are always set on the new Resolution, which will end up in the Resolver pod, and correctly use the identity of the rerun submitter.

Also, several other minor bugs are fixed and improvements are made to the workflows exercised in debugging this issue.

## Testing

Added a unit test case to cover the originally-reported issue, and several unit tests to test authentication and user identity override on the touched endpoints.

Tested re-running the pipeline (the original run was triggered by another user):
- in the cloud using the Dashboard as trigger - [result](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/f4ae60797aed4024be0150d97188f7ff)
- in the cloud using the CLI as trigger - [result](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/0c351fe6739147c48efbef7f9c7f24f3)
- locally with no authentication, using the CLI as trigger
