### PR TITLE
Fix S3Location Dashboard link generation for directories

### DIFF
--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -112,6 +112,10 @@ IMAGES_HELP = (
     "Whether to include nested functions which will include the `Image` type in their "
     "I/O signatures. Defaults to False."
 )
+S3_URIS_HELP = (
+    "If any values are supplied, includes a function that composes `S3Location` "
+    "dataclasses for the specified URIs. Defaults to None."
+)
 VIRTUAL_FUNCS_HELP = (
     "Whether to explicitly include the `_make_list`, `_make_tuple`, and `_getitem` "
     "virtual functions. Defaults to False. Note: If this pipeline is invoked with any "
@@ -279,6 +283,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--images", action="store_true", default=False, help=IMAGES_HELP
+    )
+    parser.add_argument(
+        "--s3-uris", type=str, default=None, nargs="+", help=S3_URIS_HELP
     )
     parser.add_argument(
         "--virtual-funcs",

--- a/sematic/types/__init__.py
+++ b/sematic/types/__init__.py
@@ -17,6 +17,7 @@ import sematic.types.types.none  # noqa: F401
 import sematic.types.types.str  # noqa: F401
 import sematic.types.types.tuple  # noqa: F401
 import sematic.types.types.union  # noqa: F401
+from sematic.types.types.aws import S3Bucket, S3Location  # noqa: F401
 from sematic.types.types.datetime import datetime  # noqa: F401
 from sematic.types.types.image import Image  # noqa: F401
 from sematic.types.types.link import Link  # noqa: F401

--- a/sematic/types/types/aws/s3.py
+++ b/sematic/types/types/aws/s3.py
@@ -18,6 +18,11 @@ class S3Bucket:
 class S3Location:
     """
     Basic type to describe an S3 location.
+
+    S3 only emulates a file system through key-value pairs and does not have an actual
+    hierarchical directory structure. As a convention, locations that end in a "/" are
+    rendered as "directories", and those that do not are interpreted as fully-qualified
+    file paths.
     """
 
     bucket: S3Bucket
@@ -27,7 +32,7 @@ class S3Location:
     def from_uri(cls, uri: str, region: Optional[str] = None) -> "S3Location":
         """
         Construct an S3Location object from an S3 URI of the form
-        s3://bucket-name/path/to/location
+        `s3://bucket-name/path/to/location`.
 
         Parameters
         ----------
@@ -74,8 +79,9 @@ class S3Location:
         """
         location = self.location[:-1] if self.location[-1] == "/" else self.location
         location_parts = location.split("/")
+        parent_location = f"{'/'.join(location_parts[:-1])}/"
 
-        return S3Location(bucket=self.bucket, location="/".join(location_parts[:-1]))
+        return S3Location(bucket=self.bucket, location=parent_location)
 
     def sibling_location(self, location: str) -> "S3Location":
         """
@@ -87,7 +93,7 @@ class S3Location:
         """
         return S3Location(
             bucket=self.bucket,
-            location="/".join([self.parent_directory.location, location]),
+            location=f"{self.parent_directory.location}{location}",
         )
 
     def child_location(self, location: str) -> "S3Location":

--- a/sematic/ui/packages/main/src/types/aws.tsx
+++ b/sematic/ui/packages/main/src/types/aws.tsx
@@ -23,7 +23,9 @@ function S3Button(props: {region?: string, bucket: string, location?: string}) {
   const { region, bucket, location } = props;
 
   let s3URI = "s3://" + bucket;
-  let href = new URL("https://s3.console.aws.amazon.com/s3/object/" + bucket);
+  // in case the location points to an object and not to an intermediate
+  // "directory", AWS will redirect to the object URL
+  let href = new URL("https://s3.console.aws.amazon.com/s3/buckets/" + bucket);
   
   if (region !== null && region !== undefined) {
     href.searchParams.append("region", region);


### PR DESCRIPTION
The links generated in the Dashboard for `S3Location`s that pointed to "directories" rendered an error page.

This is due to S3 only emulating a file system through key-value pairs, without having an actual hierarchical directory structure. S3 has 2 separate endpoints for "directories" and files: "buckets" and "object", respectively

The existing Dashboard hyperlink generation mechanism generates these links using only the "object" endpoint, which results in an error being rendered for "directories".

This PR updates the generation of hyperlinks to S3 in the Dashboard to use the "buckets" endpoint for all locations. In this case, S3 successfully redirects to the "object" endpoint for existent files. Rendering of file links is unaffected.

This PR also introduces a convention in which locations that end in a "/" are considered "directories", and those that do not are considered as fully-qualified file paths.

A Testing Pipeline capability of composing S3 links is added, and unit tests are updated to enforce the new convention.

```bash
$ bazel run sematic/examples/testing_pipeline:__main___local -- \
    --s3-uris s3://<redacted dir path>/ s3://<redacted dir path>/<redacted file name>
```

![image](https://user-images.githubusercontent.com/1894533/230690908-e4fe82fe-3d12-4ed6-817d-fe0c7d84cd8e.png)

**Before:**
![image](https://user-images.githubusercontent.com/1894533/230690118-58b54090-14ac-4932-8ceb-ea8f4369c5cc.png)

**After:**
![image](https://user-images.githubusercontent.com/1894533/230690500-d46a6a9f-cf5a-420e-b7e9-5540be4246e7.png)
