### PR TITLE
Add line ids for log lines

### DIFF
--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -112,6 +112,7 @@ sematic_py_lib(
         "//sematic/plugins:abstract_storage",
         "//sematic/plugins/storage:local_storage",
         "//sematic/resolvers:cloud_resolver",
+        "//sematic/resolvers:log_streamer",
         "//sematic/scheduling:job_details",
     ],
 )

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -630,6 +630,7 @@ def test_get_run_logs(
         can_continue_forward=True,
         can_continue_backward=True,
         lines=["Line 1", "Line 2"],
+        line_ids=[123, 124],
         forward_cursor_token="abc",
         reverse_cursor_token="xyz",
         log_info_message=None,

--- a/sematic/cli/tests/test_logs.py
+++ b/sematic/cli/tests/test_logs.py
@@ -104,6 +104,7 @@ def test_follow_logs(
             can_continue_forward=True,
             can_continue_backward=True,
             lines=early_lines,
+            line_ids=[i for i in range(len(early_lines))],
             forward_cursor_token="abc",
             reverse_cursor_token="zyx",
             log_info_message=None,
@@ -112,6 +113,7 @@ def test_follow_logs(
             can_continue_forward=True,
             can_continue_backward=True,
             lines=[],  # simulate situation where more WILL be produced but isn't yet
+            line_ids=[],
             forward_cursor_token="abc",
             reverse_cursor_token="zyx",
             log_info_message=None,
@@ -120,6 +122,7 @@ def test_follow_logs(
             can_continue_forward=False,
             can_continue_backward=True,
             lines=late_lines,
+            line_ids=[i + 10000 for i in range(len(late_lines))],
             forward_cursor_token=None,
             reverse_cursor_token="zyx",
             log_info_message=None,

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -111,7 +111,10 @@ class LogLineResult:
         can_continue_backward==True indicates that traversal can continue in the reverse
         direction.
     lines:
-        The actual log lines
+        The actual log lines.
+    line_ids:
+        Unique ids for each included log line. The log line at index `i` of the `lines`
+        field will have its id at index `i` of line_ids.
     forward_cursor_token:
         A string that can be used to continue traversing these logs from where you left
         off. If can_continue_forward is False, this will be set to None.
@@ -126,6 +129,7 @@ class LogLineResult:
     can_continue_forward: bool
     can_continue_backward: bool
     lines: List[str]
+    line_ids: List[int]
     forward_cursor_token: Optional[str]
     reverse_cursor_token: Optional[str] = None
     log_info_message: Optional[str] = None
@@ -291,6 +295,7 @@ def load_log_lines(
             can_continue_forward=True,
             can_continue_backward=False,
             lines=[],
+            line_ids=[],
             forward_cursor_token=forward_cursor.to_token(),
             reverse_cursor_token=None,
             log_info_message="Resolution has not started yet.",
@@ -302,6 +307,7 @@ def load_log_lines(
             can_continue_forward=True,
             can_continue_backward=False,
             lines=[],
+            line_ids=[],
             forward_cursor_token=forward_cursor.to_token(),
             reverse_cursor_token=None,
             log_info_message="The run has not yet started executing.",
@@ -385,6 +391,7 @@ def _load_non_inline_logs(
             can_continue_forward=still_running,
             can_continue_backward=False,
             lines=[],
+            line_ids=[],
             forward_cursor_token=Cursor.nothing_found(
                 filter_strings, run_id, reverse=False
             ).to_token()
@@ -433,6 +440,7 @@ def _load_inline_logs(
             can_continue_forward=False,
             can_continue_backward=False,
             lines=[],
+            line_ids=[],
             forward_cursor_token=None,
             reverse_cursor_token=None,
             log_info_message=(
@@ -455,6 +463,7 @@ def _load_inline_logs(
             else None,
             reverse_cursor_token=None,
             lines=[],
+            line_ids=[],
             log_info_message="Resolver logs are missing",
         )
 
@@ -646,6 +655,7 @@ def get_log_lines_from_line_stream(
     buffer_iterator = iter(line_stream)
     keep_going = True
     lines: List[str] = []
+    line_ids: List[int] = []
 
     def passes_filter(line: LogLine) -> bool:
         return all(substring in line.line for substring in filter_strings)
@@ -678,6 +688,7 @@ def get_log_lines_from_line_stream(
                 latest_included_line_index = line.source_file_index
 
             lines.append(line.line)
+            line_ids.append(to_line_id(line.source_file, line.source_file_index))
             if len(lines) >= max_lines:
                 keep_going = False
         except StopIteration:
@@ -747,6 +758,7 @@ def get_log_lines_from_line_stream(
         can_continue_forward=forward_cursor_token is not None,
         can_continue_backward=reverse_cursor_token is not None,
         lines=list(reversed(lines)) if reverse else lines,
+        line_ids=list(reversed(line_ids)) if reverse else line_ids,
         forward_cursor_token=forward_cursor_token,
         reverse_cursor_token=reverse_cursor_token,
         log_info_message=log_info_message,
@@ -768,3 +780,41 @@ def reversed(iterable: Iterable[T]) -> Iterable[T]:
         as_list.append(item)
     as_list.reverse()
     yield from as_list
+
+
+def to_line_id(log_file: str, line_index: int) -> int:
+    """Get a unique id for each log line.
+
+    Line ids are only guaranteed unique within a given run or resolver
+    execution. However, within such a context, the line ids are in
+    chronological order. Some line ids may appear to be sequential with
+    no gap, but it is not guaranteed that there will be no gaps between ids.
+
+    It should only be used for actual lines, and not abstract positions (such as
+    cursors).
+
+    Callers should not depend on any details about how this id is constructed.
+
+    Parameters
+    ----------
+    log_file:
+        The name of the log file where the line occurs.
+    line_index:
+        The index of the line within the log file.
+    """
+    timestamp = int("".join(char for char in log_file.split("/")[-1] if char.isdigit()))
+
+    # obfuscate the fact that there's a timestamp here; we don't want the
+    # front-end to actually use it as such. It only represents the time
+    # the whole *log file* was ingested, and not when any individual line
+    # was.
+    prefix = timestamp - 1500000000000
+
+    # We know the suffic will be less than 1000 because
+    # that's the max size for any given log file. However, that limit was
+    # fairly recent so we can use an extra 0 to be safe. For logs older
+    # than the "max 1000" rule, timestamps would be 10 seconds apart
+    # and the timestamps are in milliseconds, which gives us more headroom
+    # to avoid duplication.
+    suffix = line_index
+    return 10000 * prefix + suffix

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -19,6 +19,7 @@ from sematic.resolvers.cloud_resolver import (
     END_INLINE_RUN_INDICATOR,
     START_INLINE_RUN_INDICATOR,
 )
+from sematic.resolvers.log_streamer import MAX_LINES_PER_LOG_FILE
 from sematic.scheduling.job_details import JobKind, JobKindString
 
 V2_LOG_PREFIX = "logs/v2"
@@ -810,11 +811,10 @@ def to_line_id(log_file: str, line_index: int) -> int:
     # was.
     prefix = timestamp - 1500000000000
 
-    # We know the suffic will be less than 1000 because
-    # that's the max size for any given log file. However, that limit was
-    # fairly recent so we can use an extra 0 to be safe. For logs older
-    # than the "max 1000" rule, timestamps would be 10 seconds apart
-    # and the timestamps are in milliseconds, which gives us more headroom
-    # to avoid duplication.
+    # We know the suffix will be less than MAX_LINES_PER_LOG_FILE. However,
+    # that limit was fairly recent so we can use an extra 0 to be safe.
+    # For logs older than the MAX_LINES_PER_LOG_FILE rule, timestamps
+    # would be 10 seconds apart and the timestamps are in milliseconds,
+    # which gives us more headroom to avoid duplication.
     suffix = line_index
-    return 10000 * prefix + suffix
+    return 10 * MAX_LINES_PER_LOG_FILE * prefix + suffix

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -29,6 +29,7 @@ from sematic.log_reader import (
     load_log_lines,
     log_prefix,
     reversed,
+    to_line_id,
 )
 from sematic.resolvers.cloud_resolver import (
     END_INLINE_RUN_INDICATOR,
@@ -251,7 +252,7 @@ def prepare_logs_v2(
 
     log_file_contents_part_1 = bytes("\n".join(lines_part_1), encoding="utf8")
     prefix = log_prefix(run_id, job_kind)
-    key_part_1 = f"{prefix}12345.log"
+    key_part_1 = f"{prefix}1600000000000.log"
     mock_storage.set(key_part_1, log_file_contents_part_1)
 
     if emulate_pending_more_lines:
@@ -259,9 +260,13 @@ def prepare_logs_v2(
         return prefix
     log_file_contents_part_2 = bytes("\n".join(lines_part_2), encoding="utf8")
     prefix = log_prefix(run_id, job_kind)
-    key_part_2 = f"{prefix}12346.log"
+    key_part_2 = f"{prefix}1610000000000.log"
     mock_storage.set(key_part_2, log_file_contents_part_2)
-    return prefix
+
+    line_ids_part_1 = [to_line_id(key_part_1, i) for i in range(len(lines_part_1))]
+    line_ids_part_2 = [to_line_id(key_part_2, i) for i in range(len(lines_part_2))]
+    line_ids = line_ids_part_1 + line_ids_part_2
+    return prefix, line_ids
 
 
 @pytest.mark.parametrize(
@@ -382,7 +387,7 @@ def test_line_stream_from_log_directory(
 
     n_lines = 500
     text_lines = [f"Line {i}" for i in range(n_lines)]
-    prefix = prepare_logs_v2(
+    prefix, _ = prepare_logs_v2(
         run_id=run.id,
         text_lines=text_lines,
         mock_storage=mock_storage,
@@ -400,7 +405,7 @@ def test_line_stream_from_log_directory(
     start_index = 50
     line_stream = line_stream_from_log_directory(
         directory=log_prefix(run.id, JobKind.run),
-        cursor_file=f"{log_prefix(run.id, JobKind.run)}12345.log",
+        cursor_file=f"{log_prefix(run.id, JobKind.run)}1600000000000.log",
         cursor_line_index=start_index,
         reverse=False,
     )
@@ -416,7 +421,7 @@ def test_line_stream_from_log_directory_reverse(
     save_run(run)
     n_lines = 500
     text_lines = [f"Line {i}" for i in range(n_lines)]
-    prefix = prepare_logs_v2(
+    prefix, _ = prepare_logs_v2(
         run_id=run.id,
         text_lines=text_lines,
         mock_storage=mock_storage,
@@ -435,7 +440,7 @@ def test_line_stream_from_log_directory_reverse(
     start_index = 20
     line_stream = line_stream_from_log_directory(
         directory=log_prefix(run.id, JobKind.run),
-        cursor_file=f"{log_prefix(run.id, JobKind.run)}12346.log",
+        cursor_file=f"{log_prefix(run.id, JobKind.run)}1610000000000.log",
         cursor_line_index=start_index,
         reverse=True,
     )
@@ -623,7 +628,9 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
     save_job(make_job(run_id=run.id))
     save_run(run)
     text_lines = [line.line for line in finite_logs(100)]
-    log_preparation_function(run.id, text_lines, mock_storage, JobKind.run)
+    _, line_ids = log_preparation_function(
+        run.id, text_lines, mock_storage, JobKind.run
+    )
 
     result = load_log_lines(
         run_id=run.id,
@@ -639,10 +646,11 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
             can_continue_backward=True,
             can_continue_forward=True,
             lines=text_lines[:max_lines],
-            line_ids=None,
+            line_ids=line_ids[:max_lines],
             log_info_message=None,
         ),
         result,
+        compare_line_ids=True,
     )
 
     result = load_log_lines(
@@ -767,7 +775,9 @@ def test_load_log_lines_reverse(
     save_job(make_job(run_id=run.id))
     save_run(run)
     text_lines = [line.line for line in finite_logs(100)]
-    log_preparation_function(run.id, text_lines, mock_storage, JobKind.run)
+    _, line_ids = log_preparation_function(
+        run.id, text_lines, mock_storage, JobKind.run
+    )
 
     result = load_log_lines(
         run_id=run.id,
@@ -784,10 +794,11 @@ def test_load_log_lines_reverse(
             can_continue_backward=True,
             can_continue_forward=True,
             lines=text_lines[-1 * max_lines :],  # noqa: E203
-            line_ids=None,
+            line_ids=line_ids[-1 * max_lines :],  # noqa: E203
             log_info_message=None,
         ),
         result,
+        compare_line_ids=True,
     )
 
     result = load_log_lines(
@@ -1203,6 +1214,38 @@ def test_stream_from_text_stream_from_index_reverse():
         )
     )
     assert streamed == list(reversed(list(finite_logs(n_lines))[:start_line_index]))
+
+
+# Note: this serves both as a source of individual test cases
+# for test_to_line_id, and a list of test cases for
+# test_to_line_id_obeys_order
+LINE_ID_TESTS = [
+    ("foo/1234bar/baz1610000000000.log", 42, 1100000000000042),
+    ("foo/1234bar/baz1610000000000.log", 43, 1100000000000043),
+    ("foo/1234bar/baz1610000000333.log", 999, 1100000003330999),
+    ("foo/1234bar/baz2510000000333.log", 999, 10100000003330999),
+]
+
+
+@pytest.mark.parametrize("log_file, log_index, expected_id", LINE_ID_TESTS)
+def test_to_line_id(log_file, log_index, expected_id):
+    actual = to_line_id(log_file, log_index)
+    assert expected_id == actual
+
+
+def test_to_line_id_obeys_order():
+    """Tests that lines which were generated later have higher ids.
+
+    Even if the actual logic mapping log files/indices to ids changes, this
+    test should still pass unchanged.
+    """
+
+    # Lexical ordering should ensure these are sorted first by log
+    # file, then by line index.
+    ordered_lines = sorted(LINE_ID_TESTS)
+
+    line_ids = [to_line_id(log_file, index) for log_file, index, _ in ordered_lines]
+    assert sorted(line_ids) == line_ids
 
 
 def compare_log_line_result(

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -37,7 +37,7 @@ from sematic.resolvers.cloud_resolver import (
 from sematic.scheduling.job_details import JobKind
 
 _streamed_lines: List[str] = []
-_DUMMY_LOGS_FILE = "logs.log"
+_DUMMY_LOGS_FILE = "logs123.log"
 _DUMMY_RUN_ID = "abc123"
 
 
@@ -89,16 +89,17 @@ def test_get_log_lines_from_line_stream_does_streaming():
         run_id=_DUMMY_RUN_ID,
     )
     cursor = Cursor.from_token(result.forward_cursor_token)
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[f"Line {i}" for i in range(max_lines)],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[f"Line {i}" for i in range(max_lines)],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
     assert _streamed_lines == result.lines
 
@@ -115,16 +116,17 @@ def test_get_log_lines_from_line_stream_does_streaming():
         filter_strings=[],
         run_id=_DUMMY_RUN_ID,
     )
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-
-    assert result == LogLineResult(
-        can_continue_backward=True,
-        can_continue_forward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[f"Line {i}" for i in range(max_lines, 2 * max_lines)],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_backward=True,
+            can_continue_forward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[f"Line {i}" for i in range(max_lines, 2 * max_lines)],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
 
@@ -173,27 +175,29 @@ def test_get_log_lines_from_line_stream_filter():
         filter_strings=["2"],
     )
     cursor = Cursor.from_token(result.forward_cursor_token)
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
 
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[
-            "Line 2",
-            "Line 12",
-            "Line 20",
-            "Line 21",
-            "Line 22",
-            "Line 23",
-            "Line 24",
-            "Line 25",
-            "Line 26",
-            "Line 27",
-        ],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[
+                "Line 2",
+                "Line 12",
+                "Line 20",
+                "Line 21",
+                "Line 22",
+                "Line 23",
+                "Line 24",
+                "Line 25",
+                "Line 26",
+                "Line 27",
+            ],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = get_log_lines_from_line_stream(
@@ -209,26 +213,28 @@ def test_get_log_lines_from_line_stream_filter():
         filter_strings=["2"],
     )
 
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[
-            "Line 28",
-            "Line 29",
-            "Line 32",
-            "Line 42",
-            "Line 52",
-            "Line 62",
-            "Line 72",
-            "Line 82",
-            "Line 92",
-            "Line 102",
-        ],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[
+                "Line 28",
+                "Line 29",
+                "Line 32",
+                "Line 42",
+                "Line 52",
+                "Line 62",
+                "Line 72",
+                "Line 82",
+                "Line 92",
+                "Line 102",
+            ],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
 
@@ -305,15 +311,17 @@ def test_load_non_inline_logs(
     assert result.forward_cursor_token is not None
     cursor = Cursor.from_token(result.forward_cursor_token)
     assert cursor.traversal_had_lines
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[:max_lines],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[:max_lines],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = _load_non_inline_logs(
@@ -328,15 +336,17 @@ def test_load_non_inline_logs(
     )
     assert result.forward_cursor_token is not None
     cursor = Cursor.from_token(result.forward_cursor_token)
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        can_continue_backward=True,
-        can_continue_forward=True,
-        lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            can_continue_backward=True,
+            can_continue_forward=True,
+            lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = _load_non_inline_logs(
@@ -356,6 +366,7 @@ def test_load_non_inline_logs(
         forward_cursor_token=None,
         reverse_cursor_token=None,
         lines=[],
+        line_ids=[],
         log_info_message="No matching log lines.",
     )
 
@@ -491,13 +502,17 @@ def test_load_inline_logs(
     cursor = Cursor.from_token(result.forward_cursor_token)
     result.forward_cursor_token = None
     result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=run_text_lines[:max_lines],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=run_text_lines[:max_lines],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = _load_inline_logs(
@@ -516,12 +531,16 @@ def test_load_inline_logs(
     result.forward_cursor_token = None
     result.reverse_cursor_token = None
 
-    assert result == LogLineResult(
-        forward_cursor_token=None,
-        can_continue_backward=True,
-        can_continue_forward=True,
-        lines=run_text_lines[max_lines:],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            forward_cursor_token=None,
+            can_continue_backward=True,
+            can_continue_forward=True,
+            lines=run_text_lines[max_lines:],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = _load_inline_logs(
@@ -534,15 +553,17 @@ def test_load_inline_logs(
         max_lines=max_lines,
         filter_strings=[],
     )
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=False,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[],
-        log_info_message="No matching log lines.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=False,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[],
+            line_ids=None,
+            log_info_message="No matching log lines.",
+        ),
+        result,
     )
 
 
@@ -573,6 +594,7 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
         forward_cursor_token=None,
         reverse_cursor_token=None,
         lines=[],
+        line_ids=[],
         log_info_message="Resolution has not started yet.",
     )
 
@@ -593,6 +615,7 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
         forward_cursor_token=None,
         reverse_cursor_token=None,
         lines=[],
+        line_ids=[],
         log_info_message="The run has not yet started executing.",
     )
 
@@ -609,15 +632,17 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
         max_lines=max_lines,
     )
     token = result.forward_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        can_continue_backward=True,
-        can_continue_forward=True,
-        lines=text_lines[:max_lines],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            can_continue_backward=True,
+            can_continue_forward=True,
+            lines=text_lines[:max_lines],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -628,15 +653,17 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
         reverse=False,
     )
     token = result.forward_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -646,15 +673,18 @@ def test_load_log_lines(mock_storage, test_db, log_preparation_function):  # noq
         max_lines=max_lines,
         reverse=False,
     )
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[],
-        log_info_message="No matching log lines.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[],
+            line_ids=[],
+            log_info_message="No matching log lines.",
+        ),
+        result,
+        compare_line_ids=True,
     )
 
     result = load_log_lines(
@@ -707,6 +737,7 @@ def test_load_log_lines_reverse(
         forward_cursor_token=None,
         reverse_cursor_token=None,
         lines=[],
+        line_ids=[],
         log_info_message="Resolution has not started yet.",
     )
 
@@ -728,6 +759,7 @@ def test_load_log_lines_reverse(
         forward_cursor_token=None,
         reverse_cursor_token=None,
         lines=[],
+        line_ids=[],
         log_info_message="The run has not yet started executing.",
     )
 
@@ -745,15 +777,17 @@ def test_load_log_lines_reverse(
         reverse=True,
     )
     token = result.reverse_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        can_continue_backward=True,
-        can_continue_forward=True,
-        lines=text_lines[-1 * max_lines :],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            can_continue_backward=True,
+            can_continue_forward=True,
+            lines=text_lines[-1 * max_lines :],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -764,15 +798,17 @@ def test_load_log_lines_reverse(
         reverse=True,
     )
     token = result.reverse_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[-2 * max_lines : -1 * max_lines],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[-2 * max_lines : -1 * max_lines],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -782,15 +818,17 @@ def test_load_log_lines_reverse(
         max_lines=max_lines,
         reverse=True,
     )
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=False,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[],
-        log_info_message="No matching log lines.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=False,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[],
+            line_ids=None,
+            log_info_message="No matching log lines.",
+        ),
+        result,
     )
     result = load_log_lines(
         run_id=run.id,
@@ -848,6 +886,7 @@ def test_load_cloned_run_log_lines(
         can_continue_backward=False,
         can_continue_forward=True,
         lines=[],
+        line_ids=[],
         log_info_message="Resolution has not started yet.",
     )
 
@@ -861,15 +900,17 @@ def test_load_cloned_run_log_lines(
         max_lines=max_lines,
         reverse=False,
     )
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=False,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[],
-        log_info_message="The run has not yet started executing.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=False,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[],
+            line_ids=[],
+            log_info_message="The run has not yet started executing.",
+        ),
+        result,
     )
 
     run.future_state = FutureState.SCHEDULED
@@ -886,15 +927,17 @@ def test_load_cloned_run_log_lines(
         reverse=False,
     )
     token = result.forward_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[:max_lines],
-        log_info_message=f"Run logs sourced from original run {run.id}.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[:max_lines],
+            line_ids=None,
+            log_info_message=f"Run logs sourced from original run {run.id}.",
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -905,15 +948,17 @@ def test_load_cloned_run_log_lines(
         reverse=False,
     )
     token = result.forward_cursor_token
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
-        log_info_message=f"Run logs sourced from original run {run.id}.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
+            line_ids=None,
+            log_info_message=f"Run logs sourced from original run {run.id}.",
+        ),
+        result,
     )
 
     result = load_log_lines(
@@ -931,6 +976,7 @@ def test_load_cloned_run_log_lines(
         can_continue_backward=True,
         can_continue_forward=True,
         lines=[],
+        line_ids=[],
         log_info_message="No matching log lines.",
     )
 
@@ -999,15 +1045,17 @@ def test_continue_from_end_with_no_new_logs(
     assert result.reverse_cursor_token is not None
     cursor = Cursor.from_token(result.forward_cursor_token)
     assert cursor.traversal_had_lines
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[:max_lines],
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[:max_lines],
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     # 50 more lines requested, only 2 more available
@@ -1024,15 +1072,17 @@ def test_continue_from_end_with_no_new_logs(
     assert result.forward_cursor_token is not None
     assert result.reverse_cursor_token is not None
     cursor = Cursor.from_token(result.forward_cursor_token)
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[max_lines:break_at_line],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[max_lines:break_at_line],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
     # 50 more lines requested, no more available
@@ -1049,15 +1099,17 @@ def test_continue_from_end_with_no_new_logs(
     assert result.forward_cursor_token is not None
     assert result.reverse_cursor_token is not None
     cursor = Cursor.from_token(result.forward_cursor_token)
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=[],  # noqa: E203
-        log_info_message="No matching log lines.",
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=[],  # noqa: E203
+            line_ids=[],
+            log_info_message="No matching log lines.",
+        ),
+        result,
     )
 
     # upload more logs
@@ -1083,20 +1135,22 @@ def test_continue_from_end_with_no_new_logs(
     )
     assert result.forward_cursor_token is not None
     assert result.reverse_cursor_token is not None
-    result.forward_cursor_token = None
-    result.reverse_cursor_token = None
-    assert result == LogLineResult(
-        can_continue_forward=True,
-        can_continue_backward=True,
-        forward_cursor_token=None,
-        reverse_cursor_token=None,
-        lines=text_lines[break_at_line:total_lines],  # noqa: E203
-        log_info_message=None,
+    compare_log_line_result(
+        LogLineResult(
+            can_continue_forward=True,
+            can_continue_backward=True,
+            forward_cursor_token=None,
+            reverse_cursor_token=None,
+            lines=text_lines[break_at_line:total_lines],  # noqa: E203
+            line_ids=None,
+            log_info_message=None,
+        ),
+        result,
     )
 
 
 def test_stream_from_text_stream_from_index_forward():
-    log_file = "logs.log"
+    log_file = "logs123.log"
     n_lines = 100
     text_stream = (f"Line {i}" for i in range(n_lines))
 
@@ -1124,7 +1178,7 @@ def test_stream_from_text_stream_from_index_forward():
 
 
 def test_stream_from_text_stream_from_index_reverse():
-    log_file = "logs.log"
+    log_file = "logs123.log"
     n_lines = 100
     text_stream = (f"Line {i}" for i in range(n_lines))
 
@@ -1149,3 +1203,24 @@ def test_stream_from_text_stream_from_index_reverse():
         )
     )
     assert streamed == list(reversed(list(finite_logs(n_lines))[:start_line_index]))
+
+
+def compare_log_line_result(
+    expected: LogLineResult,
+    actual: LogLineResult,
+    compare_cursors: bool = False,
+    compare_line_ids: bool = False,
+):
+    if not compare_cursors:
+        expected.forward_cursor_token = None
+        expected.reverse_cursor_token = None
+        actual.forward_cursor_token = None
+        actual.reverse_cursor_token = None
+    assert len(actual.line_ids) == len(actual.lines)
+    assert sorted(actual.line_ids) == actual.line_ids
+
+    if not compare_line_ids:
+        expected.line_ids = None  # type: ignore
+        actual.line_ids = None  # type: ignore
+
+    assert expected == actual

--- a/sematic/ui/packages/main/src/Payloads.tsx
+++ b/sematic/ui/packages/main/src/Payloads.tsx
@@ -43,6 +43,7 @@ export type LogLineResult = {
   can_continue_backward: boolean;
   can_continue_forward: boolean;
   lines: string[];
+  line_ids: number[];
   forward_cursor_token: string | null;
   reverse_cursor_token: string | null;
   log_info_message: string | null;


### PR DESCRIPTION
The front-end wants a more robust way to ensure that duplicate lines are not shown in the log UI (due to duplicated requests, for example). This PR adds unique line ids for each returned log line that is derived from the log line's source file and index in such a way as to ensure that the ids are unique within a given run, and that higher ids are for later log lines.

Testing
-------
In addition to unit tests, also deployed and confirmed that the line ids are being returned by the HTTP request for log lines.