### PR TITLE
Fix CircleCI GitHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">Build ML pipelines with only Python, run on your laptop, or in the cloud.</h3>
 
 ![PyPI](https://img.shields.io/pypi/v/sematic/0.28.1?style=for-the-badge)
-[![CircleCI](https://img.shields.io/circleci/build/github/sematic-ai/sematic/main?label=CircleCI&style=for-the-badge&token=c8e0115ddccadc17b98ab293b32cad27026efb25)](https://app.circleci.com/pipelines/github/sematic-ai/sematic?branch=main&filter=all)
+[![CircleCI](https://img.shields.io/circleci/build/github/sematic-ai/sematic/main?label=CircleCI&style=for-the-badge&token=60d1953bfee5b6bf8201f8e84a10eaa5bf5622fe)](https://app.circleci.com/pipelines/github/sematic-ai/sematic?branch=main&filter=all)
 ![PyPI - License](https://img.shields.io/pypi/l/sematic?style=for-the-badge)
 [![Python 3.8](https://img.shields.io/badge/Python-3.8-blue?style=for-the-badge&logo=none)](https://python.org)
 [![Python 3.9](https://img.shields.io/badge/Python-3.9-blue?style=for-the-badge&logo=none)](https://python.org)


### PR DESCRIPTION
The API token was completely missing from the CircleCI project settings. Created a dedicated one.

Before:
![image](https://user-images.githubusercontent.com/1894533/231853066-879039ca-9885-4238-b2c3-24fe9f5e9252.png)

After:
<img width="183" alt="image" src="https://user-images.githubusercontent.com/1894533/231853152-484ecd8d-4afd-4c48-b8cb-5afe256d053c.png">
