### PR TITLE
Improve release doc about setting up helm repo ahead of time

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -262,6 +262,9 @@ changes.
   consistent and expected state, and to test the actual commands users will be using to
   deploy the release.
     ```bash
+    $ # Run this step if it has never been done before
+    $ helm repo add sematic-ai https://sematic-ai.github.io/helm-charts
+
     $ # STAGE:
     $ helm upgrade sematic-server sematic-ai/sematic-server -n stage -f /path/to/stage_values.yml
     $ helm list -n stage  # check that the expected APP VERSION was deployed


### PR DESCRIPTION
`helm repo add sematic-ai https://sematic-ai.github.io/helm-charts` might need to be run at least once. It might be a once-in-a-lifetime setup, but it is still worth mentioning.
