### PR TITLE
Force HTTP requests to redirect to HTTPS by default

### DIFF
--- a/helm/sematic-server/templates/ingress.yaml
+++ b/helm/sematic-server/templates/ingress.yaml
@@ -8,8 +8,12 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.ingress.force_ssl }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -88,7 +88,6 @@ ray:
 
 rbac:
   create: true
-  
   # Should the server be allowed to manage Ray clusters?
   # Should be 'true' if using Sematic's Ray or Spark
   # integrations.
@@ -114,6 +113,7 @@ service:
 ingress:
   create: false
   sematic_dashboard_url: https://my.sematic # REPLACE ME
+  force_ssl: true
   class_name: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
accidental usage of `http://` urls that are insecure, and cause google oauth to throw errors because it does not allow mixed use of secure/insecure domains.  rather than failing silently, we set all http requests to redirect to https by default so that users have a secure default.  also added `ingress.force_ssl` as an option so that this can be disabled for local/unsecured clusters.

fixes #597