### PR TITLE
Extracts the text selection tool as a common utility

### DIFF
--- a/sematic/ui/packages/main/src/hooks/textSelectionHooks.ts
+++ b/sematic/ui/packages/main/src/hooks/textSelectionHooks.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * This hook is used to detect if the user is selecting text. If the user is selecting text, 
+ * the hook will prevent the default behavior of the click event.
+ * 
+ * @returns a ref that should be attached to the element that should be monitored for text selection. 
+ */
+export function useTextSelection<T extends HTMLElement>() {    
+    const monitorElementRef = useRef() as React.MutableRefObject<T>;
+
+    const isSelectingText = useRef(false);
+
+    const onMouseDown = useCallback((e: Event) => {
+        isSelectingText.current = false;
+    }, []);
+
+    const onMouseUp = useCallback((e: Event) => {
+        if (isSelectingText.current) {
+            e.preventDefault();
+        }
+    }, []);
+
+    const onClick = useCallback((e: Event) => {
+        if (isSelectingText.current) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }, []);
+
+    const onMouseMove: (this: HTMLElement, ev: MouseEvent) => any = useCallback((e: MouseEvent) => {
+        if (e.buttons === 1) {
+            isSelectingText.current = true;
+        }
+    }, []);
+
+    useEffect(() => {
+        const monitorElement = monitorElementRef.current;
+
+        if (monitorElement) {
+            monitorElement.addEventListener("mousedown", onMouseDown);
+            monitorElement.addEventListener("mouseup", onMouseUp);
+            monitorElement.addEventListener("click", onClick);
+            monitorElement.addEventListener("mousemove", onMouseMove);
+
+            return () => {
+                monitorElement.removeEventListener("mousedown", onMouseDown);
+                monitorElement.removeEventListener("mouseup", onMouseUp);
+                monitorElement.removeEventListener("click", onClick);
+                monitorElement.removeEventListener("mousemove", onMouseMove);
+            };
+        }
+    });
+
+    return monitorElementRef;
+}

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
@@ -3,12 +3,13 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CopyButton from '@sematic/common/lib/src/component/CopyButton';
-import { useCallback } from 'react';
 import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
 import { useRunJobHistory } from 'src/hooks/podHistoryHooks';
 import { useRunPanelLoadingIndicator } from 'src/hooks/runDetailsHooks';
+import { useTextSelection } from 'src/hooks/textSelectionHooks';
 import PodEventHistory from 'src/pipelines/pod_lifecycle/PodEventHistory';
 
 const StyledCode = styled.code`
@@ -25,15 +26,13 @@ function PodLifecycleWithRunId(prop: { runId: string }) {
 
   useRunPanelLoadingIndicator(loading);
 
-  const preventPropagation = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
+  const elementRef = useTextSelection<HTMLDivElement>();
 
   if (!value) return null;
   if (value?.length === 0) return <Typography variant="body2">No pod history found.</Typography>;
 
   return <>
-    <Typography fontSize="small" color="GrayText" style={{marginBottom: '1em'}}>
+    <Typography fontSize="small" color="GrayText" style={{ marginBottom: '1em' }}>
       The information in this tab is provided for debugging purposes.
       The information it displays is periodically polled from Kubernetes,
       and some intermediate states may not be represented in the timelines.
@@ -42,13 +41,15 @@ function PodLifecycleWithRunId(prop: { runId: string }) {
       (job, index) =>
         <Accordion key={index} defaultExpanded={index === value.length - 1}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />} >
-            <Typography fontSize="small" color="GrayText" component="span">
-              {`Job ID: `}
-              <StyledCode>{job.name}</StyledCode>
-              <span onClick={preventPropagation}>
-                <CopyButton text={job.name} message="Copied Job ID" color={"grey"} />
-              </span>
-            </Typography>
+            <Box ref={elementRef} style={{ width: `100%` }}>
+              <Typography fontSize="small" color="GrayText" component="span">
+                {`Job ID: `}
+                <StyledCode>{job.name}</StyledCode>
+                <span>
+                  <CopyButton text={job.name} message="Copied Job ID" color={"grey"} />
+                </span>
+              </Typography>
+            </Box>
           </AccordionSummary>
           <AccordionDetails>
             <PodEventHistory historyRecords={job.status_history_serialization} key={index} />

--- a/sematic/ui/packages/main/src/types/aws.tsx
+++ b/sematic/ui/packages/main/src/types/aws.tsx
@@ -1,8 +1,8 @@
 import { OpenInNew } from "@mui/icons-material";
 import { Button, Tooltip } from "@mui/material";
+import { useTextSelection } from "src/hooks/textSelectionHooks";
 import { CommonValueViewProps } from "./common";
 import S3Icon from "./s3.png";
-import { useRef } from "react";
 
 export function S3LocationValueView(props: CommonValueViewProps) {
   const { valueSummary } = props;
@@ -37,31 +37,7 @@ function S3Button(props: { region?: string, bucket: string, location?: string })
     href.searchParams.append("prefix", location);
   }
 
-  // The following code is to allow the user to select the text in the button
-  // without triggering the link.
-  const isSelectingText = useRef(false);
-
-  const onMouseDown = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    isSelectingText.current = false;
-  }
-
-  const onMouseUp = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    if (isSelectingText.current) {
-      e.preventDefault();
-    }
-  }
-
-  const onClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    if (isSelectingText.current) {
-      e.preventDefault();
-    }
-  }
-
-  const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (e.buttons === 1) {
-      isSelectingText.current = true;
-    }
-  }
+  const elementRef = useTextSelection<HTMLDivElement>();
 
   return <Tooltip title="View in AWS console">
     <Button
@@ -71,12 +47,9 @@ function S3Button(props: { region?: string, bucket: string, location?: string })
       endIcon={<OpenInNew />}
       draggable={false}
       style={{ userSelect: "text" }}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
     >
       <img src={S3Icon} width="20px" style={{ paddingRight: "5px" }} draggable="false" alt="" />
-      <div onMouseMove={onMouseMove} style={{ cursor: 'text' }} >{s3URI}</div>
+      <div ref={elementRef} style={{ cursor: 'text' }} >{s3URI}</div>
     </Button>
   </Tooltip>;
 }


### PR DESCRIPTION
Introduces a tool that prevents text selection from triggering click events. 

This was something used for S3Button. Now, it is extracted as a common utility that also applies to Pod life cycle accordions. 

Before:
![capture1](https://user-images.githubusercontent.com/1046489/231525537-73592a7b-d76a-4182-91cb-d280bd7f4ed2.gif)

After:
![capture1](https://user-images.githubusercontent.com/1046489/231525110-50aabed7-9a36-4a47-8896-80eb2c82bec8.gif)

