### PR TITLE
Add Sematic Grafana dashboards as helm package

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -253,10 +253,24 @@ changes.
         $ mv *.tgz $HELM_REPO/sematic-server/
         ```
 
+    1. (OPTIONAL) Only do this step if you know that the Sematic Grafana dashboards
+    have been updated and need to be released.  Generate the updated Helm package
+    from the Sematic repo.
+        ```bash
+        $ export HELM_REPO=~/code/helm-charts
+        $ helm package helm/sematic-grafana-dashboards
+        $ helm repo index . \
+                --url https://sematic-ai.github.io/helm-charts/sematic-grafana-dashboards \
+                --merge $HELM_REPO/index.yaml
+        $ mv index.yaml $HELM_REPO/index.yaml
+        $ mv *.tgz $HELM_REPO/sematic-grafana-dashboards/
+        ```
     1. You should now have a new `sematic-server/sematic-server-X.X.X.tgz` file in the
-    `helm-charts` repo, and a modified `index.yaml` file. Commit and push both of these
-    to a new release branch, and create a PR for the change based on `gh-pages`. Wait for
-    approval, and merge it.
+    `helm-charts` repo, and a modified `index.yaml` file. If you optionally created a package
+    for the Grafana dashboards, you should also have a
+    `sematic-grafana-dashboards/sematic-grafana-dashboards-X.X.X.tgz` file in the `helm-charts`
+    repo.  Commit and push all of these to a new release branch, and create a PR for the change
+    based on `gh-pages`. Wait for approval, and merge it.
 
 1. Deploy this new official release to the `stage` environment, in order to leave it in a
   consistent and expected state, and to test the actual commands users will be using to

--- a/helm/sematic-grafana-dashboards/.helmignore
+++ b/helm/sematic-grafana-dashboards/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/sematic-grafana-dashboards/Chart.yaml
+++ b/helm/sematic-grafana-dashboards/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: sematic-grafana-dashboards
+description: Sematic AI Grafana Dashboards
+type: application
+version: 1.0.0
+appVersion: v0.0.1
+maintainers:
+  - name: sematic-ai
+    url: https://github.com/sematic-ai/sematic/

--- a/helm/sematic-grafana-dashboards/templates/sematic_jobs_dashboard_configmap.yaml
+++ b/helm/sematic-grafana-dashboards/templates/sematic_jobs_dashboard_configmap.yaml
@@ -1,0 +1,563 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: sematic-jobs-dashboard
+data:
+  sematic_jobs_dashboard_configmap.json: |-
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.1.7"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "content": "# Viewing Run\n\n# [$run_id](https://pilot.verdant.sematic.cloud/runs/$run_id)",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.1.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "code",
+          "expr": "{job=~\".*sematic-worker-$run_id.*\"} |= `` |= `$log_filter` | json line=\"log\" | line_format `{{.line}}`",
+          "key": "Q-6892653b-f7f6-47e4-b0e2-c2fa672f4049-0",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Job logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1.1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg by(container_name, pod) (container_memory_working_set_bytes{pod=~\".*sematic-worker-$run_id.*\"}) / avg by(container_name, pod) (cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{resource=\"memory\", pod=~\".*sematic-worker-$run_id.*\"})",
+          "key": "Q-24743101-1f98-4379-a792-53dc870be018-0",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage Fraction",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg by(container_name, pod) (container_memory_working_set_bytes{pod=~\".*sematic-worker-$run_id.*\"})",
+          "hide": true,
+          "key": "Q-24743101-1f98-4379-a792-53dc870be018-0",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A / (1024*1024*1024)",
+          "hide": false,
+          "refId": "B",
+          "type": "math"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{pod=~\".*sematic-worker-$run_id.*\", resource=\"memory\"})",
+          "hide": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$C / (1024 * 1024 * 1024)",
+          "hide": false,
+          "refId": "D",
+          "type": "math"
+        }
+      ],
+      "title": "Memory Usage GB",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Limits"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    0,
+                    10
+                  ],
+                  "fill": "dot"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\".*sematic-worker-$run_id.*\", container=~\".*sematic-worker-$run_id.*\"}[5m])",
+          "key": "Q-24743101-1f98-4379-a792-53dc870be018-0",
+          "legendFormat": "Usage",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{pod=~\".*sematic-worker-$run_id.*\", resource=\"cpu\"})",
+          "hide": false,
+          "legendFormat": "Limits",
+          "range": true,
+          "refId": "Limits"
+        }
+      ],
+      "title": "Pod CPU Usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Run Id",
+        "name": "run_id",
+        "options": [
+          {
+            "selected": false,
+            "text": "c1fbb12aa6ca4463b07d7d4c0438bd45",
+            "value": "c1fbb12aa6ca4463b07d7d4c0438bd45"
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Log Filter",
+        "name": "log_filter",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sematic jobs",
+  "uid": "M1NEFyx4z",
+  "version": 19,
+  "weekStart": ""
+}
+
+

--- a/helm/sematic-grafana-dashboards/templates/sematic_jobs_dashboard_configmap.yaml
+++ b/helm/sematic-grafana-dashboards/templates/sematic_jobs_dashboard_configmap.yaml
@@ -118,7 +118,7 @@ data:
       },
       "id": 3,
       "options": {
-        "content": "# Viewing Run\n\n# [$run_id](https://pilot.verdant.sematic.cloud/runs/$run_id)",
+        "content": "# Viewing Run\n\n# [$run_id]({{ .Values.sematic_server_dashboard_url }}/runs/$run_id)",
         "mode": "markdown"
       },
       "pluginVersion": "9.1.7",

--- a/helm/sematic-grafana-dashboards/templates/sematic_server_dashboard_configmap.yaml
+++ b/helm/sematic-grafana-dashboards/templates/sematic_server_dashboard_configmap.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: sematic-server-dashboard
+data:
+  sematic_server_dashboard_configmap.json: |-
+{
+  "__inputs": [
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.1.7"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 19,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "{app=\"sematic-server\", namespace=\"pilot\"} != `socket` != `kube-probe` | json line=\"log\" | line_format `{{.line}}`",
+          "key": "Q-df73f6a9-a449-42ee-bf11-a09d0f7590c4-0",
+          "queryType": "range",
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          }
+        }
+      ],
+      "title": "Server Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "pilot",
+          "value": "pilot"
+        },
+        "description": "The Kubernetes namespace to view information about",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "pilot",
+            "value": "pilot"
+          }
+        ],
+        "query": "pilot",
+        "queryValue": "pilot",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "description": "Raw text string to filter server log lines",
+        "hide": 0,
+        "label": "Log Filter",
+        "name": "logfilter",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sematic Server",
+  "uid": "33h1gao4k",
+  "version": 6,
+  "weekStart": ""
+}

--- a/helm/sematic-grafana-dashboards/templates/sematic_server_dashboard_configmap.yaml
+++ b/helm/sematic-grafana-dashboards/templates/sematic_server_dashboard_configmap.yaml
@@ -92,7 +92,7 @@ data:
       "targets": [
         {
           "editorMode": "code",
-          "expr": "{app=\"sematic-server\", namespace=\"pilot\"} != `socket` != `kube-probe` | json line=\"log\" | line_format `{{.line}}`",
+          "expr": "{app=\"sematic-server\", namespace=\"{{ .Values.sematic_server_namespace }}\"} != `socket` != `kube-probe` | json line=\"log\" | line_format `{{.line}}`",
           "key": "Q-df73f6a9-a449-42ee-bf11-a09d0f7590c4-0",
           "queryType": "range",
           "refId": "A",
@@ -115,8 +115,8 @@ data:
       {
         "current": {
           "selected": true,
-          "text": "pilot",
-          "value": "pilot"
+          "text": "{{ .Values.sematic_server_namespace }}",
+          "value": "{{ .Values.sematic_server_namespace }}"
         },
         "description": "The Kubernetes namespace to view information about",
         "hide": 0,
@@ -126,12 +126,12 @@ data:
         "options": [
           {
             "selected": true,
-            "text": "pilot",
-            "value": "pilot"
+            "text": "{{ .Values.sematic_server_namespace }}",
+            "value": "{{ .Values.sematic_server_namespace }}"
           }
         ],
-        "query": "pilot",
-        "queryValue": "pilot",
+        "query": "{{ .Values.sematic_server_namespace }}",
+        "queryValue": "{{ .Values.sematic_server_namespace }}",
         "skipUrlSync": false,
         "type": "custom"
       },

--- a/helm/sematic-grafana-dashboards/values.yaml
+++ b/helm/sematic-grafana-dashboards/values.yaml
@@ -1,0 +1,2 @@
+sematic_server_namespace: default
+sematic_server_dashboard_url: https://my.sematic


### PR DESCRIPTION
creates a separate helm package called `sematic-grafana-dashboards`, that will be served up by the same helm release mechanism we currently have in the `sematic-ai/helm-charts` repo, i.e. it will share the same `index.yaml` file in that repo, but will be it's own standalone helm package that must be installed separately by the user.