### PR TITLE
Remove unused image_tags param from sematic_pipeline

### DIFF
--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -23,7 +23,6 @@ def sematic_pipeline(
         bases = None,
         tags = None,
         image_layers = None,
-        image_tags = None,
         env = None,
         insecure_repository = None,
         dev = False):


### PR DESCRIPTION
Removes an unused parameter from `sematic_pipeline`, in order to avoid confusion.