### PR TITLE
Fix display for run runtime when run is running

### DIFF
--- a/sematic/ui/packages/main/src/components/RunTime.tsx
+++ b/sematic/ui/packages/main/src/components/RunTime.tsx
@@ -28,6 +28,8 @@ export function RunTime(props: { run: Run; prefix?: string }) {
   let endTimeString = run.failed_at || run.resolved_at;
   if (endTimeString) {
     endedAt = new Date(endTimeString);
+  } else if (["CREATED", "SCHEDULED", "RAN", "RETRYING"].includes(run.future_state) ){
+    endedAt = new Date();
   } else {
     return <UnkownRunTime />;
   }

--- a/sematic/ui/packages/main/src/components/RunTime.tsx
+++ b/sematic/ui/packages/main/src/components/RunTime.tsx
@@ -28,9 +28,7 @@ export function RunTime(props: { run: Run; prefix?: string }) {
   let endTimeString = run.failed_at || run.resolved_at;
   if (endTimeString) {
     endedAt = new Date(endTimeString);
-  } else if (["CREATED", "SCHEDULED", "RAN", "RETRYING"].includes(run.future_state) ){
-    endedAt = new Date();
-  } else {
+  } else if (!["CREATED", "SCHEDULED", "RAN", "RETRYING"].includes(run.future_state) ){
     return <UnkownRunTime />;
   }
 


### PR DESCRIPTION
Before:
<img width="140" alt="Screenshot 2023-04-07 at 8 07 29 AM" src="https://user-images.githubusercontent.com/7181589/230643997-f2be76b3-6211-467b-bfcd-4ae840aa03bb.png">

After:
<img width="99" alt="Screenshot 2023-04-07 at 9 28 48 AM" src="https://user-images.githubusercontent.com/7181589/230644016-3036fc03-34ad-47f4-9ebb-3941ce2a81a8.png">

Testing
-------
```
$ make ui
$ serve-dev
$ bazel run sematic/examples/testing_pipeline:__main__ -- --cloud --detach --sleep 10000
```
Look at run while running, look at completed/canceled/cloned runs