### PR TITLE
Add `LOCAL_STORAGE_PATH` to config map

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -23,9 +23,9 @@ data:
 {{ end }}
 {{ if .Values.local_storage.enabled }}
   STORAGE: "sematic.plugins.storage.local_storage.LocalStorage"
-  {{ if .Values.local_storage.local_storage_path }}
-    LOCAL_STORAGE_PATH: {{ .Values.local_storage.local_storage_path | quote }}
-  {{ end }}
+{{ if .Values.local_storage.local_storage_path }}
+  LOCAL_STORAGE_PATH: {{ .Values.local_storage.local_storage_path | quote }}
+{{ end }}
 {{ end }}
 {{ if .Values.slack.enabled }}
   PUBLISH: "sematic.plugins.publishing.slack.SlackPublisher"

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -21,6 +21,12 @@ data:
   AWS_S3_REGION: {{ .Values.aws.bucket_region | quote }}
   STORAGE: "sematic.plugins.storage.s3_storage.S3Storage"
 {{ end }}
+{{ if .Values.local_storage.enabled }}
+  STORAGE: "sematic.plugins.storage.local_storage.LocalStorage"
+  {{ if .Values.local_storage.local_storage_path }}
+    LOCAL_STORAGE_PATH: {{ .Values.local_storage_path | quote }}
+  {{ end }}
+{{ end }}
 {{ if .Values.slack.enabled }}
   PUBLISH: "sematic.plugins.publishing.slack.SlackPublisher"
   SLACK_WEBHOOK_TOKEN: {{ .Values.slack.slack_webhook_token | quote }}

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
 {{ if .Values.local_storage.enabled }}
   STORAGE: "sematic.plugins.storage.local_storage.LocalStorage"
   {{ if .Values.local_storage.local_storage_path }}
-    LOCAL_STORAGE_PATH: {{ .Values.local_storage_path | quote }}
+    LOCAL_STORAGE_PATH: {{ .Values.local_storage.local_storage_path | quote }}
   {{ end }}
 {{ end }}
 {{ if .Values.slack.enabled }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -8,6 +8,10 @@ aws:
   storage_bucket: my-s3-bucket # REPLACE ME
   bucket_region: my-s3-region # REPLACE ME
 
+local_storage:
+  enabled: false
+  local_storage_path: /path/to/storage # REPLACE ME. Optional, defaults to ~/.sematic/data
+
 slack:
   enabled: true
   slack_webhook_token: XXX/YYY/ZZZ # REPLACE ME


### PR DESCRIPTION
When local storage is selected, users can customize the storage location. This PR exposes this to the config map.