### PR TITLE
Support uninitialized Git repo rendering

### DIFF
--- a/sematic/db/models/git_info.py
+++ b/sematic/db/models/git_info.py
@@ -1,6 +1,5 @@
 # Standard Library
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -9,7 +8,7 @@ class GitInfo:
     Information about a git workspace.
     """
 
-    remote: Optional[str]
-    branch: Optional[str]
-    commit: Optional[str]
-    dirty: Optional[bool]
+    remote: str
+    branch: str
+    commit: str
+    dirty: bool

--- a/sematic/ui/packages/main/src/components/GitInfo.tsx
+++ b/sematic/ui/packages/main/src/components/GitInfo.tsx
@@ -68,7 +68,11 @@ function GitInfoBox(props: { resolution: Resolution | undefined }) {
   const { resolution } = props;
   const theme = useTheme();
 
-  if (!resolution || !resolution.git_info_json) {
+  if (
+    !resolution
+    || !resolution.git_info_json
+    || !resolution.git_info_json.commit
+  ) {
     return (
       <Typography
         color="GrayText"

--- a/sematic/ui/packages/main/src/components/GitInfo.tsx
+++ b/sematic/ui/packages/main/src/components/GitInfo.tsx
@@ -68,11 +68,7 @@ function GitInfoBox(props: { resolution: Resolution | undefined }) {
   const { resolution } = props;
   const theme = useTheme();
 
-  if (
-    !resolution
-    || !resolution.git_info_json
-    || !resolution.git_info_json.commit
-  ) {
+  if (!resolution || !resolution.git_info_json) {
     return (
       <Typography
         color="GrayText"

--- a/sematic/utils/git.py
+++ b/sematic/utils/git.py
@@ -71,12 +71,18 @@ def get_git_info(object_: Any) -> Optional[GitInfo]:
         logger.debug(f"Found bare git repo in '{repo.git_dir}'")
         return None
 
-    return GitInfo(
-        remote=_get_remote(repo),
-        branch=_get_branch(repo),
-        commit=_get_commit(repo),
-        dirty=repo.is_dirty(),
-    )
+    remote = _get_remote(repo)
+    if remote is None:
+        return None
+
+    commit = _get_commit(repo)
+    if commit is None:
+        return None
+
+    branch = _get_branch(repo)
+    dirty = repo.is_dirty()
+
+    return GitInfo(remote=remote, branch=branch, commit=commit, dirty=dirty)
 
 
 def _get_repo(git: Any, source: Any) -> Optional["Repo"]:  # type: ignore # noqa: F821
@@ -113,7 +119,7 @@ def _get_commit(repo: "Repo") -> Optional[str]:  # type: ignore # noqa: F821
         return None
 
 
-def _get_branch(repo: "Repo") -> Optional[str]:  # type: ignore # noqa: F821
+def _get_branch(repo: "Repo") -> str:  # type: ignore # noqa: F821
     try:
         return repo.active_branch.name
     except Exception:


### PR DESCRIPTION
When submitting a pipeline from an uninitialized Git repo, information about the repo may be successfully collected, even though the first commit does not exist. This will produce a rendering error:

![image](https://user-images.githubusercontent.com/1894533/233201017-232af8cd-a91b-40ed-82d0-7a2b598d0d18.png)

By requiring a commit to exist for the purposes of rendering the Git information, the issue is fixed:

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/1894533/233201185-fa1f896c-adec-4bce-aaef-79caf8c29982.png">
