### PR TITLE
Add APIs to clean up orphaned jobs

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -411,7 +411,9 @@ def _update_resolution_user(
 
 @sematic_api.route("/api/v1/resolutions/with_orphaned_jobs", methods=["GET"])
 @authenticate
-def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Response:
+def get_orphaned_resolution_job_identifiers_endpoint(
+    user: Optional[User],
+) -> flask.Response:
     run_ids = get_resolutions_with_orphaned_jobs()
 
     return flask.jsonify(
@@ -423,7 +425,17 @@ def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Respons
 
 @sematic_api.route("/api/v1/resolutions/<root_id>/clean_jobs", methods=["POST"])
 @authenticate
-def clean_orphaned_jobs_endpoint(user: Optional[User], root_id: str) -> flask.Response:
+def clean_orphaned_resolution_jobs_endpoint(
+    user: Optional[User], root_id: str
+) -> flask.Response:
+    resolution = get_resolution(root_id)
+    if not ResolutionStatus[resolution.status].is_terminal():  # type: ignore
+        message = (
+            f"Can't clean jobs of resolution {root_id} "
+            f"in non-terminal state {resolution.status}."
+        )
+        logger.error(message)
+        return jsonify_error(message, HTTPStatus.BAD_REQUEST)
     force = flask.request.args.get("force", "false").lower() == "true"
     jobs = get_jobs_by_run_id(root_id, kind=JobKind.resolver)
     state_changes = clean_jobs(jobs, force)

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -414,11 +414,11 @@ def _update_resolution_user(
 def get_orphaned_resolution_job_identifiers_endpoint(
     user: Optional[User],
 ) -> flask.Response:
-    run_ids = get_resolutions_with_orphaned_jobs()
+    resolution_ids = get_resolutions_with_orphaned_jobs()
 
     return flask.jsonify(
         dict(
-            content=run_ids,
+            content=resolution_ids,
         )
     )
 

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -34,6 +34,7 @@ from sematic.db.queries import (
     get_graph,
     get_jobs_by_run_id,
     get_resolution,
+    get_resolutions_with_orphaned_jobs,
     get_resources_by_root_id,
     get_run,
     get_run_graph,
@@ -43,7 +44,7 @@ from sematic.db.queries import (
 )
 from sematic.plugins.abstract_publisher import get_publishing_plugins
 from sematic.scheduling.job_details import JobKind
-from sematic.scheduling.job_scheduler import schedule_resolution
+from sematic.scheduling.job_scheduler import clean_jobs, schedule_resolution
 from sematic.scheduling.kubernetes import cancel_job
 
 logger = logging.getLogger(__name__)
@@ -406,3 +407,28 @@ def _update_resolution_user(
     resolution.settings_env_vars[var_key] = user.api_key
 
     return resolution, True
+
+
+@sematic_api.route("/api/v1/resolutions/with_orphaned_jobs", methods=["GET"])
+@authenticate
+def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Response:
+    run_ids = get_resolutions_with_orphaned_jobs()
+
+    return flask.jsonify(
+        dict(
+            content=run_ids,
+        )
+    )
+
+
+@sematic_api.route("/api/v1/resolutions/<root_id>/clean_jobs", methods=["POST"])
+@authenticate
+def clean_orphaned_jobs_endpoint(user: Optional[User], root_id: str) -> flask.Response:
+    force = flask.request.args.get("force", "false").lower() == "true"
+    jobs = get_jobs_by_run_id(root_id, kind=JobKind.resolver)
+    state_changes = clean_jobs(jobs, force)
+    return flask.jsonify(
+        dict(
+            content=[change.value for change in state_changes],
+        )
+    )

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -37,6 +37,7 @@ from sematic.db.queries import (
     get_basic_pipeline_metrics,
     get_external_resources_by_run_id,
     get_jobs_by_run_id,
+    get_orphaned_run_jobs,
     get_resolution,
     get_root_graph,
     get_run,
@@ -48,7 +49,7 @@ from sematic.db.queries import (
     save_run_external_resource_links,
 )
 from sematic.log_reader import load_log_lines
-from sematic.scheduling.job_scheduler import schedule_run, update_run_status
+from sematic.scheduling.job_scheduler import clean_jobs, schedule_run, update_run_status
 from sematic.scheduling.kubernetes import cancel_job
 from sematic.utils.exceptions import IllegalStateTransitionError
 from sematic.utils.retry import retry
@@ -565,7 +566,16 @@ def get_run_jobs(user: Optional[User], run_id: str) -> flask.Response:
     )
 
 
-@sematic_api.route("/api/v1/runs/all/jobs/clean_orphaned", methods=["POST"])
+@sematic_api.route("/api/v1/runs/orphaned_jobs", methods=["DELETE"])
 @authenticate
 def clean_orphaned_jobs_endpoint(user: Optional[User]) -> flask.Response:
-    pass
+    force = flask.request.args.get("force", "false").lower() == "true"
+    jobs = get_orphaned_run_jobs()
+    state_changes = clean_jobs(jobs, force)
+    for run_id in state_changes.impacted_runs:
+        broadcast_job_update(run_id, user)
+    return flask.jsonify(
+        dict(
+            content=asdict(state_changes),
+        )
+    )

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -563,3 +563,9 @@ def get_run_jobs(user: Optional[User], run_id: str) -> flask.Response:
             content=jobs,
         )
     )
+
+
+@sematic_api.route("/api/v1/runs/all/jobs/clean_orphaned", methods=["POST"])
+@authenticate
+def clean_orphaned_jobs_endpoint(user: Optional[User]) -> flask.Response:
+    pass

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -581,6 +581,13 @@ def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Respons
 @sematic_api.route("/api/v1/runs/<run_id>/clean_jobs", methods=["POST"])
 @authenticate
 def clean_orphaned_jobs_endpoint(user: Optional[User], run_id: str) -> flask.Response:
+    run = get_run(run_id)
+    if not FutureState[run.future_state].is_terminal():  # type: ignore
+        message = (
+            f"Can't clean jobs of run {run_id} "
+            f"in non-terminal state {run.future_state}."
+        )
+        return jsonify_error(message, HTTPStatus.BAD_REQUEST)
     force = flask.request.args.get("force", "false").lower() == "true"
     jobs = get_jobs_by_run_id(run_id)
     state_changes = clean_jobs(jobs, force)

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -37,12 +37,12 @@ from sematic.db.queries import (
     get_basic_pipeline_metrics,
     get_external_resources_by_run_id,
     get_jobs_by_run_id,
-    get_orphaned_run_jobs,
     get_resolution,
     get_root_graph,
     get_run,
     get_run_graph,
     get_run_status_details,
+    get_runs_with_orphaned_jobs,
     save_graph,
     save_job,
     save_run,
@@ -566,16 +566,27 @@ def get_run_jobs(user: Optional[User], run_id: str) -> flask.Response:
     )
 
 
-@sematic_api.route("/api/v1/runs/orphaned_jobs", methods=["DELETE"])
+@sematic_api.route("/api/v1/runs/with_orphaned_jobs", methods=["GET"])
 @authenticate
-def clean_orphaned_jobs_endpoint(user: Optional[User]) -> flask.Response:
-    force = flask.request.args.get("force", "false").lower() == "true"
-    jobs = get_orphaned_run_jobs()
-    state_changes = clean_jobs(jobs, force)
-    for run_id in state_changes.impacted_runs:
-        broadcast_job_update(run_id, user)
+def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Response:
+    run_ids = get_runs_with_orphaned_jobs()
+
     return flask.jsonify(
         dict(
-            content=asdict(state_changes),
+            content=run_ids,
+        )
+    )
+
+
+@sematic_api.route("/api/v1/runs/<run_id>/clean_jobs", methods=["POST"])
+@authenticate
+def clean_orphaned_jobs_endpoint(user: Optional[User], run_id: str) -> flask.Response:
+    force = flask.request.args.get("force", "false").lower() == "true"
+    jobs = get_jobs_by_run_id(run_id)
+    state_changes = clean_jobs(jobs, force)
+    broadcast_job_update(run_id, user)
+    return flask.jsonify(
+        dict(
+            content=[change.value for change in state_changes],
         )
     )

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -423,13 +423,13 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
 
 @retry(tries=3, delay=5, jitter=1)
 def get_runs_with_orphaned_jobs() -> List[str]:
-    response = _get("/api/v1/runs/with_orphaned_jobs")
+    response = _get("/runs/with_orphaned_jobs")
     return response["content"]
 
 
 @retry(tries=3, delay=5, jitter=1)
 def clean_orphaned_jobs_for_run(run_id: str, force: bool) -> List[str]:
-    response = _post(f"/api/v1/runs/{run_id}/clean_jobs?force={force}")
+    response = _post(f"/runs/{run_id}/clean_jobs?force={force}")
     return response["content"]
 
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -433,6 +433,18 @@ def clean_orphaned_jobs_for_run(run_id: str, force: bool) -> List[str]:
     return response["content"]
 
 
+@retry(tries=3, delay=5, jitter=1)
+def get_resolutions_with_orphaned_jobs() -> List[str]:
+    response = _get("/resolutions/with_orphaned_jobs")
+    return response["content"]
+
+
+@retry(tries=3, delay=5, jitter=1)
+def clean_orphaned_jobs_for_resolution(root_run_id: str, force: bool) -> List[str]:
+    response = _post(f"/resolutions/{root_run_id}/clean_jobs?force={force}")
+    return response["content"]
+
+
 @retry(tries=3, delay=10, jitter=1)
 def update_run_future_states(run_ids: List[str]) -> Dict[str, FutureState]:
     """Ask the server to update the status of given run ids if needed and return them.

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -421,17 +421,15 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
     ]
 
 
-@retry(tries=3, delay=5, jitter=1)
 def get_runs_with_orphaned_jobs() -> List[str]:
     """Get ids of runs that have terminated, which still have non-terminal jobs."""
     response = _get("/runs/with_orphaned_jobs")
     return response["content"]
 
 
-@retry(tries=3, delay=5, jitter=1)
 def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:
     """Clean up the jobs for the run with the given id."""
-    response = _post(f"/runs/{run_id}/clean_jobs?force={force}")
+    response = _post(f"/runs/{run_id}/clean_jobs?force={force}", retry=True)
     return response["content"]
 
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -423,24 +423,28 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
 
 @retry(tries=3, delay=5, jitter=1)
 def get_runs_with_orphaned_jobs() -> List[str]:
+    """Get ids of runs that have terminated, which still have non-terminal jobs."""
     response = _get("/runs/with_orphaned_jobs")
     return response["content"]
 
 
 @retry(tries=3, delay=5, jitter=1)
-def clean_orphaned_jobs_for_run(run_id: str, force: bool) -> List[str]:
+def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:
+    """Clean up the jobs for the run with the given id."""
     response = _post(f"/runs/{run_id}/clean_jobs?force={force}")
     return response["content"]
 
 
 @retry(tries=3, delay=5, jitter=1)
 def get_resolutions_with_orphaned_jobs() -> List[str]:
+    """Get ids of resolutions that have terminated which still have non-terminal jobs."""
     response = _get("/resolutions/with_orphaned_jobs")
     return response["content"]
 
 
 @retry(tries=3, delay=5, jitter=1)
 def clean_orphaned_jobs_for_resolution(root_run_id: str, force: bool) -> List[str]:
+    """Clean up the jobs for the resolution with the given id."""
     response = _post(f"/resolutions/{root_run_id}/clean_jobs?force={force}")
     return response["content"]
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -435,17 +435,18 @@ def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:
     return response["content"]
 
 
-@retry(tries=3, delay=5, jitter=1)
 def get_resolutions_with_orphaned_jobs() -> List[str]:
     """Get ids of resolutions that have terminated which still have non-terminal jobs."""
     response = _get("/resolutions/with_orphaned_jobs")
     return response["content"]
 
 
-@retry(tries=3, delay=5, jitter=1)
 def clean_orphaned_jobs_for_resolution(root_run_id: str, force: bool) -> List[str]:
     """Clean up the jobs for the resolution with the given id."""
-    response = _post(f"/resolutions/{root_run_id}/clean_jobs?force={force}")
+    response = _post(f"/resolutions/{root_run_id}/clean_jobs?force={force}", retry=True)
+    return response["content"]
+
+
 def get_orphaned_resource_ids() -> List[str]:
     """Get the ids of resources whose resolutions are no longer active."""
     response = _get("/external_resources/orphaned")

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -421,6 +421,18 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
     ]
 
 
+@retry(tries=3, delay=5, jitter=1)
+def get_runs_with_orphaned_jobs() -> List[str]:
+    response = _get("/api/v1/runs/with_orphaned_jobs")
+    return response["content"]
+
+
+@retry(tries=3, delay=5, jitter=1)
+def clean_orphaned_jobs_for_run(run_id: str, force: bool) -> List[str]:
+    response = _post(f"/api/v1/runs/{run_id}/clean_jobs?force={force}")
+    return response["content"]
+
+
 @retry(tries=3, delay=10, jitter=1)
 def update_run_future_states(run_ids: List[str]) -> Dict[str, FutureState]:
     """Ask the server to update the status of given run ids if needed and return them.

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -19,7 +19,7 @@ import dataclasses
 import json
 import logging
 from enum import Enum, unique
-from typing import Dict, Optional, Union
+from typing import Dict, FrozenSet, Optional, Union
 
 # Third-party
 from sqlalchemy import Column, types
@@ -100,6 +100,10 @@ class ResolutionStatus(Enum):
     def is_terminal(self) -> bool:
         return len(_ALLOWED_TRANSITIONS[self]) == 0
 
+    @classmethod
+    def terminal_states(cls) -> FrozenSet:
+        return _TERMINAL_STATES
+
 
 _ALLOWED_TRANSITIONS = {
     # Local resolver can jump straight to RUNNING
@@ -129,6 +133,10 @@ _ALLOWED_TRANSITIONS = {
     ResolutionStatus.FAILED: {},
     ResolutionStatus.CANCELED: {},
 }
+
+_TERMINAL_STATES = frozenset(
+    {state for state in ResolutionStatus if state.is_terminal()}
+)
 
 
 class InvalidResolution(Exception):

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -139,11 +139,6 @@ _TERMINAL_STATES = frozenset(
 )
 
 
-_TERMINAL_STATES = frozenset(
-    {state for state in ResolutionStatus if state.is_terminal()}
-)
-
-
 class InvalidResolution(Exception):
     pass
 

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -308,7 +308,13 @@ def save_job(job: Job) -> Job:
 def get_runs_with_orphaned_jobs() -> List[str]:
     with db().get_session() as session:
         query_results = list(
-            session.query(Job.run_id, Job.kind, Job.state, Run.id, Run.future_state)
+            session.query(
+                Job.run_id,
+                sqlalchemy.func.max(Job.kind),
+                sqlalchemy.func.max(Job.state),
+                sqlalchemy.func.max(Run.id),
+                sqlalchemy.func.max(Run.future_state),
+            )
             .filter(Job.run_id == Run.id)
             .filter(Job.kind == JobKind.run)
             .filter(
@@ -317,9 +323,10 @@ def get_runs_with_orphaned_jobs() -> List[str]:
                 )
             )
             .filter(Job.state.not_in(KubernetesJobState.terminal_states()))
+            .group_by(Job.run_id)
             .all()
         )
-        run_ids = set()
+        run_ids = []
         for _, __, job_state, run_id, future_state in query_results:
             logger.info(
                 "Run %s in state %s has orphaned job in state %s",
@@ -327,7 +334,7 @@ def get_runs_with_orphaned_jobs() -> List[str]:
                 future_state,
                 job_state,
             )
-            run_ids.add(run_id)
+            run_ids.append(run_id)
     return list(run_ids)
 
 

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -25,7 +25,7 @@ from sematic.db.models.run import Run
 from sematic.db.models.runs_external_resource import RunExternalResource
 from sematic.db.models.user import User
 from sematic.plugins.abstract_external_resource import ResourceState
-from sematic.scheduling.job_details import JobKind, JobKindString
+from sematic.scheduling.job_details import JobKind, JobKindString, KubernetesJobState
 from sematic.utils.exceptions import IllegalStateTransitionError
 
 logger = logging.getLogger(__name__)
@@ -303,6 +303,32 @@ def save_job(job: Job) -> Job:
         session.commit()
 
         return job
+
+
+def get_orphaned_run_jobs() -> List[Job]:
+    with db().get_session() as session:
+        query_results = list(
+            session.query(Job, Run.id, Run.future_state)
+            .filter(Job.run_id == Run.id)
+            .filter(Job.kind == JobKind.run)
+            .filter(
+                Run.future_state.in_(
+                    [state.value for state in FutureState.terminal_states()]
+                )
+            )
+            .filter(Job.state.not_in(KubernetesJobState.terminal_states()))
+            .all()
+        )
+        jobs = []
+        for job, run_id, future_state in query_results:
+            logger.info(
+                "Job %s for run %s in state %s is orphaned",
+                job.identifier(),
+                run_id,
+                future_state,
+            )
+            jobs.append(job)
+    return jobs
 
 
 def get_jobs_by_run_id(run_id: str, kind: JobKindString = JobKind.run) -> List[Job]:

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -305,10 +305,10 @@ def save_job(job: Job) -> Job:
         return job
 
 
-def get_orphaned_run_jobs() -> List[Job]:
+def get_runs_with_orphaned_jobs() -> List[str]:
     with db().get_session() as session:
         query_results = list(
-            session.query(Job, Run.id, Run.future_state)
+            session.query(Job.run_id, Job.kind, Job.state, Run.id, Run.future_state)
             .filter(Job.run_id == Run.id)
             .filter(Job.kind == JobKind.run)
             .filter(
@@ -319,22 +319,24 @@ def get_orphaned_run_jobs() -> List[Job]:
             .filter(Job.state.not_in(KubernetesJobState.terminal_states()))
             .all()
         )
-        jobs = []
-        for job, run_id, future_state in query_results:
+        run_ids = set()
+        for _, __, job_state, run_id, future_state in query_results:
             logger.info(
-                "Job %s for run %s in state %s is orphaned",
-                job.identifier(),
+                "Run %s in state %s has orphaned job in state %s",
                 run_id,
                 future_state,
+                job_state,
             )
-            jobs.append(job)
-    return jobs
+            run_ids.add(run_id)
+    return list(run_ids)
 
 
-def get_orphaned_resolver_jobs() -> List[Job]:
+def get_resolutions_with_orphaned_jobs() -> List[str]:
     with db().get_session() as session:
         query_results = list(
-            session.query(Job, Resolution.root_id, Resolution.status)
+            session.query(
+                Job.run_id, Job.kind, Job.state, Resolution.root_id, Resolution.status
+            )
             .filter(Job.run_id == Resolution.root_id)
             .filter(Job.kind == JobKind.resolver)
             .filter(
@@ -345,16 +347,16 @@ def get_orphaned_resolver_jobs() -> List[Job]:
             .filter(Job.state.not_in(KubernetesJobState.terminal_states()))
             .all()
         )
-        jobs = []
-        for job, root_id, status in query_results:
+        resolution_ids = []
+        for _, __, job_state, root_id, status in query_results:
             logger.info(
-                "Job %s for resolution %s in state %s is orphaned",
-                job.identifier(),
+                "Resolution %s in state %s has orphaned job in state %s",
                 root_id,
                 status,
+                job_state,
             )
-            jobs.append(job)
-    return jobs
+            resolution_ids.append(root_id)
+    return resolution_ids
 
 
 def get_jobs_by_run_id(run_id: str, kind: JobKindString = JobKind.run) -> List[Job]:

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -20,7 +20,7 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.external_resource import ExternalResource
 from sematic.db.models.job import Job
 from sematic.db.models.note import Note
-from sematic.db.models.resolution import Resolution
+from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.models.runs_external_resource import RunExternalResource
 from sematic.db.models.user import User
@@ -326,6 +326,32 @@ def get_orphaned_run_jobs() -> List[Job]:
                 job.identifier(),
                 run_id,
                 future_state,
+            )
+            jobs.append(job)
+    return jobs
+
+
+def get_orphaned_resolver_jobs() -> List[Job]:
+    with db().get_session() as session:
+        query_results = list(
+            session.query(Job, Resolution.root_id, Resolution.status)
+            .filter(Job.run_id == Resolution.root_id)
+            .filter(Job.kind == JobKind.resolver)
+            .filter(
+                Resolution.status.in_(
+                    [status.value for status in ResolutionStatus.terminal_states()]
+                )
+            )
+            .filter(Job.state.not_in(KubernetesJobState.terminal_states()))
+            .all()
+        )
+        jobs = []
+        for job, root_id, status in query_results:
+            logger.info(
+                "Job %s for resolution %s in state %s is orphaned",
+                job.identifier(),
+                root_id,
+                status,
             )
             jobs.append(job)
     return jobs

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -28,10 +28,12 @@ from sematic.db.queries import (
     get_job,
     get_jobs_by_run_id,
     get_resolution,
+    get_resolutions_with_orphaned_jobs,
     get_resources_by_root_id,
     get_root_graph,
     get_run,
     get_run_graph,
+    get_runs_with_orphaned_jobs,
     save_external_resource_record,
     save_graph,
     save_job,
@@ -42,6 +44,7 @@ from sematic.db.queries import (
 from sematic.db.tests.fixtures import make_job  # noqa: F811
 from sematic.db.tests.fixtures import (  # noqa: F401
     allow_any_run_state_transition,
+    make_resolution,
     make_run,
     persisted_artifact,
     persisted_resolution,
@@ -55,7 +58,12 @@ from sematic.plugins.abstract_external_resource import (
     ManagedBy,
     ResourceState,
 )
-from sematic.scheduling.job_details import JobDetails, JobStatus, KubernetesJobState
+from sematic.scheduling.job_details import (
+    JobDetails,
+    JobKind,
+    JobStatus,
+    KubernetesJobState,
+)
 from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
 from sematic.utils.exceptions import IllegalStateTransitionError
 
@@ -433,3 +441,80 @@ def test_save_read_jobs(test_db):  # noqa: F811
         match=(r"Tried to update status from .* to .*, " r"but the latter was older"),
     ):
         save_job(retry_job_from_scratch)
+
+
+def test_get_runs_with_orphaned_jobs(test_db):  # noqa: F811
+    root_run = make_run()
+    child_run_1 = make_run(root_id=root_run.id)
+    child_run_2 = make_run(root_id=root_run.id)
+    for r in [root_run, child_run_1, child_run_2]:
+        save_run(r)
+
+    created_status = JobStatus(
+        state=KubernetesJobState.Requested,
+        message="Just created",
+        last_updated_epoch_seconds=time.time(),
+    )
+
+    details_1 = JobDetails(try_number=0)
+    job_1 = make_job(
+        details=details_1, name="job_1", status=created_status, run_id=child_run_1.id
+    )
+    save_job(job_1)
+
+    details_2 = JobDetails(try_number=0)
+    job_2 = make_job(
+        details=details_2, name="job_2", status=created_status, run_id=child_run_2.id
+    )
+    save_job(job_2)
+
+    child_run_2.future_state = FutureState.SCHEDULED
+    save_run(child_run_2)
+    child_run_2.future_state = FutureState.RESOLVED
+    save_run(child_run_2)
+
+    run_ids = get_runs_with_orphaned_jobs()
+    assert run_ids == [child_run_2.id]
+
+
+def test_get_resolutions_with_orphaned_jobs(test_db):  # noqa: F811
+    root_run_1 = make_run()
+    root_run_2 = make_run()
+    save_run(root_run_1)
+    save_run(root_run_2)
+
+    resolution_1 = make_resolution(root_id=root_run_1.id)
+    resolution_2 = make_resolution(
+        root_id=root_run_2.id, status=ResolutionStatus.FAILED
+    )
+    save_resolution(resolution_1)
+    save_resolution(resolution_2)
+
+    created_status = JobStatus(
+        state=KubernetesJobState.Requested,
+        message="Just created",
+        last_updated_epoch_seconds=time.time(),
+    )
+
+    details_1 = JobDetails(try_number=0)
+    job_1 = make_job(
+        details=details_1,
+        name="job_1",
+        status=created_status,
+        run_id=resolution_1.root_id,
+        kind=JobKind.resolver,
+    )
+    save_job(job_1)
+
+    details_2 = JobDetails(try_number=0)
+    job_2 = make_job(
+        details=details_2,
+        name="job_2",
+        status=created_status,
+        run_id=resolution_2.root_id,
+        kind=JobKind.resolver,
+    )
+    save_job(job_2)
+
+    resolution_ids = get_resolutions_with_orphaned_jobs()
+    assert resolution_ids == [resolution_2.root_id]

--- a/sematic/scheduling/BUILD
+++ b/sematic/scheduling/BUILD
@@ -15,6 +15,7 @@ sematic_py_lib(
         "//sematic/db/models:job",
         "//sematic/db/models:resolution",
         "//sematic/db/models:run",
+        "//sematic/db:queries",
         "//sematic/scheduling:kubernetes",
     ],
 )

--- a/sematic/scheduling/BUILD
+++ b/sematic/scheduling/BUILD
@@ -16,6 +16,7 @@ sematic_py_lib(
         "//sematic/db/models:resolution",
         "//sematic/db/models:run",
         "//sematic/db:queries",
+        "//sematic/scheduling:job_details",
         "//sematic/scheduling:kubernetes",
     ],
 )

--- a/sematic/scheduling/job_details.py
+++ b/sematic/scheduling/job_details.py
@@ -274,6 +274,9 @@ class JobDetails:
     # Used to detect when K8s replaces the job's pod.
     previous_node_name: Optional[str] = None
 
+    # Indicates whether the job has been canceled by Sematic.
+    canceled: bool = False
+
     def latest_pod_summary(self) -> Optional[PodSummary]:
         if len(self.current_pods) == 0:
             return None
@@ -359,7 +362,7 @@ class JobDetails:
         most_recent_condition = (
             latest_summary.condition if latest_summary is not None else None
         )
-        if not self.has_started:
+        if not (self.has_started or self.canceled):
             description = "The job has been requested, but no pods are created yet."
             if self.try_number != 0:
                 description += (
@@ -371,7 +374,7 @@ class JobDetails:
                 message=description,
                 last_updated_epoch_seconds=last_updated_epoch_seconds,
             )
-        elif not self.still_exists:
+        elif self.canceled or not self.still_exists:
             return JobStatus(
                 state=KubernetesJobState.Deleted,
                 message="The job no longer exists",

--- a/sematic/scheduling/job_details.py
+++ b/sematic/scheduling/job_details.py
@@ -3,7 +3,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum, unique
-from typing import List, Literal, Optional
+from typing import FrozenSet, List, Literal, Optional
 
 # Sematic
 from sematic.utils.exceptions import ExceptionMetadata, KubernetesError
@@ -81,6 +81,10 @@ class KubernetesJobState:
     @classmethod
     def is_active(cls, state) -> bool:
         return state in _ACTIVE_STATES
+
+    @classmethod
+    def terminal_states(cls) -> FrozenSet["KubernetesJobStateString"]:
+        return frozenset({cls.Deleted})
 
 
 _ACTIVE_STATES = {

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -10,6 +10,7 @@ from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.queries import save_job
 from sematic.scheduling import kubernetes as k8s
+from sematic.scheduling.job_details import KubernetesJobState
 from sematic.versions import MIN_CLIENT_SERVER_SUPPORTS, string_version_to_tuple
 
 logger = logging.getLogger(__name__)
@@ -281,6 +282,7 @@ def _schedule_resolution_job(
 @unique
 class JobCleaningStateChange(Enum):
     DELETED = "DELETED"
+    UNMODIFIED = "UNMODIFIED"
     DELETION_ERROR = "DELETION_ERROR"
     FORCE_DELETED = "FORCE_DELETED"
 
@@ -288,6 +290,9 @@ class JobCleaningStateChange(Enum):
 def clean_jobs(jobs: List[Job], force: bool) -> List[JobCleaningStateChange]:
     changes = []
     for job in jobs:
+        if job.state in KubernetesJobState.terminal_states():
+            changes.append(JobCleaningStateChange.UNMODIFIED)
+            continue
         try:
             logger.info("Cleaning job %s", job.identifier())
             canceled_job = k8s.cancel_job(job)

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -1,5 +1,6 @@
 # Standard Library
 import logging
+from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 # Sematic
@@ -7,6 +8,7 @@ from sematic.abstract_future import FutureState
 from sematic.db.models.job import Job
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
+from sematic.db.queries import save_job
 from sematic.scheduling import kubernetes as k8s
 from sematic.versions import MIN_CLIENT_SERVER_SUPPORTS, string_version_to_tuple
 
@@ -274,3 +276,43 @@ def _schedule_resolution_job(
         max_parallelism=max_parallelism,
         rerun_from=rerun_from,
     )
+
+
+@dataclass
+class JobCleaningStateChanges:
+    deleted: List[str] = field(default_factory=list)
+    deletion_error: List[str] = field(default_factory=list)
+    force_deleted: List[str] = field(default_factory=list)
+    impacted_runs: List[str] = field(default_factory=list)
+
+
+def clean_jobs(jobs: List[Job], force: bool) -> JobCleaningStateChanges:
+    state_changes = JobCleaningStateChanges()
+
+    # track in a dict to avoid duplication for jobs that are part of the
+    # same run (ex: retries). Why not a set? We want to preserve order
+    # for determinism. Will convert to a list at the end.
+    impacted_runs = {}
+    for job in jobs:
+        impacted_runs[job.run_id] = True
+        try:
+            logger.info("Cleaning orphaned job %s", job.identifier())
+            canceled_job = k8s.cancel_job(job)
+            save_job(canceled_job)
+            state_changes.deleted.append(job.identifier())
+        except Exception:
+            logger.exception("Error cleaning orphaned job %s", job.identifier())
+            state_changes.deletion_error.append(job.identifier())
+            if force:
+                try:
+                    logger.info("Force cleaning job %s", job.identifier())
+                    details = job.details
+                    details = details.force_clean()
+                    job.details = details
+                    save_job(job)
+                    state_changes.force_deleted.append(job.identifier())
+                except Exception:
+                    logger.exception("Could not force-delete job %s", job.identifier())
+
+    state_changes.impacted_runs = list(impacted_runs.keys())
+    return state_changes

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -292,6 +292,7 @@ def clean_jobs(jobs: List[Job], force: bool) -> List[JobCleaningStateChange]:
     for job in jobs:
         if job.state in KubernetesJobState.terminal_states():
             changes.append(JobCleaningStateChange.UNMODIFIED)
+            logger.info("Leaving job %s unmodified", job.identifier())
             continue
         try:
             logger.info("Cleaning job %s", job.identifier())

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -1,6 +1,6 @@
 # Standard Library
 import logging
-from dataclasses import dataclass, field
+from enum import Enum, unique
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 # Sematic
@@ -278,31 +278,23 @@ def _schedule_resolution_job(
     )
 
 
-@dataclass
-class JobCleaningStateChanges:
-    deleted: List[str] = field(default_factory=list)
-    deletion_error: List[str] = field(default_factory=list)
-    force_deleted: List[str] = field(default_factory=list)
-    impacted_runs: List[str] = field(default_factory=list)
+@unique
+class JobCleaningStateChange(Enum):
+    DELETED = "DELETED"
+    DELETION_ERROR = "DELETION_ERROR"
+    FORCE_DELETED = "FORCE_DELETED"
 
 
-def clean_jobs(jobs: List[Job], force: bool) -> JobCleaningStateChanges:
-    state_changes = JobCleaningStateChanges()
-
-    # track in a dict to avoid duplication for jobs that are part of the
-    # same run (ex: retries). Why not a set? We want to preserve order
-    # for determinism. Will convert to a list at the end.
-    impacted_runs = {}
+def clean_jobs(jobs: List[Job], force: bool) -> List[JobCleaningStateChange]:
+    changes = []
     for job in jobs:
-        impacted_runs[job.run_id] = True
         try:
-            logger.info("Cleaning orphaned job %s", job.identifier())
+            logger.info("Cleaning job %s", job.identifier())
             canceled_job = k8s.cancel_job(job)
             save_job(canceled_job)
-            state_changes.deleted.append(job.identifier())
+            changes.append(JobCleaningStateChange.DELETED)
         except Exception:
-            logger.exception("Error cleaning orphaned job %s", job.identifier())
-            state_changes.deletion_error.append(job.identifier())
+            logger.exception("Error cleaning job %s", job.identifier())
             if force:
                 try:
                     logger.info("Force cleaning job %s", job.identifier())
@@ -310,9 +302,11 @@ def clean_jobs(jobs: List[Job], force: bool) -> JobCleaningStateChanges:
                     details = details.force_clean()
                     job.details = details
                     save_job(job)
-                    state_changes.force_deleted.append(job.identifier())
+                    changes.append(JobCleaningStateChange.FORCE_DELETED)
                 except Exception:
                     logger.exception("Could not force-delete job %s", job.identifier())
+                    changes.append(JobCleaningStateChange.DELETION_ERROR)
+            else:
+                changes.append(JobCleaningStateChange.DELETION_ERROR)
 
-    state_changes.impacted_runs = list(impacted_runs.keys())
-    return state_changes
+    return changes

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -190,6 +190,8 @@ def cancel_job(job: Job) -> Job:
         raise ValueError(f"Expected a {Job.__name__}, got a {type(job).__name__}")
     details = job.details
     if not details.still_exists:
+        details.canceled = True
+        job.update_status(details.get_status(time.time()))
         logger.info(
             "No need to cancel Kubernetes job %s, as it no longer exists",
             job.identifier(),
@@ -209,6 +211,7 @@ def cancel_job(job: Job) -> Job:
             pass
 
     details.still_exists = False
+    details.canceled = True
     job.details = details
 
     return job


### PR DESCRIPTION
Add APIs to clean up jobs that are still around/whose metadata claims they are after their run/resolution has terminated.

Testing
-------
In addition to unit tests, also used this API via the API client on the Sematic deployment in the `josh` namespace.