### PR TITLE
Refactors devLogger creation

### DIFF
--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -18463,7 +18463,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
@@ -27279,6 +27279,7 @@
         "javascript-time-ago": "^2.3.13",
         "jotai": "^1.12.1",
         "jotai-location": "^0.3.2",
+        "lodash": "^4.17.21",
         "mpld3": "^0.5.8",
         "plotly.js-cartesian-dist": "^2.12.1",
         "posthog-js": "^1.45.1",
@@ -30486,6 +30487,7 @@
         "javascript-time-ago": "^2.3.13",
         "jotai": "^1.12.1",
         "jotai-location": "^0.3.2",
+        "lodash": "^4.17.21",
         "mpld3": "^0.5.8",
         "plotly.js-cartesian-dist": "^2.12.1",
         "posthog-js": "^1.45.1",
@@ -41178,7 +41180,7 @@
     },
     "lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {

--- a/sematic/ui/packages/main/package.json
+++ b/sematic/ui/packages/main/package.json
@@ -25,6 +25,7 @@
     "javascript-time-ago": "^2.3.13",
     "jotai": "^1.12.1",
     "jotai-location": "^0.3.2",
+    "lodash": "^4.17.21",
     "mpld3": "^0.5.8",
     "plotly.js-cartesian-dist": "^2.12.1",
     "posthog-js": "^1.45.1",


### PR DESCRIPTION
The `useLogger` is used in many React components; each time a component consumes it, it has to re-fetch the setting in the URL and local storage, which is not performant.

1. The debug flag is set per page load and persists unless the page is reloaded again. The setting does not need to be re-read when the page session is live.

2. The logging function instance can be memorized instead of re-created for each component. 

This PR addresses the above issues by leveraging [lodash's memoize](https://www.geeksforgeeks.org/lodash-_-memoize-method/)