### PR TITLE
Pod lifecycle history UI

### DIFF
--- a/sematic/ui/packages/common/src/Models.ts
+++ b/sematic/ui/packages/common/src/Models.ts
@@ -88,12 +88,12 @@ export interface Note extends HasUserMixin {
   updated_at: Date;
 };
 
-export type ExternalResourceState = 
-"CREATED" |
-"ACTIVATING" |
-"ACTIVE" |
-"DEACTIVATING" |
-"DEACTIVATED";
+export type ExternalResourceState =
+  "CREATED" |
+  "ACTIVATING" |
+  "ACTIVE" |
+  "DEACTIVATING" |
+  "DEACTIVATED";
 
 export type ExternalResource = {
   id: string,
@@ -131,4 +131,23 @@ export type ExternalResourceHistorySerialization = {
   }
 };
 
+type PodHistoryStatusSerialization = {
+  last_updated_epoch_seconds: number;
+  message: string
+  state: string
+};
+
+export type Job = {
+  created_at: Date,
+  detail_serialization: any;
+  kind: string;
+  last_updated_epoch_secondsL: number;
+  message: string;
+  name: string;
+  namespace: string;
+  run_id: string;
+  state: string;
+  status_history_serialization: Array<PodHistoryStatusSerialization>;
+  updated_at: Date;
+}
 

--- a/sematic/ui/packages/common/src/Models.ts
+++ b/sematic/ui/packages/common/src/Models.ts
@@ -133,15 +133,15 @@ export type ExternalResourceHistorySerialization = {
 
 type PodHistoryStatusSerialization = {
   last_updated_epoch_seconds: number;
-  message: string
-  state: string
+  message: string;
+  state: string;
 };
 
 export type Job = {
   created_at: Date,
-  detail_serialization: any;
+  detail_serialization: object;
   kind: string;
-  last_updated_epoch_secondsL: number;
+  last_updated_epoch_seconds: number;
   message: string;
   name: string;
   namespace: string;

--- a/sematic/ui/packages/main/src/Payloads.tsx
+++ b/sematic/ui/packages/main/src/Payloads.tsx
@@ -1,4 +1,4 @@
-import { Artifact, Edge, Note, Resolution, Run, User } from "@sematic/common/src/Models";
+import { Artifact, Edge, Job, Note, Resolution, Run, User } from "@sematic/common/src/Models";
 
 export type RunListPayload = {
   current_page_url: string;
@@ -103,4 +103,8 @@ export type BasicMetricsPayload = {
     count_by_state: {[k: string]: number},
     total_count: number
   }
+}
+
+export type RunJobPayload = {
+  content: Array<Job>
 }

--- a/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
+++ b/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
@@ -20,7 +20,7 @@ export function useRunJobHistory(runId: string) {
         const payload: RunJobPayload = await response.json();
 
         if (!payload['content']) {
-            throw Error('external_resources response is not in the correct format.')
+            throw Error('jobs response is not in the correct format.')
         }
 
         return payload['content'] as Array<Job>
@@ -68,5 +68,3 @@ export function useRunJobHistory(runId: string) {
 
     return {value, loading, error};
 }
-
-

--- a/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
+++ b/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
@@ -1,0 +1,72 @@
+import { useRefFn } from "@sematic/common/lib/src/utils/hooks";
+import { Job } from "@sematic/common/src/Models";
+import { useCallback, useEffect } from "react";
+import useAsyncFn from "react-use/lib/useAsyncFn";
+import useLatest from "react-use/lib/useLatest";
+import { RunJobPayload } from "src/Payloads";
+import { useHttpClient } from "src/hooks/httpHooks";
+import { jobSocket } from "src/sockets";
+import { AsyncInvocationQueue } from "src/utils";
+
+
+export function useRunJobHistory(runId: string) {
+    const {fetch} = useHttpClient();
+
+    const [{value, loading, error}, reload] = useAsyncFn(async ()=> {
+        const response = await fetch({
+            url: `/api/v1/runs/${runId}/jobs`
+        });
+
+        const payload: RunJobPayload = await response.json();
+
+        if (!payload['content']) {
+            throw Error('external_resources response is not in the correct format.')
+        }
+
+        return payload['content'] as Array<Job>
+    }, [fetch, runId]);
+
+    const latestReload = useLatest(reload);
+
+    const asyncInvocationManager = useRefFn(() => new AsyncInvocationQueue());
+    const abortController = useRefFn(() => new AbortController());
+
+    const reloadWithQueue = useCallback(async () => {
+        if (abortController.signal.aborted) {
+            return;
+        }
+        const release = await asyncInvocationManager.acquire();
+        if (abortController.signal.aborted) {
+            return;
+        }
+
+        await latestReload.current();
+        release();
+        //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const onJobUpdate = useCallback((args: {run_id: string}) => {
+        if (args.run_id === runId) {
+            reloadWithQueue();
+        };
+        //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    
+    useEffect(() => {
+        latestReload.current();
+        jobSocket.on("update", onJobUpdate);
+
+        return () => {
+            jobSocket.removeListener("update", onJobUpdate);
+            if (!abortController.signal.aborted) {
+                abortController.abort();
+            }
+        }
+        //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+
+    return {value, loading, error};
+}
+
+

--- a/sematic/ui/packages/main/src/pipelines/RunTabs.tsx
+++ b/sematic/ui/packages/main/src/pipelines/RunTabs.tsx
@@ -57,7 +57,7 @@ export default function RunTabs(props: {
             <Tab label="Logs" value="logs" />
             {grafanaTab}
             <Tab label="Resources" value="ext_res" />
-            <Tab label="Pods states" value="pod_lifecycle" />
+            <Tab label="Pods" value="pod_lifecycle" />
           </TabList>
         </StickyHeader>
         <TabPanel value="input">

--- a/sematic/ui/packages/main/src/pipelines/RunTabs.tsx
+++ b/sematic/ui/packages/main/src/pipelines/RunTabs.tsx
@@ -12,6 +12,7 @@ import SourceCode from "src/components/SourceCode";
 import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
 import { ArtifactList } from "src/pipelines/Artifacts";
 import ExternalResourcePanel from "src/pipelines/external_resource/ExternalResource";
+import PodLifecycle from "src/pipelines/pod_lifecycle/PodLifecycle";
 import LogPanel from "src/pipelines/LogPanel";
 import OutputPanel from "src/pipelines/OutputPanel";
 
@@ -56,6 +57,7 @@ export default function RunTabs(props: {
             <Tab label="Logs" value="logs" />
             {grafanaTab}
             <Tab label="Resources" value="ext_res" />
+            <Tab label="Pods states" value="pod_lifecycle" />
           </TabList>
         </StickyHeader>
         <TabPanel value="input">
@@ -75,6 +77,9 @@ export default function RunTabs(props: {
         </TabPanel>
         <TabPanel hidden={selectedRunTab !== "ext_res"} value="ext_res">
             <ExternalResourcePanel />
+        </TabPanel>
+        <TabPanel hidden={selectedRunTab !== "pod_lifecycle"} value="pod_lifecycle">
+            <PodLifecycle />
         </TabPanel>
       </TabContext>
     </>

--- a/sematic/ui/packages/main/src/pipelines/external_resource/ExternalResource.tsx
+++ b/sematic/ui/packages/main/src/pipelines/external_resource/ExternalResource.tsx
@@ -9,7 +9,7 @@ import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
 import { useRunPanelLoadingIndicator } from 'src/hooks/runDetailsHooks';
 import ExternalResourceState from 'src/pipelines/external_resource/ExternalResourceState';
 
-const ThinTimetime = styled(Timeline)`
+const ThinTimeline = styled(Timeline)`
     margin: 0;
     flex: 0;
     & .${timelineItemClasses.root}:before {
@@ -63,12 +63,12 @@ export default function ExternalResourcePanel() {
 
     return <>
         {extraResourcesInfoSection}
-        <ThinTimetime key={selectedRun?.id}>
+        <ThinTimeline key={selectedRun?.id}>
             {historyRecords?.map(
                 (state, index) => 
                 <ExternalResourceState 
                     historyRecord={state} key={index} isLast={historyRecords.length - 1 === index}/>
             )}
-        </ThinTimetime>
+        </ThinTimeline>
     </>
 }

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
@@ -1,0 +1,30 @@
+import Timeline from '@mui/lab/Timeline';
+import timelineItemClasses from '@mui/lab/TimelineItem/timelineItemClasses';
+import { styled } from '@mui/system';
+import PodLifecycleEvent from 'src/pipelines/pod_lifecycle/PodLifecycleEvent';
+import { Job } from '@sematic/common/lib/src/Models';
+
+const ThinTimetime = styled(Timeline)`
+    margin: 0;
+    flex: 0;
+    & .${timelineItemClasses.root}:before {
+        flex: 0;
+        padding: 0;
+    }
+`;
+
+interface PodEventHistoryProps {
+  historyRecords: Job['status_history_serialization'];
+}
+
+export default function PodEventHistory(props: PodEventHistoryProps) {
+  const { historyRecords } = props;
+
+  return <ThinTimetime>
+      {historyRecords.map(
+        (state, index) =>
+          <PodLifecycleEvent key={index} podStatus={state}
+            isLast={historyRecords.length - 1 === index} isFirst={index === 0} />
+      )}
+    </ThinTimetime>
+}

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
@@ -3,8 +3,9 @@ import timelineItemClasses from '@mui/lab/TimelineItem/timelineItemClasses';
 import { styled } from '@mui/system';
 import PodLifecycleEvent from 'src/pipelines/pod_lifecycle/PodLifecycleEvent';
 import { Job } from '@sematic/common/lib/src/Models';
+import { useMemo } from 'react';
 
-const ThinTimetime = styled(Timeline)`
+const ThinTimeline = styled(Timeline)`
     margin: 0;
     flex: 0;
     & .${timelineItemClasses.root}:before {
@@ -20,11 +21,14 @@ interface PodEventHistoryProps {
 export default function PodEventHistory(props: PodEventHistoryProps) {
   const { historyRecords } = props;
 
-  return <ThinTimetime>
-      {historyRecords.map(
+  const reversedHistoryRecords = useMemo(
+    () => historyRecords.slice().reverse(), [historyRecords]);
+
+  return <ThinTimeline>
+      {reversedHistoryRecords.map(
         (state, index) =>
           <PodLifecycleEvent key={index} podStatus={state}
-            isLast={historyRecords.length - 1 === index} isFirst={index === 0} />
+            isLast={historyRecords.length - 1 === index} />
       )}
-    </ThinTimetime>
+    </ThinTimeline>
 }

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
@@ -36,7 +36,7 @@ function PodLifecycleWithRunId(prop: { runId: string }) {
     <Typography fontSize="small" color="GrayText" style={{marginBottom: '1em'}}>
       The information in this tab is provided for debugging purposes.
       The information it displays is periodically polled from Kubernetes,
-      and not all intermediate states may be represented in the timelines.
+      and some intermediate states may not be represented in the timelines.
     </Typography>
     {value!.map(
       (job, index) =>

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
@@ -1,28 +1,24 @@
+import styled from '@emotion/styled';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
-import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
+import CopyButton from '@sematic/common/lib/src/component/CopyButton';
+import { useCallback } from 'react';
 import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
 import { useRunJobHistory } from 'src/hooks/podHistoryHooks';
 import { useRunPanelLoadingIndicator } from 'src/hooks/runDetailsHooks';
 import PodEventHistory from 'src/pipelines/pod_lifecycle/PodEventHistory';
-import styled from '@emotion/styled';
-import { theme } from '@sematic/common/lib/src/theme/mira';
-import CopyButton from '@sematic/common/lib/src/component/CopyButton';
-import { useCallback } from 'react';
 
 const StyledCode = styled.code`
   font-size: 12px;
-  color: ${theme.palette.grey[500]};
   cursor: text;
   user-select: text;  
 `;
 
 // Separate component to assign key to the component, so that it will be re-mounted when runId changes
-function PodLifecycleWithRunId(prop: {runId: string}) {
+function PodLifecycleWithRunId(prop: { runId: string }) {
   const { runId } = prop;
 
   const { value, loading } = useRunJobHistory(runId);
@@ -34,22 +30,25 @@ function PodLifecycleWithRunId(prop: {runId: string}) {
   }, []);
 
   if (!value) return null;
-  if (value?.length === 0) return <Typography variant="body2">No job history found</Typography>;
+  if (value?.length === 0) return <Typography variant="body2">No pod history found.</Typography>;
 
   return <>
+    <Typography fontSize="small" color="GrayText" style={{marginBottom: '1em'}}>
+      The information in this tab is provided for debugging purposes.
+      The information it displays is periodically polled from Kubernetes,
+      and not all intermediate states may be represented in the timelines.
+    </Typography>
     {value!.map(
       (job, index) =>
         <Accordion key={index} defaultExpanded={index === value.length - 1}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />} >
-            <Box>
-              <Chip label={job.kind} size="small" />
-              {' Kubernetes Job ID: '}
-
+            <Typography fontSize="small" color="GrayText" component="span">
+              {`Job ID: `}
               <StyledCode>{job.name}</StyledCode>
               <span onClick={preventPropagation}>
                 <CopyButton text={job.name} message="Copied Job ID" color={"grey"} />
               </span>
-            </Box>
+            </Typography>
           </AccordionSummary>
           <AccordionDetails>
             <PodEventHistory historyRecords={job.status_history_serialization} key={index} />

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
@@ -1,0 +1,67 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
+import { useRunJobHistory } from 'src/hooks/podHistoryHooks';
+import { useRunPanelLoadingIndicator } from 'src/hooks/runDetailsHooks';
+import PodEventHistory from 'src/pipelines/pod_lifecycle/PodEventHistory';
+import styled from '@emotion/styled';
+import { theme } from '@sematic/common/lib/src/theme/mira';
+import CopyButton from '@sematic/common/lib/src/component/CopyButton';
+import { useCallback } from 'react';
+
+const StyledCode = styled.code`
+  font-size: 12px;
+  color: ${theme.palette.grey[500]};
+  cursor: text;
+  user-select: text;  
+`;
+
+// Separate component to assign key to the component, so that it will be re-mounted when runId changes
+function PodLifecycleWithRunId(prop: {runId: string}) {
+  const { runId } = prop;
+
+  const { value, loading } = useRunJobHistory(runId);
+
+  useRunPanelLoadingIndicator(loading);
+
+  const preventPropagation = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  if (!value) return null;
+  if (value?.length === 0) return <Typography variant="body2">No job history found</Typography>;
+
+  return <>
+    {value!.map(
+      (job, index) =>
+        <Accordion key={index} defaultExpanded={index === value.length - 1}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+            <Box>
+              <Chip label={job.kind} size="small" />
+              {' Kubernetes Job ID: '}
+
+              <StyledCode>{job.name}</StyledCode>
+              <span onClick={preventPropagation}>
+                <CopyButton text={job.name} message="Copied Job ID" color={"grey"} />
+              </span>
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails>
+            <PodEventHistory historyRecords={job.status_history_serialization} key={index} />
+          </AccordionDetails>
+        </Accordion>
+    )}
+  </>
+}
+
+export default function PodLifecycle() {
+
+  const { selectedRun } = usePipelinePanelsContext();
+
+  return <PodLifecycleWithRunId key={selectedRun!.id} runId={selectedRun!.id} />
+}

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
@@ -5,12 +5,12 @@ import TimelineItem from "@mui/lab/TimelineItem/TimelineItem";
 import TimelineSeparator from "@mui/lab/TimelineSeparator/TimelineSeparator";
 import Chip from "@mui/material/Chip/Chip";
 import Typography from "@mui/material/Typography/Typography";
-import { styled } from "@mui/system";
+import styled from "@emotion/styled";
 import { Job } from "@sematic/common/lib/src/Models";
 import { format } from 'date-fns';
 import { useMemo } from "react";
 
-const TERMINATE_STATE: string = 'Deleted';
+const TERMINATE_STATE = 'Deleted';
 const SpacedText = styled(Typography)`
     margin: 4px 0;
 `;
@@ -31,18 +31,11 @@ function StyledChipWithColor(props:
 interface PodLifecycleEventProps {
     podStatus: Job['status_history_serialization'][number];
     isLast: boolean;
-    isFirst: boolean;
 }
 
 function getColorByState(podEvent: string) {
     if (["Running", "Pending"].includes(podEvent)) {
         return 'primary';
-    }
-    if (TERMINATE_STATE === podEvent) {
-        return 'success';
-    }
-    if (["Requested"].includes(podEvent)) {
-        return undefined;
     }
     return undefined;
 }
@@ -53,7 +46,7 @@ function TimelineDotWithColor({ resourceState }: { resourceState: string }) {
 };
 
 export default function PodLifecycleEvent(props: PodLifecycleEventProps) {
-    const { podStatus: { message, last_updated_epoch_seconds, state }, isLast, isFirst } = props;
+    const { podStatus: { message, last_updated_epoch_seconds, state }, isLast } = props;
 
     const timeString = useMemo(
         () => format(
@@ -65,10 +58,10 @@ export default function PodLifecycleEvent(props: PodLifecycleEventProps) {
             {isLast ?
                 <TimelineDotWithColor resourceState={state} />
                 : <TimelineDot />}
-            {!isLast && <TimelineConnector />}
+            {state !== TERMINATE_STATE && <TimelineConnector />}
         </TimelineSeparator>
         <TimelineContent>
-            {isFirst ?
+            {isLast ?
                 <StyledChipWithColor size={"small"} resourceState={state} />
                 : <StyledChip size={"small"} label={state} />}
             <SpacedText>{message}</SpacedText>

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
@@ -1,0 +1,78 @@
+import TimelineConnector from "@mui/lab/TimelineConnector/TimelineConnector";
+import TimelineContent from "@mui/lab/TimelineContent/TimelineContent";
+import TimelineDot from "@mui/lab/TimelineDot/TimelineDot";
+import TimelineItem from "@mui/lab/TimelineItem/TimelineItem";
+import TimelineSeparator from "@mui/lab/TimelineSeparator/TimelineSeparator";
+import Chip from "@mui/material/Chip/Chip";
+import Typography from "@mui/material/Typography/Typography";
+import { styled } from "@mui/system";
+import { Job } from "@sematic/common/lib/src/Models";
+import { format } from 'date-fns';
+import { useMemo } from "react";
+
+const TERMINATE_STATE: string = 'Deleted';
+const SpacedText = styled(Typography)`
+    margin: 4px 0;
+`;
+
+function StyledChip(props: React.ComponentProps<typeof Chip>) {
+    return <Chip {...props} sx={{ mr: 1 }} />
+};
+
+function StyledChipWithColor(props:
+    React.ComponentProps<typeof StyledChip> & { resourceState: string }) {
+    const { resourceState, ...restProps } = props;
+
+    const color = useMemo(() => getColorByState(resourceState), [resourceState]);
+
+    return <StyledChip {...restProps} color={color} label={resourceState} />
+}
+
+interface PodLifecycleEventProps {
+    podStatus: Job['status_history_serialization'][number];
+    isLast: boolean;
+    isFirst: boolean;
+}
+
+function getColorByState(podEvent: string) {
+    if (["Running", "Pending"].includes(podEvent)) {
+        return 'primary';
+    }
+    if (TERMINATE_STATE === podEvent) {
+        return 'success';
+    }
+    if (["Requested"].includes(podEvent)) {
+        return undefined;
+    }
+    return undefined;
+}
+
+function TimelineDotWithColor({ resourceState }: { resourceState: string }) {
+    const color = useMemo(() => getColorByState(resourceState) || 'grey', [resourceState]);
+    return <TimelineDot color={color} />;
+};
+
+export default function PodLifecycleEvent(props: PodLifecycleEventProps) {
+    const { podStatus: { message, last_updated_epoch_seconds, state }, isLast, isFirst } = props;
+
+    const timeString = useMemo(
+        () => format(
+            new Date(last_updated_epoch_seconds * 1000),
+            'LLL\xa0d,\xa0yyyy\xa0h:mm:ss\xa0a'), [last_updated_epoch_seconds]);
+
+    return <TimelineItem>
+        <TimelineSeparator>
+            {isLast ?
+                <TimelineDotWithColor resourceState={state} />
+                : <TimelineDot />}
+            {!isLast && <TimelineConnector />}
+        </TimelineSeparator>
+        <TimelineContent>
+            {isFirst ?
+                <StyledChipWithColor size={"small"} resourceState={state} />
+                : <StyledChip size={"small"} label={state} />}
+            <SpacedText>{message}</SpacedText>
+            <SpacedText>{timeString}</SpacedText>
+        </TimelineContent>
+    </TimelineItem>
+}

--- a/sematic/ui/packages/main/src/sockets.ts
+++ b/sematic/ui/packages/main/src/sockets.ts
@@ -3,3 +3,5 @@ import io from "socket.io-client";
 export const graphSocket = io("/graph");
 
 export const pipelineSocket = io("/pipeline");
+
+export const jobSocket = io("/job");


### PR DESCRIPTION
Implements the Pod lifecycle history UI. 

The information displayed will be updated when the job is running.

![capture1](https://user-images.githubusercontent.com/1046489/231288962-cf532ca8-d84d-4104-abc1-f5bca99b3199.gif)


The change is deployed to the `chance` namespace.