### PR TITLE
Fix composite type castability check for float

### DIFF
--- a/sematic/types/types/float.py
+++ b/sematic/types/types/float.py
@@ -1,4 +1,5 @@
 # Standard Library
+import inspect
 import numbers
 import typing
 
@@ -18,7 +19,7 @@ def can_cast_type(type_: type, _) -> typing.Tuple[bool, typing.Optional[str]]:
 
     Only subclasses of `numbers.Real` can cast to `float`.
     """
-    if issubclass(type_, numbers.Real):
+    if inspect.isclass(type_) and issubclass(type_, numbers.Real):
         return True, None
 
     return False, "Cannot cast {} to float".format(type_)


### PR DESCRIPTION
When a composite type is checked if it can cast to `float`:
```
ERROR:sematic.resolvers.silent_resolver:Error executing future
Traceback (most recent call last):
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/calculator.py", line 185, in calculate
    output = self.func(**kwargs)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/examples/testing_pipeline/pipeline.py", line 557, in testing_pipeline
    result = add_all(futures) if len(futures) > 1 else futures[0]
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/calculator.py", line 152, in __call__
    argument_map[name] = _convert_lists(argument_map[name])
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/calculator.py", line 525, in _convert_lists
    return _make_list(make_list_type(value_), value_)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/calculator.py", line 493, in _make_list
    can_cast, error = can_cast_type(item.calculator.output_type, element_type)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/types/casting.py", line 58, in can_cast_type
    return can_cast_func(from_type, to_type)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/types/types/union.py", line 47, in _union_can_cast
    can_cast, _ = can_cast_type(from_type, unioned_type)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/types/casting.py", line 58, in can_cast_type
    return can_cast_func(from_type, to_type)
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/types/types/float.py", line 27, in can_cast_type
    if issubclass(type_, numbers.Real):
  File "/home/tudor/.cache/bazel/_bazel_tudor/33dcc00034a66e07dc9fd2f996f93d80/external/python3_8_x86_64-unknown-linux-gnu/lib/python3.8/abc.py", line 102, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

This PR adds a missing check in the casting logic, which [already exists](https://github.com/sematic-ai/sematic/blob/66e306a45769d70ba092fa1e8ef0fbe5aae5ab92/sematic/types/types/integer.py#L25) in the `integer` casting logic.
