### PR TITLE
Make local storage location configurable

### DIFF
--- a/docs/local-execution.md
+++ b/docs/local-execution.md
@@ -43,6 +43,18 @@ was configured. By default, when running locally after having launched the
 server with `$ sematic start`, artifacts will be persisted on your local
 machine, in the `~/.sematic/data` directory.
 
+To customize this location, set the `LOCAL_STORAGE_PATH` setting to the path of your choice:
+
+```shell
+$ sematic settings set -p sematic.plugins.storage.local_storage.LocalStorage LOCAL_STORAGE_PATH /path/to/location
+```
+
+or at runtime:
+
+```shell
+$ LOCAL_STORAGE_PATH=/path/to/location sematic start
+```
+
 A different storage backend can be selected by selecting a different storage
 plug-in when starting the server (whether a local or deployed server). For
 example, to select the S3 storage plug-in:

--- a/sematic/plugins/storage/tests/BUILD
+++ b/sematic/plugins/storage/tests/BUILD
@@ -13,8 +13,11 @@ pytest_test(
     name = "test_local_storage",
     srcs = ["test_local_storage.py"],
     pip_deps = ["flask"],
+    # buildifier: leave-alone
     deps = [
         "//sematic/api/tests:fixtures",
+        "//sematic/config:config",
+        "//sematic/config/tests:fixtures",
         "//sematic/db/tests:fixtures",
         "//sematic/plugins/storage:local_storage",
     ],

--- a/sematic/plugins/storage/tests/test_local_storage.py
+++ b/sematic/plugins/storage/tests/test_local_storage.py
@@ -7,9 +7,19 @@ from urllib.parse import urlparse
 import flask.testing
 
 # Sematic
-from sematic.api.tests.fixtures import mock_auth, test_client  # noqa: F401
+from sematic.api.tests.fixtures import (  # noqa: F401
+    mock_auth,
+    mock_plugin_settings,
+    test_client,
+)
+from sematic.config.config import get_config
+from sematic.config.tests.fixtures import empty_settings_file  # noqa: F401
 from sematic.db.tests.fixtures import test_db  # noqa: F401
-from sematic.plugins.storage.local_storage import LocalStorage
+from sematic.plugins.storage.local_storage import (
+    LocalStorage,
+    LocalStorageSettingsVar,
+    _get_data_dir,
+)
 
 
 def test_upload_download(
@@ -41,3 +51,14 @@ def test_upload_download(
             response = test_client.get(parsed_url.path)
 
             assert response.data == value
+
+
+def test_settings():
+    with mock_plugin_settings(
+        LocalStorage, {LocalStorageSettingsVar.LOCAL_STORAGE_PATH: "/foo/bar"}
+    ):
+        assert _get_data_dir() == "/foo/bar"
+
+
+def test_default_settings(empty_settings_file):  # noqa: F811
+    assert _get_data_dir() == get_config().data_dir


### PR DESCRIPTION
This PR introduces a new settings for the `LocalStorage` plug-in. Before this PR, the local storage location was `~/.sematic/data`. Users can now customize it with the `LOCAL_STORAGE_PATH` settings and env var.