### PR TITLE
Migrating `inline=False` to `standalone=True`

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,6 +30,7 @@
 ## Public API reference
 
 * [API reference](api.md)
+* [Errors](errors.md)
 
 ## Type support
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,14 +14,14 @@ in the Sematic UI.
     
     The `Callable` to instrument; usually the decorated function.
 
-- `inline`: bool
+- `standalone`: bool
     
-    When using the `CloudResolver`, whether the instrumented function
-    should be executed inside the same process and worker that is executing
-    the `Resolver` itself.
+    When using the `CloudResolver`, whether the instrumented function should be
+    executed inside its own container job (`True`) or in the same process and
+    worker that is executing the `Resolver` itself (`False`).
 
-    Defaults to `True`, as most pipeline functions are expected to be
-    lightweight. Explicitly set this to `False` in order to distribute its
+    Defaults to `False`, as most pipeline functions are expected to be
+    lightweight. Set this to `True` in order to distribute its
     execution to a worker and parallelize its execution.
 
 - `cache`: bool
@@ -117,9 +117,10 @@ Resolves a pipeline on a Kubernetes cluster.
 
 - `max_parallelism`: Optional[int]
 
-    The maximum number of non-inlined runs that this resolver will allow to be in the
-    `SCHEDULED` state at any one time. Must be a positive integer, or `None` for
-    unlimited runs. Defaults to `None`.
+    The maximum number of [Standalone
+    Runs](./glossary.md#standalone-inline-function) that this resolver will
+    allow to be in the `SCHEDULED` state at any one time. Must be a positive
+    integer, or `None` for unlimited runs. Defaults to `None`.
 
     This is intended as a simple mechanism to limit the amount of computing resources
     consumed by one pipeline execution for pipelines with a high degree of

--- a/docs/cloud-resolver.md
+++ b/docs/cloud-resolver.md
@@ -45,25 +45,28 @@ can be overridden by environment variables.
 
 Sematic will run two types of pods for each pipeline:
 
-* **Driver pod** – this is where the graph of your pipeline gets processed,
-  and where the `Resolver` and `inline=True` pipeline steps run. This pod
-  has the word "driver" in its name.
-* **Worker pods** – this is where individual pipeline steps will be run if they
-  are marked as `inline=False`. These pods have the work "worker" in their name.
+* **Driver pod** – this is where the graph of your pipeline gets processed, and
+  where the `Resolver` and [Inline
+  Functions](./glossary.md#standalone-inline-function) run. This pod has the
+  word "driver" in its name.
+* **Worker pods** – this is where [Standalone Functions](./glossary.md#standalone-inline-function)
+  (`@sematic.func(standalone=True`). These pods have the work "worker" in their
+  name.
 
-By default, the resolution of the graph and all pipeline steps will run in a
-single pod, the resolver pod. This is fine for minor pipeline steps that take up
-little time and resources. Some pipeline steps may require specific resources
-(e.g. GPUs) and need to run in their own isolated containers. This can be
-achieved as follows:
+By default, the execution of the graph and all [Sematic
+Functions](./glossary.md#sematic-function) will run in a single pod, the
+resolver pod. This is fine for minor pipeline steps that take up little time and
+resources. Some Functions may require specific resources (e.g. GPUs) and
+need to run in their own standalone containers. This can be achieved as follows:
 
 ```python
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def train_model(...):
     ...
 ```
 
-`inline=False` functions will be executed asynchronously as separate Kubernetes pods.
+[Standalone Functions](./glossary.md#standalone-inline-function) will be
+executed asynchronously as separate Kubernetes pods.
 
 ### Customize resource requirements
 
@@ -95,7 +98,7 @@ GPU_RESOURCE_REQS = ResourceRequirements(
     )
 )
 
-@sematic.func(resource_requirements=GPU_RESOURCE_REQS)
+@sematic.func(standalone=True, resource_requirements=GPU_RESOURCE_REQS)
 def train_model(...):
     ...
 ```
@@ -103,42 +106,37 @@ def train_model(...):
 If there is a corresponding node available in your Kubernetes cluster, this
 function will be executed on that node.
 
-Note that `inline=False` is necessary for these resource requirements to be
+Note that `standalone=True` is necessary for these resource requirements to be
 honored, otherwise, they will be ignored.
 
-### Understanding "Inline"
+### Understanding Inline and Standalone Functions
 
-Before understanding inline functions, it is first helpful to refresh yourself
-on the description of the "driver" job above. Note that this job is distinct
-from the container where the root run executes - it's best to think of the
-driver as an "extra" container for the overall pipeline.
-
-Given this understanding of the driver job, the behavior of inline executions
-can be summarized as follows. Every Sematic func executes in one of two places:
+Every Sematic func executes in one of two places:
 
 (1) The driver container
 (2) Its own, dedicated container
 
-The *only* determining factor in which of these two is used for a given function
-is whether or not it has `inline=True`. For functions where `inline=True`, they
-will execute in the driver container. This is best used for very lightweight
-functions that execute quickly and don't make any calls to external services. For
-functions where `inline=False`, they execute in their own containers.
+The *only* determining factor in which of these two is used for a given Function
+is whether or not it has `standalone=True`. For functions where
+`standalone=False` (the default), they will execute in the driver container.
+This is best used for very lightweight functions that execute quickly and don't
+make any calls to external services. For functions where `standalone=True`, they
+execute in their own containers.
 
-A common source of confusion with inline functions is to think there's a
+A common source of confusion with Inline Functions is to think there's a
 relationship between nested functions and inline. Consider the following code:
 
 ```python
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def calculate_average(a: float, b: float, c: float) -> float:
   total = add(a, b, c)
   average = divide(total, 3)
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add(a: float, b: float, c: float) -> float:
   return a + b + c
 
-@sematic.func(inline=True)
+@sematic.func(standalone=False)
 def divide(a: float, b: int) -> float:
   return a / b
 ```
@@ -147,15 +145,15 @@ Let's assume `calculate_average` and `add` are actually doing something
 "heavy" that requires a dedicated container, rather than just performing
 simple arithmetic operations.
 
-People sometimes assume that since `divide`
-is nested inside `calculate_average`, and `divide` is inline, `divide`
-must execute in the same container as `calculate_average`. This is NOT
-correct. This misunderstanding stems from a misunderstanding of how Sematic
-works with Futures. Recall that Sematic functions return futures when you
-call them (see [Future Algebra](future-algebra.md)). That means that `total` in `calculate_average`
-*actually holds a Future instead of a `float`*. So when `divide(total, 3)`
-is called above, the content of `total` is not even known. Therefore, how
-could it be executed?
+People sometimes assume that since `divide` is nested inside
+`calculate_average`, and `divide` is inline, `divide` must execute in the same
+container as `calculate_average`. This is NOT correct. This misunderstanding
+stems from a misunderstanding of how Sematic works with Futures. Recall that
+[Sematic Functions](./glossary.md#sematic-function) return futures when you call
+them (see [Future Algebra](future-algebra.md)). That means that `total` in
+`calculate_average` *actually holds a Future instead of a `float`*. So when
+`divide(total, 3)` is called above, the content of `total` is not even known.
+Therefore, how could it be executed?
 
 Instead, what happens is this:
 
@@ -166,27 +164,24 @@ also returns immediately without doing any work.
 4. The driver job analyzes the `Future` coming from `calculate_average` and
 sees that to get the value for it, it must first execute `add` and then
 execute `divide`.
-5. Since `add` is non-inline, the driver starts a container within which to
+5. Since `add` is standalone, the driver starts a container within which to
 execute `add`. `add` returns an actual `float` which is the sum of `a`, `b`, and
 `c`.
 6. The driver sees that it now has everything required to execute `divide`, so
 it does so. Since `divide` is inline, the driver doesn't need to start a new
 container for it, and instead it executes `divide` in its own process.
 
-#### When to use inline?
+#### When to use Standalone?
 
-After walking through the above example, you may be wondering if there's a simple
-way to know when something should be marked as inline vs not. Even if you don't
-follow the above trace of the execution, you can still use `inline` correctly if
-you follow this guidance:
-
-- Any Sematic function doing something "trivial" that executes in a few seconds or
-less and requires negligible CPU or memory should be inline.
-- Any Sematic function which primarily calls other Sematic functions and doesn't
-do any work "of its own" aside from these calls should be inline
-- Any other Sematic functions should NOT be inline. In practice this usually means
-"leaf node" Sematic functions that don't call other Sematic functions and which
-do some "real work."
+- Any [Sematic Function](./glossary.md#sematic-function) doing something
+"trivial" that executes in a few seconds or less and requires negligible CPU or
+memory should be inline.
+- Any [Sematic Functions](./glossary.md#sematic-function) which primarily calls
+other Sematic functions and doesn't do any work "of its own" aside from these
+calls should be inline
+- Any other [Sematic Functions](./glossary.md#sematic-function) should be
+standalone. In practice this usually means "leaf node" Sematic functions that
+don't call other Sematic functions and which do some "real work."
 
 Most Sematic functions tend to meet the first two criteria, so functions are inline
 by default.

--- a/docs/cloud-resolver.md
+++ b/docs/cloud-resolver.md
@@ -50,7 +50,7 @@ Sematic will run two types of pods for each pipeline:
   Functions](./glossary.md#standalone-inline-function) run. This pod has the
   word "driver" in its name.
 * **Worker pods** – this is where [Standalone Functions](./glossary.md#standalone-inline-function)
-  (`@sematic.func(standalone=True`). These pods have the work "worker" in their
+  (`@sematic.func(standalone=True`). These pods have the word "worker" in their
   name.
 
 By default, the execution of the graph and all [Sematic
@@ -171,14 +171,14 @@ execute `add`. `add` returns an actual `float` which is the sum of `a`, `b`, and
 it does so. Since `divide` is inline, the driver doesn't need to start a new
 container for it, and instead it executes `divide` in its own process.
 
-#### When to use Standalone?
+#### When to use Standalone or Inline?
 
 - Any [Sematic Function](./glossary.md#sematic-function) doing something
 "trivial" that executes in a few seconds or less and requires negligible CPU or
 memory should be inline.
 - Any [Sematic Functions](./glossary.md#sematic-function) which primarily calls
 other Sematic functions and doesn't do any work "of its own" aside from these
-calls should be inline
+calls should be inline.
 - Any other [Sematic Functions](./glossary.md#sematic-function) should be
 standalone. In practice this usually means "leaf node" Sematic functions that
 don't call other Sematic functions and which do some "real work."

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,5 +1,11 @@
 ## Inline Functions cannot have resource requirements
 
+```
+ValueError: Inline Functions cannot have resource requirements.
+Try using @sematic.func(standalone=True, ...).
+See https://go.sematic.dev/t3mynx.
+```
+
 [Inline Function](./glossary.md#standalone-inline-function)s run within the same
 process and container as the `CloudResolver` orchestrating the pipeline.
 Therefore, they cannot have custom resource requirements.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,6 +1,6 @@
 ## Inline Functions cannot have resource requirements
 
-[Inline Function](./glossary.md#standalone-inline-function) run within the same
+[Inline Function](./glossary.md#standalone-inline-function)s run within the same
 process and container as the `CloudResolver` orchestrating the pipeline.
 Therefore, they cannot have custom resource requirements.
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,20 +1,20 @@
-## Inline Functions cannot have resource requirements
+## Only Standalone Functions can have resource requirements
 
 ```
-ValueError: Inline Functions cannot have resource requirements.
+ValueError: Only Standalone Functions can have resource requirements.
 Try using @sematic.func(standalone=True, ...).
 See https://go.sematic.dev/t3mynx.
 ```
 
-[Inline Function](./glossary.md#standalone-inline-function)s run within the same
-process and container as the `CloudResolver` orchestrating the pipeline.
-Therefore, they cannot have custom resource requirements.
-
-To use custom resource requirements, make the the Function "Standalone", i.e.
-running in its own container:
+In order for a Function to have its own dedicated resources, it needs to be a
+[Standalone Function](./glossary.md#standalone-inline-function), i.e. run in its
+own dedicated container.
 
 ```python
 @sematic.func(standalone=True, resource_requirements=RESOURCE_REQS)
 def foo():
     ...
 ```
+
+Note that this only works with the
+[`CloudResolver`](./glossary.md#cloud-execution).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,14 @@
+## Inline Functions cannot have resource requirements
+
+[Inline Function](./glossary.md#standalone-inline-function) run within the same
+process and container as the `CloudResolver` orchestrating the pipeline.
+Therefore, they cannot have custom resource requirements.
+
+To use custom resource requirements, make the the Function "Standalone", i.e.
+running in its own container:
+
+```python
+@sematic.func(standalone=True, resource_requirements=RESOURCE_REQS)
+def foo():
+    ...
+```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -145,7 +145,26 @@ Three runs will be persisted:
 
 See [Sematic Functions](./functions.md).
 
-## Upstream, downstream function
+## Standalone, Inline Function
+
+When executed with `CloudResolver`, by default, all Sematic Function run
+"inline". That means they execute in the same Kubernetes container as the
+`CloudResolver` which orchestrates the pipeline.
+
+Standalone Functions run in their own Kubernetes container, job, and pod. They
+can therefore request custom resource requirements:
+
+```python
+@sematic.func(standalone=True, resource_requirements=GPU_RESOURCE_REQS)
+def foo():
+    ...
+```
+
+See [Customize resource
+requirements](./cloud-resolver.md#customize-resource-requirements) for more
+info.
+
+## Upstream, downstream Function
 
 In the following example:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -147,7 +147,7 @@ See [Sematic Functions](./functions.md).
 
 ## Standalone, Inline Function
 
-When executed with `CloudResolver`, by default, all Sematic Function run
+When executed with `CloudResolver`, by default, all Sematic Functions run
 "inline". That means they execute in the same Kubernetes container as the
 `CloudResolver` which orchestrates the pipeline.
 

--- a/docs/multiple-base-images.md
+++ b/docs/multiple-base-images.md
@@ -25,9 +25,10 @@ them:
   execute. Sematic aims to make this loop as tight as possible, and having to build multiple
   images every time (or remember which ones you need to rebuild when) would significantly
   damage this workflow.
-- If you have a step which is really lightweight, there's a better option than having
-  a small new container: _no_ new container. This is a great case for inline functions.
-  See the [CloudResolver docs](cloud-resolver.md#when-to-use-inline) for more.
+- If you have a step which is really lightweight, there's a better option than
+  having a small new container: _no_ new container. This is a great case for
+  [Inline Functions](./glossary.md#standalone-inline-function). See the
+  [CloudResolver docs](cloud-resolver.md#when-to-use-inline) for more.
 
 ### Multiple images if you must
 

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -146,7 +146,7 @@ class FutureProperties:
     Ideally over time we move all future properties to this dataclass.
     """
 
-    inline: bool
+    standalone: bool
     name: str
     tags: List[str]
     cache: bool = False
@@ -159,25 +159,25 @@ class AbstractFuture(abc.ABC):
     """
     Abstract base class to support `Future`.
 
-    This is necessary for two reasons:
-    - Resolve dependency loops (notably Future depends on LocalResolver)
-    - Enabling MyPy compliance in functions that take futures as inputs
+    This is necessary for two reasons: - Resolve dependency loops (notably
+    Future depends on LocalResolver) - Enabling MyPy compliance in functions
+    that take futures as inputs
 
-    What should go into `AbstractFuture` vs. `Future`?
-    In general, as much as possible should go into `AbstractFuture` without:
-    - introducing dependency cycles
-    - actual logic (e.g. resolve)
+    What should go into `AbstractFuture` vs. `Future`? In general, as much as
+    possible should go into `AbstractFuture` without: - introducing dependency
+    cycles - actual logic (e.g. resolve)
 
     Parameters
     ----------
     calculator: AbstractCalculator
         The calculator this is a future of.
     kwargs: Dict[str, Any]
-        The input arguments to the calculator. Can be concrete values or other futures.
-    inline: bool
-        When using the `CloudResolver`, whether the instrumented function should be
-        executed inside the same process and worker that is executing the `Resolver`
-        itself.
+        The input arguments to the calculator. Can be concrete values or other
+        futures.
+    standalone: bool
+        When using the `CloudResolver`, whether the instrumented function should
+        be executed as a standalone Kubernetes job or inside the same process
+        and worker that is executing the `Resolver` itself.
     original_future_id: Optional[str]
         The id of the original future this future was cloned from, if any.
     cache: bool
@@ -186,18 +186,18 @@ class AbstractFuture(abc.ABC):
 
         Do not activate this on a non-deterministic function!
     resource_requirements: Optional[ResourceRequirements]
-        When using the `CloudResolver`, specifies what special execution resources the
-        function requires. Defaults to `None`.
+        When using the `CloudResolver`, specifies what special execution
+        resources the function requires. Defaults to `None`.
     retry_settings: Optional[RetrySettings]
-        Specifies in case of which Exceptions the function's execution should be retried,
-        and how many times. Defaults to `None`.
+        Specifies in case of which Exceptions the function's execution should be
+        retried, and how many times. Defaults to `None`.
     """
 
     def __init__(
         self,
         calculator: AbstractCalculator,
         kwargs: Dict[str, Any],
-        inline: bool,
+        standalone: bool,
         original_future_id: Optional[str] = None,
         cache: bool = False,
         resource_requirements: Optional[ResourceRequirements] = None,
@@ -219,7 +219,7 @@ class AbstractFuture(abc.ABC):
         self.nested_future: Optional["AbstractFuture"] = None
 
         self._props = FutureProperties(
-            inline=inline,
+            standalone=standalone,
             cache=cache,
             resource_requirements=resource_requirements,
             retry_settings=retry_settings,

--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -164,8 +164,9 @@ class AbstractFuture(abc.ABC):
     that take futures as inputs
 
     What should go into `AbstractFuture` vs. `Future`? In general, as much as
-    possible should go into `AbstractFuture` without: - introducing dependency
-    cycles - actual logic (e.g. resolve)
+    possible should go into `AbstractFuture` without:
+    - introducing dependency cycles
+    - actual logic (e.g. resolve)
 
     Parameters
     ----------

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -333,7 +333,7 @@ def func(
         raise ValueError(
             "Inline Functions cannot have resource requirements "
             "Try using @sematic.func(standalone=True, ...). "
-            "See https://docs.sematic.dev/public-api-reference/errors#inline-functions-cannot-have-resource-requirements"  # noqa: E501
+            "See https://go.sematic.dev/t3mynx"  # noqa: E501
         )
 
     def _wrapper(func_):
@@ -361,7 +361,7 @@ def func(
                 ).format(_repr_str_iterable(missing_annotations))
             )
 
-        if standalone and base_image_tag is not None:
+        if not standalone and base_image_tag is not None:
             # Not raising an exception because users may be setting `standalone=False`
             # dynamically from CLI args. It would be annoying to have to also
             # change `base_image_tag` dynamically.

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -329,10 +329,11 @@ def func(
         warn(INLINE_DEPRECATION_MESSAGE, DeprecationWarning)
         standalone = inline
 
-    if standalone and resource_requirements is not None:
+    if not standalone and resource_requirements is not None:
         raise ValueError(
-            "Inline functions cannot have resource requirements "
-            "Try using @sematic.func(standalone=True, ...)"
+            "Inline Functions cannot have resource requirements "
+            "Try using @sematic.func(standalone=True, ...). "
+            "See https://docs.sematic.dev/public-api-reference/errors#inline-functions-cannot-have-resource-requirements"  # noqa: E501
         )
 
     def _wrapper(func_):

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -362,7 +362,7 @@ def func(
             )
 
         if standalone and base_image_tag is not None:
-            # Not raising an exception because users may be setting `standalone`
+            # Not raising an exception because users may be setting `standalone=False`
             # dynamically from CLI args. It would be annoying to have to also
             # change `base_image_tag` dynamically.
             logging.warning(

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -331,7 +331,7 @@ def func(
 
     if not standalone and resource_requirements is not None:
         raise ValueError(
-            "Inline Functions cannot have resource requirements "
+            "Only Standalone Functions can have resource requirements "
             "Try using @sematic.func(standalone=True, ...). "
             "See https://go.sematic.dev/t3mynx"  # noqa: E501
         )

--- a/sematic/calculator.py
+++ b/sematic/calculator.py
@@ -327,7 +327,7 @@ def func(
     """
     if inline is not None:
         warn(INLINE_DEPRECATION_MESSAGE, DeprecationWarning)
-        standalone = inline
+        standalone = not inline
 
     if not standalone and resource_requirements is not None:
         raise ValueError(

--- a/sematic/ee/plugins/external_resource/ray/cluster.py
+++ b/sematic/ee/plugins/external_resource/ray/cluster.py
@@ -50,7 +50,7 @@ class RayCluster(AbstractExternalResource):
     is intended to be used via Sematic's "with" api:
 
     ```python
-    @sematic.func(inline=False)
+    @sematic.func(standalone=True)
     def use_ray() -> int:
         with RayCluster(config=CLUSTER_CONFIG):
             return ray.get(some_ray_task.remote())[0]

--- a/sematic/ee/plugins/external_resource/ray/tests/load_testing/pipeline.py
+++ b/sematic/ee/plugins/external_resource/ray/tests/load_testing/pipeline.py
@@ -64,7 +64,7 @@ class LoadResults:
     mnist_results: MnistResults
 
 
-@func(inline=False)
+@func(standalone=True)
 def collatz_with_ray(
     n_workers: int, n_tasks: int, wait_minutes: int, memory_growth_factor: float
 ) -> CollatzResults:
@@ -161,7 +161,7 @@ def wait_for_results(refs, inputs, max_wait_seconds):
     ]
 
 
-@func(inline=False)
+@func(standalone=True)
 def load_test_mnist(
     n_rates: int, n_epochs: int, n_workers: int, wait_minutes: int
 ) -> MnistResults:
@@ -220,7 +220,7 @@ def train_model(
     return loss
 
 
-@func(inline=True)
+@func(standalone=False)
 def make_results(
     collatz_results: CollatzResults, mnist_results: MnistResults
 ) -> LoadResults:
@@ -230,7 +230,7 @@ def make_results(
     )
 
 
-@func(inline=True)
+@func(standalone=False)
 def load_test_ray(
     collatz_config: Optional[CollatzConfig] = None,
     mnist_config: Optional[MnistConfig] = None,

--- a/sematic/examples/bazel/pipeline.py
+++ b/sematic/examples/bazel/pipeline.py
@@ -5,28 +5,28 @@ import time
 import sematic
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add(a: float, b: float) -> float:
     time.sleep(5)
     return a + b
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add3(a: float, b: float, c: float) -> float:
     return add(add(a, b), c)
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def fail() -> float:
     return fail_nested()
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def fail_nested() -> float:
     raise ValueError("Some exception")
 
 
-@sematic.func(inline=True)
+@sematic.func
 def pipeline(a: float, b: float, c: float) -> float:
     # return add(add3(a, b, c), add(a, b))
     # return add(a, b)

--- a/sematic/examples/cifar_classifier/pipeline.py
+++ b/sematic/examples/cifar_classifier/pipeline.py
@@ -22,7 +22,7 @@ class PipelineResults:
     evaluation_results: EvaluationResults
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def train(config: TrainingConfig) -> TorchCheckpoint:
     """# Train an image classifier on the CIFAR10 dataset
 
@@ -40,7 +40,7 @@ def train(config: TrainingConfig) -> TorchCheckpoint:
         return train_classifier(config)
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def evaluate(
     checkpoint: TorchCheckpoint, config: EvaluationConfig
 ) -> EvaluationResults:
@@ -62,7 +62,7 @@ def evaluate(
         return evaluate_classifier(checkpoint, config)
 
 
-@sematic.func(inline=True)
+@sematic.func
 def bundle_results(
     final_checkpoint: TorchCheckpoint, evaluation_results: EvaluationResults
 ) -> PipelineResults:
@@ -78,7 +78,7 @@ def bundle_results(
     )
 
 
-@sematic.func(inline=True)
+@sematic.func
 def pipeline(
     train_config: TrainingConfig, eval_config: EvaluationConfig
 ) -> PipelineResults:

--- a/sematic/examples/lightning_resnet/pipeline.py
+++ b/sematic/examples/lightning_resnet/pipeline.py
@@ -31,7 +31,7 @@ class PipelineResults:
     evaluation_results: EvaluationResults
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def train(config: TrainingConfig, data_config: DataConfig) -> Checkpoint:
     """# Perform distributed training of a ResNet model.
 
@@ -77,7 +77,7 @@ def train(config: TrainingConfig, data_config: DataConfig) -> Checkpoint:
         return ray.get(call_train_classifier_from_ray.remote())
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def evaluate(
     checkpoint: Checkpoint, config: EvaluationConfig, data_config: DataConfig
 ) -> EvaluationResults:
@@ -114,7 +114,7 @@ def evaluate(
         return ray.get(call_evaluate_classifier_from_ray.remote())
 
 
-@sematic.func(inline=True)
+@sematic.func
 def bundle_results(
     final_checkpoint: Checkpoint,
     evaluation_results: EvaluationResults,
@@ -131,7 +131,7 @@ def bundle_results(
     )
 
 
-@sematic.func(inline=True)
+@sematic.func
 def pipeline(
     train_config: TrainingConfig, data_config: DataConfig, eval_config: EvaluationConfig
 ) -> PipelineResults:

--- a/sematic/examples/mnist/pytorch/pipeline.py
+++ b/sematic/examples/mnist/pytorch/pipeline.py
@@ -24,7 +24,7 @@ from sematic import (
 from sematic.examples.mnist.pytorch.train_eval import Net, test, train
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def load_mnist_dataset(train: bool, path: str = "/tmp/pytorch-mnist") -> MNIST:
     transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])
     return MNIST(root=path, train=train, download=True, transform=transform)
@@ -35,7 +35,7 @@ class DataLoaderConfig:
     batch_size: Optional[int] = 1000
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def get_dataloader(dataset: Dataset, config: DataLoaderConfig) -> DataLoader:
     return DataLoader(dataset, batch_size=config.batch_size)
 
@@ -74,7 +74,7 @@ GPU_RESOURCE_REQS = ResourceRequirements(
 )
 
 
-@sematic.func(inline=False, resource_requirements=GPU_RESOURCE_REQS)
+@sematic.func(standalone=True, resource_requirements=GPU_RESOURCE_REQS)
 def train_model(
     config: TrainConfig,
     train_loader: DataLoader,
@@ -108,7 +108,7 @@ class EvaluationResults:
     confusion_matrix: plotly.graph_objs.Figure
 
 
-@sematic.func(inline=False, resource_requirements=GPU_RESOURCE_REQS)
+@sematic.func(standalone=True, resource_requirements=GPU_RESOURCE_REQS)
 def evaluate_model(
     model: nn.Module, test_loader: DataLoader, device: torch.device
 ) -> EvaluationResults:
@@ -126,7 +126,7 @@ def evaluate_model(
     )
 
 
-@sematic.func(inline=True)
+@sematic.func
 def train_eval(
     train_dataloader: DataLoader, test_dataloader: DataLoader, train_config: TrainConfig
 ) -> EvaluationResults:
@@ -146,7 +146,7 @@ def train_eval(
     return evaluation_results
 
 
-@sematic.func(inline=True)
+@sematic.func
 def pipeline(config: PipelineConfig) -> EvaluationResults:
     """
     # MNIST example in PyTorch
@@ -177,7 +177,7 @@ def pipeline(config: PipelineConfig) -> EvaluationResults:
     return evaluation_results
 
 
-@sematic.func(inline=True)
+@sematic.func
 def find_best_accuracy_index(evaluation_results: List[EvaluationResults]) -> int:
     """
     Find the best accuracy out of a list of evaluation results.
@@ -192,12 +192,12 @@ def find_best_accuracy_index(evaluation_results: List[EvaluationResults]) -> int
     return best_index
 
 
-@sematic.func(inline=True)
+@sematic.func
 def get_best_learning_rate(configs: List[TrainConfig], best_index: int) -> float:
     return configs[best_index].learning_rate
 
 
-@sematic.func(inline=True)
+@sematic.func
 def scan_learning_rate(
     dataloader_config: DataLoaderConfig, train_configs: List[TrainConfig]
 ) -> float:

--- a/sematic/examples/retry/pipeline.py
+++ b/sematic/examples/retry/pipeline.py
@@ -14,9 +14,7 @@ class SomeException(Exception):
     pass
 
 
-@sematic.func(
-    inline=True, retry=sematic.RetrySettings(exceptions=(SomeException,), retries=5)
-)
+@sematic.func(retry=sematic.RetrySettings(exceptions=(SomeException,), retries=5))
 def raise_exception() -> float:
     """
     A toy function to illustrate the retry mechanism

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -56,7 +56,7 @@ RERUN_FROM_HELP = (
     "to None."
 )
 MAX_PARALLELISM_HELP = (
-    "The maximum number of non-inlined runs that will be allowed to be in the "
+    "The maximum number of Standalone Function Runs that will be allowed to be in the "
     "`SCHEDULED` state at any one time. Must be a positive integer, or None for "
     "unlimited runs. Defaults to None."
 )

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add(a: float, b: float) -> float:
     """
     Adds two numbers.
@@ -35,7 +35,7 @@ def add(a: float, b: float) -> float:
     return a + b
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add_with_ray(a: float, b: float) -> float:
     """
     Adds two numbers, using a Ray cluster.
@@ -61,7 +61,7 @@ def add_ray_task(x, y):
     return x + y
 
 
-@sematic.func(inline=True)
+@sematic.func
 def add_inline(a: float, b: float) -> float:
     """
     Adds two numbers inline.
@@ -71,7 +71,7 @@ def add_inline(a: float, b: float) -> float:
     return a + b
 
 
-@sematic.func(inline=True)
+@sematic.func
 def add_inline_using_resource(a: float, b: float) -> float:
     """
     Adds two numbers and logs info about a custom resource.
@@ -81,7 +81,6 @@ def add_inline_using_resource(a: float, b: float) -> float:
     with TimedMessage(
         message="some message", allocation_seconds=2, deallocation_seconds=2
     ) as timed_message:
-
         logger.info(
             "Adding inline with timed_message='%s'", timed_message.read_message()
         )
@@ -89,7 +88,7 @@ def add_inline_using_resource(a: float, b: float) -> float:
         return a + b
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add_using_resource(a: float, b: float) -> float:
     """
     Adds two numbers and logs info about a custom resource.
@@ -99,13 +98,12 @@ def add_using_resource(a: float, b: float) -> float:
     with TimedMessage(
         message="Some message", allocation_seconds=2, deallocation_seconds=2
     ) as timed_message:
-
         logger.info("Adding with timed_message='%s'", timed_message.read_message())
         time.sleep(5)
         return a + b
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add_with_resource_requirements(a: float, b: float) -> float:
     """
     Adds two numbers with ResourceRequirements.
@@ -119,7 +117,7 @@ def add_with_resource_requirements(a: float, b: float) -> float:
     return a + b
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add2_nested(a: float, b: float) -> float:
     """
     Adds two numbers using a nested structure.
@@ -128,7 +126,7 @@ def add2_nested(a: float, b: float) -> float:
     return add(a, b)
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add4_nested(a: float, b: float, c: float, d: float) -> float:
     """
     Adds four numbers using a nested structure.
@@ -137,7 +135,7 @@ def add4_nested(a: float, b: float, c: float, d: float) -> float:
     return add2_nested(add2_nested(a, b), add2_nested(c, d))
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_no_input() -> float:
     """
     Returns a number without taking any inputs.
@@ -147,7 +145,7 @@ def do_no_input() -> float:
     return 7
 
 
-@sematic.func(inline=True, cache=True)
+@sematic.func(standalone=False, cache=True)
 def add_inline_cached(a: float, b: float) -> float:
     """
     Adds two numbers inline, attempting to source the value from the cache.
@@ -157,7 +155,7 @@ def add_inline_cached(a: float, b: float) -> float:
     return a + b
 
 
-@sematic.func(inline=False, cache=True)
+@sematic.func(standalone=True, cache=True)
 def add2_nested_cached(a: float, b: float) -> float:
     """
     Adds two numbers using a nested structure, attempting to source the value from the
@@ -167,7 +165,7 @@ def add2_nested_cached(a: float, b: float) -> float:
     return add_inline_cached(a, b)
 
 
-@sematic.func(inline=False, cache=True)
+@sematic.func(standalone=True, cache=True)
 def add4_nested_cached(a: float, b: float, c: float, d: float) -> float:
     """
     Adds four numbers using a nested structure, attempting to source the value from the
@@ -177,7 +175,7 @@ def add4_nested_cached(a: float, b: float, c: float, d: float) -> float:
     return add2_nested_cached(add2_nested_cached(a, b), add2_nested_cached(c, d))
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add_all(values: List[float]) -> float:
     """
     Adds all the numbers in the list.
@@ -189,7 +187,7 @@ def add_all(values: List[float]) -> float:
     return sum
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def add_fan_out(val: float, fan_out: int) -> float:
     """
     Adds the specified number of dynamically-generated functions in parallel.
@@ -201,7 +199,7 @@ def add_fan_out(val: float, fan_out: int) -> float:
     return add_all(futures)
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_sleep(val: float, sleep_time: int) -> float:
     """
     Sleeps for the specified number of seconds, in 1-second stretches, logging an INFO
@@ -220,7 +218,7 @@ def do_sleep(val: float, sleep_time: int) -> float:
     return val
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_spam_logs(val: float, log_lines: int) -> float:
     """
     Logs the indicated number of INFO messages.
@@ -233,7 +231,7 @@ def do_spam_logs(val: float, log_lines: int) -> float:
     return val
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_oom(val: float) -> float:
     """
     Causes an Out of Memory error.
@@ -246,7 +244,7 @@ def do_oom(val: float) -> float:
     return val
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_raise(val: float) -> float:
     """
     Raises a ValueError, without retries.
@@ -257,7 +255,7 @@ def do_raise(val: float) -> float:
 
 
 @sematic.func(
-    inline=False, retry=sematic.RetrySettings(exceptions=(ValueError,), retries=10)
+    standalone=True, retry=sematic.RetrySettings(exceptions=(ValueError,), retries=10)
 )
 def do_retry(val: float, failure_probability: float = 0.5) -> float:
     """
@@ -272,7 +270,7 @@ def do_retry(val: float, failure_probability: float = 0.5) -> float:
     return val
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def load_image() -> Image:
     """
     Loads and returns an `Image`.
@@ -282,7 +280,7 @@ def load_image() -> Image:
     return Image.from_file("sematic/examples/testing_pipeline/resources/sammy.png")
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def explode_image(
     val: float, image: Image
 ) -> Tuple[float, Image, List[Image], Dict[str, Image]]:
@@ -298,7 +296,7 @@ def explode_image(
     return val, image, [image, image], {"the_image": image}
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_image_io(val: float) -> float:
     """
     Internally uses functions that pass around `Image` objects in their I/O signatures.
@@ -308,7 +306,7 @@ def do_image_io(val: float) -> float:
     return add(1, image_tuple[0])
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def compose_s3_locations(
     val: float, s3_uris: List[str]
 ) -> Tuple[float, List[S3Location]]:
@@ -321,7 +319,7 @@ def compose_s3_locations(
     return val, s3_locations
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_s3_locations(val: float, s3_uris: List[str]) -> float:
     """
     Internally uses a function that composes `S3Location` dataclasses for the specified
@@ -332,7 +330,7 @@ def do_s3_locations(val: float, s3_uris: List[str]) -> float:
     return add(1, location_tuple[0])
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_virtual_funcs(a: float, b: float, c: float) -> float:
     """
     Adds three numbers while explicitly including _make_tuple, _make_list, and _getitem.
@@ -343,7 +341,7 @@ def do_virtual_funcs(a: float, b: float, c: float) -> float:
     return add_all([d, e, f])
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def fork_subprocess(val: float, action: str, code: int) -> float:
     """
     Forks a subprocess, and then performs the specified action, using the specified value:
@@ -387,7 +385,7 @@ def fork_subprocess(val: float, action: str, code: int) -> float:
     return val
 
 
-@sematic.func(inline=False)
+@sematic.func(standalone=True)
 def do_exit(val: float, exit_code: int) -> float:
     """
     Exits execution using the specified exit code.
@@ -400,7 +398,7 @@ def do_exit(val: float, exit_code: int) -> float:
     return val
 
 
-@sematic.func(inline=True)
+@sematic.func
 def testing_pipeline(
     inline: bool = False,
     nested: bool = False,
@@ -429,7 +427,7 @@ def testing_pipeline(
     Parameters
     ----------
     inline: bool
-        Whether to include inline functions in the pipeline. Defaults to False.
+        Whether to include Inline Functions in the pipeline. Defaults to False.
     nested: bool
         Whether to include nested functions in the pipeline. Defaults to False.
     no_input: bool

--- a/sematic/future.py
+++ b/sematic/future.py
@@ -13,7 +13,7 @@ _MUTABLE_FIELDS = {"name", "standalone", "cache", "resource_requirements", "tags
 
 INLINE_DEPRECATION_MESSAGE = (
     "The inline argument to the @sematic.func decorator will be deprecated on "
-    "<date>. Please use standalone=True for standalone=True."
+    "June 1st, 2023. Please replace inline=False with standalone=True."
 )
 
 

--- a/sematic/future.py
+++ b/sematic/future.py
@@ -1,5 +1,5 @@
 # Standard Library
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Optional
 from warnings import warn  # noqa: F401
 
 # Sematic

--- a/sematic/future.py
+++ b/sematic/future.py
@@ -1,5 +1,6 @@
 # Standard Library
-from typing import Any, Callable, List, Optional, Union  # noqa: F401
+from typing import Any, Callable, List, Optional, Union
+from warnings import warn  # noqa: F401
 
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState
@@ -8,7 +9,12 @@ from sematic.resolvers.local_resolver import LocalResolver
 from sematic.resolvers.resource_requirements import ResourceRequirements
 from sematic.resolvers.silent_resolver import SilentResolver
 
-_MUTABLE_FIELDS = {"name", "inline", "cache", "resource_requirements", "tags"}
+_MUTABLE_FIELDS = {"name", "standalone", "cache", "resource_requirements", "tags"}
+
+INLINE_DEPRECATION_MESSAGE = (
+    "The inline argument to the @sematic.func decorator will be deprecated on "
+    "<date>. Please use standalone=True for standalone=True."
+)
 
 
 class Future(AbstractFuture):
@@ -53,14 +59,14 @@ class Future(AbstractFuture):
         ----------
         name: str
             The future's name. This will be used to name the run in the UI.
-        inline: bool
+        standalone: bool
             When using the `CloudResolver`, whether the instrumented function
-            should be executed inside the same process and worker that is executing
-            the `Resolver` itself.
+            should be executed in a standalone container or inside the same
+            process and worker that is executing the `Resolver` itself.
 
-            Defaults to `True`, as most pipeline functions are expected to be
-            lightweight. Explicitly set this to `False` in order to distribute its
-            execution to a worker and parallelize its execution.
+            Defaults to `False`, as most pipeline functions are expected to be
+            lightweight. Set to `True` in order to distribute
+            its execution to a worker and parallelize its execution.
         cache: bool
             Whether to cache the function's output value under the
             `cache_namespace` configured in the `Resolver`. Defaults to `False`.
@@ -89,9 +95,15 @@ class Future(AbstractFuture):
                 )
 
         if "inline" in kwargs:
+            warn(INLINE_DEPRECATION_MESSAGE, DeprecationWarning)
             value = kwargs["inline"]
+            del kwargs["inline"]
+            kwargs["standalone"] = value
+
+        if "standalone" in kwargs:
+            value = kwargs["standalone"]
             if not (isinstance(value, bool)):
-                raise ValueError(f"Invalid `inline`, must be a bool: {repr(value)}")
+                raise ValueError(f"Invalid `standalone`, must be a bool: {repr(value)}")
 
         if "cache" in kwargs:
             value = kwargs["cache"]

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -447,7 +447,7 @@ def _load_inline_logs(
             log_info_message=(
                 "UI logs are only available for runs that "
                 "(a) are executed using the CloudResolver and "
-                "(b) are using the resolver in non-detached mode OR have inline=False."
+                "(b) are using the resolver in non-detached mode OR have standalone=True."
             ),
         )
 

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -171,7 +171,7 @@ class CloudResolver(LocalResolver):
         if self._container_image_uris is None:
             return None
 
-        if future.props.standalone:
+        if not future.props.standalone:
             return self._get_resolution_container_image()
 
         base_image_tag = future.props.base_image_tag or DEFAULT_BASE_IMAGE_TAG
@@ -224,7 +224,7 @@ class CloudResolver(LocalResolver):
         # For the cloud resolver, the server will update the relevant
         # run fields when it gets scheduled by the server.
         # Inline futures still need the updates.
-        if not future.props.standalone:
+        if future.props.standalone:
             return
 
         super()._update_run_and_future_pre_scheduling(run, future)
@@ -365,14 +365,14 @@ class CloudResolver(LocalResolver):
         return [
             future.id
             for future in self._futures
-            if future.props.standalone and future.state == FutureState.SCHEDULED
+            if not future.props.standalone and future.state == FutureState.SCHEDULED
         ]
 
     def _wait_for_any_remote_jobs(self) -> List[str]:
         scheduled_futures_by_id: Dict[str, AbstractFuture] = {
             future.id: future
             for future in self._futures
-            if not future.props.standalone and future.state == FutureState.SCHEDULED
+            if future.props.standalone and future.state == FutureState.SCHEDULED
         }
 
         if not scheduled_futures_by_id:
@@ -424,7 +424,7 @@ class CloudResolver(LocalResolver):
         Inline futures can always be scheduled. External futures can only be scheduled
         if the maximum parallelism degree has not been exceeded.
         """
-        if future.props.standalone:
+        if not future.props.standalone:
             return True
 
         if not self._max_parallelism:

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -46,41 +46,43 @@ class CloudResolver(LocalResolver):
     detach: bool
         Defaults to `True`.
 
-        When `True`, the driver job will run on the remote cluster. This is the so
-        called `fire-and-forget` mode. The shell prompt will return as soon as
-        the driver job as been submitted.
+        When `True`, the driver job will run on the remote cluster. This is the
+        so called `fire-and-forget` mode. The shell prompt will return as soon
+        as the driver job as been submitted.
 
         When `False`, the driver job runs on the local machine. The shell prompt
         will return when the entire pipeline has completed.
     cache_namespace: CacheNamespace
-        A string or a `Callable` which takes a root `Future` and returns a string, which
-        will be used as the cache key namespace in which the executed funcs' outputs will
-        be cached, as long as they also have the `cache` flag activated. Defaults to
-        `None`.
+        A string or a `Callable` which takes a root `Future` and returns a
+        string, which will be used as the cache key namespace in which the
+        executed funcs' outputs will be cached, as long as they also have the
+        `cache` flag activated. Defaults to `None`.
 
-        The `Callable` option takes as input the `Resolution` root `Future`. All the other
-        required variables must be enclosed in the `Callables`' context. The `Callable`
-        must have a small memory footprint and must return immediately!
+        The `Callable` option takes as input the `Resolution` root `Future`. All
+        the other required variables must be enclosed in the `Callables`'
+        context. The `Callable` must have a small memory footprint and must
+        return immediately!
     max_parallelism: Optional[int]
-        The maximum number of non-inlined runs that this resolver will allow to be in the
-        `SCHEDULED` state at any one time. Must be a positive integer, or `None` for
-        unlimited runs. Defaults to `None`.
-        This is intended as a simple mechanism to limit the amount of computing resources
-        consumed by one pipeline execution for pipelines with a high degree of
-        parallelism. Note that if other resolvers are active, runs from them will not be
-        considered in this parallelism limit. Note also that runs that are in the RAN
-        state do not contribute to the limit, since they do not consume computing
-        resources.
+        The maximum number of Standalone Function Runs that this resolver will
+        allow to be in the `SCHEDULED` state at any one time. Must be a positive
+        integer, or `None` for unlimited runs. Defaults to `None`. This is
+        intended as a simple mechanism to limit the amount of computing
+        resources consumed by one pipeline execution for pipelines with a high
+        degree of parallelism. Note that if other resolvers are active, runs
+        from them will not be considered in this parallelism limit. Note also
+        that runs that are in the RAN state do not contribute to the limit,
+        since they do not consume computing resources.
     rerun_from: Optional[str]
-        When `None`, the pipeline is resolved from scratch, as normally. When not `None`,
-        must be the id of a `Run` from a previous resolution. Instead of running from
-        scratch, parts of that previous resolution is cloned up until the specified `Run`,
-        and only the specified `Run`, nested and downstream `Future`s are executed. This
-        is meant to be used for retries or for hotfixes, without needing to re-run the
-        entire pipeline again.
+        When `None`, the pipeline is resolved from scratch, as normally. When
+        not `None`, must be the id of a `Run` from a previous resolution.
+        Instead of running from scratch, parts of that previous resolution is
+        cloned up until the specified `Run`, and only the specified `Run`,
+        nested and downstream `Future`s are executed. This is meant to be used
+        for retries or for hotfixes, without needing to re-run the entire
+        pipeline again.
     _is_running_remotely: bool
-        For Sematic internal usage. End users should always leave this at the default
-        value of `False`.
+        For Sematic internal usage. End users should always leave this at the
+        default value of `False`.
     """
 
     # Time between external resource updates *during activation and deactivation*
@@ -169,7 +171,7 @@ class CloudResolver(LocalResolver):
         if self._container_image_uris is None:
             return None
 
-        if future.props.inline:
+        if future.props.standalone:
             return self._get_resolution_container_image()
 
         base_image_tag = future.props.base_image_tag or DEFAULT_BASE_IMAGE_TAG
@@ -222,7 +224,7 @@ class CloudResolver(LocalResolver):
         # For the cloud resolver, the server will update the relevant
         # run fields when it gets scheduled by the server.
         # Inline futures still need the updates.
-        if not future.props.inline:
+        if not future.props.standalone:
             return
 
         super()._update_run_and_future_pre_scheduling(run, future)
@@ -363,14 +365,14 @@ class CloudResolver(LocalResolver):
         return [
             future.id
             for future in self._futures
-            if future.props.inline and future.state == FutureState.SCHEDULED
+            if future.props.standalone and future.state == FutureState.SCHEDULED
         ]
 
     def _wait_for_any_remote_jobs(self) -> List[str]:
         scheduled_futures_by_id: Dict[str, AbstractFuture] = {
             future.id: future
             for future in self._futures
-            if not future.props.inline and future.state == FutureState.SCHEDULED
+            if not future.props.standalone and future.state == FutureState.SCHEDULED
         }
 
         if not scheduled_futures_by_id:
@@ -422,7 +424,7 @@ class CloudResolver(LocalResolver):
         Inline futures can always be scheduled. External futures can only be scheduled
         if the maximum parallelism degree has not been exceeded.
         """
-        if future.props.inline:
+        if future.props.standalone:
             return True
 
         if not self._max_parallelism:

--- a/sematic/resolvers/state_machine_resolver.py
+++ b/sematic/resolvers/state_machine_resolver.py
@@ -330,12 +330,12 @@ class StateMachineResolver(Resolver, abc.ABC):
 
         self._future_will_schedule(future)
 
-        if future.props.inline:
-            logger.info("Running inline %s %s", future.id, future.calculator)
-            self._run_inline(future)
-        else:
+        if future.props.standalone:
             logger.info("Scheduling %s %s", future.id, future.calculator)
             self._schedule_future(future)
+        else:
+            logger.info("Running inline %s %s", future.id, future.calculator)
+            self._run_inline(future)
 
     @typing.final
     def _resolve_nested_future(self, future: AbstractFuture) -> None:

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -34,7 +34,7 @@ from sematic.tests.fixtures import (  # noqa: F401
 )
 
 
-@func(base_image_tag="cuda", inline=False)
+@func(base_image_tag="cuda", standalone=True)
 def add(a: float, b: float) -> float:
     return a + b
 
@@ -178,7 +178,7 @@ def test_max_parallelism_validation(max_parallelism, expected_validates):
     ),
 )
 def test_make_run(_, base_image_tag, expected_image):
-    @func(inline=False, base_image_tag=base_image_tag)
+    @func(standalone=True, base_image_tag=base_image_tag)
     def foo():
         pass
 

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -109,7 +109,7 @@ def test_not_a_function():
 
 def test_inline_and_resource_reqs():
     with pytest.raises(
-        ValueError, match="Inline Functions cannot have resource requirements"
+        ValueError, match="Only Standalone Functions can have resource requirements"
     ):
 
         @func(

--- a/sematic/tests/test_calculator.py
+++ b/sematic/tests/test_calculator.py
@@ -109,11 +109,11 @@ def test_not_a_function():
 
 def test_inline_and_resource_reqs():
     with pytest.raises(
-        ValueError, match="Inline functions cannot have resource requirements"
+        ValueError, match="Inline Functions cannot have resource requirements"
     ):
 
         @func(
-            inline=True,
+            standalone=False,
             resource_requirements=ResourceRequirements(
                 KubernetesResourceRequirements()
             ),
@@ -262,7 +262,7 @@ def test_convert_lists():
     result = _convert_lists([1, foo(), [2, bar()], 3, [4, [5, foo()]]])
 
     assert isinstance(result, Future)
-    assert result.props.inline is True
+    assert result.props.standalone is False
     assert len(result.kwargs) == 5
     assert (
         result.calculator.output_type
@@ -279,14 +279,16 @@ def test_convert_lists():
     assert isinstance(result.kwargs["v4"].kwargs["v1"].kwargs["v1"], Future)
 
     @func
-    def pipeline() -> List[
-        Union[
-            int,
-            str,
-            List[Union[int, str]],
-            List[Union[int, List[Union[int, str]]]],
+    def pipeline() -> (
+        List[
+            Union[
+                int,
+                str,
+                List[Union[int, str]],
+                List[Union[int, List[Union[int, str]]]],
+            ]
         ]
-    ]:
+    ):
         return [1, foo(), [2, bar()], 3, [4, [5, foo()]]]  # type: ignore
 
     assert pipeline().resolve(tracking=False) == [
@@ -303,7 +305,7 @@ def test_convert_tuples():
     expected_type = Tuple[int, List[int], Tuple[str, str], str]
     result = _convert_tuples(value, expected_type)
     assert isinstance(result, Future)
-    assert result.props.inline is True
+    assert result.props.standalone is False
 
     @func
     def pipeline() -> expected_type:
@@ -312,22 +314,22 @@ def test_convert_tuples():
     assert pipeline().resolve(tracking=False) == (42, [1, 42, 3], ("foo", "bar"), "foo")
 
 
-def test_inline_default():
+def test_standalone_default():
     @func
     def f():
         pass
 
-    assert f._inline is True
-    assert f().props.inline is True
+    assert f._standalone is False
+    assert f().props.standalone is False
 
 
-def test_inline():
-    @func(inline=False)
+def test_standalone():
+    @func(standalone=True)
     def f():
         pass
 
-    assert f._inline is False
-    assert f().props.inline is False
+    assert f._standalone is True
+    assert f().props.standalone is True
 
 
 def test_resource_requirements():
@@ -335,7 +337,7 @@ def test_resource_requirements():
         kubernetes=KubernetesResourceRequirements(node_selector={"a": "b"}, requests={})
     )
 
-    @func(resource_requirements=resource_requirements, inline=False)
+    @func(resource_requirements=resource_requirements, standalone=True)
     def f():
         pass
 

--- a/sematic/tests/test_future.py
+++ b/sematic/tests/test_future.py
@@ -33,15 +33,15 @@ def test_set_validate_name():
         future.set(name=123)
 
 
-def test_set_validate_inline():
+def test_set_validate_standalone():
     future = foo()
 
-    assert future.props.inline is True
-    future.set(inline=False)
-    assert future.props.inline is False
+    assert future.props.standalone is False
+    future.set(standalone=True)
+    assert future.props.standalone is True
 
-    with pytest.raises(ValueError, match="Invalid `inline`"):
-        future.set(inline=123)
+    with pytest.raises(ValueError, match="Invalid `standalone`"):
+        future.set(standalone=123)
 
 
 def test_set_validate_cache():


### PR DESCRIPTION
We still need to keep the Inline term in some places to refer to non-Standalone functions.