### PR TITLE
Make gevent monkey patch occur early

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@ exports_files(["README.md"])
 exports_files(["README.rst"])
 exports_files(["docs/changelog.md"])
 exports_files(["helm/sematic-server/Chart.yaml"])
+exports_files(["sematic.pth"])
 
 stamp_build_setting(name = "stamp")
 

--- a/sematic.pth
+++ b/sematic.pth
@@ -1,0 +1,6 @@
+# This enables us to use websockets and standard HTTP requests in the same server locally,
+# which is what we want. If you try to use Gunicorn to do this, gevent will complain about
+# not monkey patching early enough, unless you have the gevent monkey patch applied VERY
+# early (like user/sitecustomize).
+# Monkey patching: https://github.com/gevent/gevent/issues/1235
+import gevent.monkey; gevent.monkey.patch_all()

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -42,6 +42,9 @@ sematic_py_lib(
     pip_deps = [
         "gevent",
     ],
+    data = [
+        "//:sematic.pth",
+    ]
 )
 
 sematic_py_lib(

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -1,16 +1,6 @@
 """
 Sematic Public API
 """
-# Third-party
-import gevent.monkey  # type: ignore
-
-# This enables us to use websockets and standard HTTP requests in the same server locally,
-# which is what we want. If you try to use Gunicorn to do this, gevent will complain about
-# not monkey patching early enough, unless you have the gevent monkey patch applied VERY
-# early (like user/sitecustomize).
-# Monkey patching: https://github.com/gevent/gevent/issues/1235
-gevent.monkey.patch_all()
-
 # Standard Library
 import os  # noqa: E402
 import platform  # noqa: E402

--- a/sematic/api/BUILD
+++ b/sematic/api/BUILD
@@ -48,6 +48,9 @@ py_binary(
     deps = [
         ":server_lib",
     ],
+    data = [
+        "//:sematic.pth",
+    ],
 )
 
 sematic_py_lib(

--- a/sematic/api/server.py
+++ b/sematic/api/server.py
@@ -1,3 +1,14 @@
+if __name__ == "__main__":
+    # Third-party
+    import gevent.monkey  # type: ignore
+
+    # This enables us to use websockets and standard HTTP requests in the same server locally,
+    # which is what we want. If you try to use Gunicorn to do this, gevent will complain about
+    # not monkey patching early enough, unless you have the gevent monkey patch applied VERY
+    # early (like user/sitecustomize).
+    # Monkey patching: https://github.com/gevent/gevent/issues/1235
+    gevent.monkey.patch_all()
+
 # Standard Library
 import argparse
 import logging

--- a/sematic/api/server.py
+++ b/sematic/api/server.py
@@ -2,10 +2,11 @@ if __name__ == "__main__":
     # Third-party
     import gevent.monkey  # type: ignore
 
-    # This enables us to use websockets and standard HTTP requests in the same server locally,
-    # which is what we want. If you try to use Gunicorn to do this, gevent will complain about
-    # not monkey patching early enough, unless you have the gevent monkey patch applied VERY
-    # early (like user/sitecustomize).
+    # This enables us to use websockets and standard HTTP requests in
+    # the same server locally, which is what we want. If you try to
+    # use Gunicorn to do this, gevent will complain about
+    # not monkey patching early enough, unless you have the gevent
+    # monkey patch applied VERY early (like user/sitecustomize).
     # Monkey patching: https://github.com/gevent/gevent/issues/1235
     gevent.monkey.patch_all()
 

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -1,3 +1,14 @@
+if __name__ == "__main__":
+    # Third-party
+    import gevent.monkey  # type: ignore
+
+    # This enables us to use websockets and standard HTTP requests in the same server locally,
+    # which is what we want. If you try to use Gunicorn to do this, gevent will complain about
+    # not monkey patching early enough, unless you have the gevent monkey patch applied VERY
+    # early (like user/sitecustomize).
+    # Monkey patching: https://github.com/gevent/gevent/issues/1235
+    gevent.monkey.patch_all()
+
 # Sematic
 import sematic.cli.cancel  # noqa: F401, E402
 import sematic.cli.logs  # noqa: F401, E402

--- a/sematic/cli/main.py
+++ b/sematic/cli/main.py
@@ -2,9 +2,11 @@ if __name__ == "__main__":
     # Third-party
     import gevent.monkey  # type: ignore
 
-    # This enables us to use websockets and standard HTTP requests in the same server locally,
-    # which is what we want. If you try to use Gunicorn to do this, gevent will complain about
-    # not monkey patching early enough, unless you have the gevent monkey patch applied VERY
+    # This enables us to use websockets and standard HTTP requests in
+    # the same server locally, which is what we want. If you try to
+    # use Gunicorn to do this, gevent will complain about
+    # not monkey patching early enough, unless you have the gevent
+    # monkey patch applied VERY
     # early (like user/sitecustomize).
     # Monkey patching: https://github.com/gevent/gevent/issues/1235
     gevent.monkey.patch_all()


### PR DESCRIPTION
When using gevent, it requires a monkey patch to some standard libraries. This monkey patch has to be applied *very early*, before certain other stdlib imports occur (even in transitive deps). The import is basically only required if you are using the server, but if the patch is applied at the wrong time when doing other things it can cause strange behaviors in other libs. This PR makes it so that we install a [`.pth` file](https://docs.python.org/3/library/site.html) with our wheel which will apply the patch before the user's main module is loaded. The `.pth` file will only work when installed with the wheel though, so some changes are also added in this PR to do an early patch for running the server and the CLI as main for when we're working directly in bazel.

Testing
-------
- built wheel, started local server and ran a pipeline against it using python 3.10
- used bazel with `bazel run //sematic/cli:main_py3_10 -- start` to start the server and ran a pipeline against it
- used `serve-dev` to deploy and ran a pipeline