### PR TITLE
Fix malformed API client error message

### DIFF
--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -214,7 +214,9 @@ def schedule_resolution_endpoint(
         resolution, updated = _update_resolution_user(resolution=resolution, user=user)
         if updated:
             logger.debug(
-                "Updated Resolution %s User to %s", resolution.root_id, resolution.user_id
+                "Updated Resolution %s User to %s",
+                resolution.root_id,
+                resolution.user_id,
             )
             save_resolution(resolution)
 

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -24,6 +24,7 @@ from sematic.api.endpoints.events import (
 )
 from sematic.api.endpoints.payloads import get_resolution_payload
 from sematic.api.endpoints.request_parameters import jsonify_error
+from sematic.config.settings import MissingSettingsError
 from sematic.config.user_settings import UserSettingsVar
 from sematic.db.models.factories import clone_resolution, clone_root_run
 from sematic.db.models.resolution import InvalidResolution, Resolution, ResolutionStatus
@@ -209,22 +210,29 @@ def schedule_resolution_endpoint(
             status=HTTPStatus.BAD_REQUEST,
         )
 
-    resolution, updated = _update_resolution_user(resolution=resolution, user=user)
-    if updated:
-        logger.debug(
-            "Updated Resolution %s User to %s", resolution.root_id, resolution.user_id
+    try:
+        resolution, updated = _update_resolution_user(resolution=resolution, user=user)
+        if updated:
+            logger.debug(
+                "Updated Resolution %s User to %s", resolution.root_id, resolution.user_id
+            )
+            save_resolution(resolution)
+
+        resolution, post_schedule_job = schedule_resolution(
+            resolution=resolution,
+            max_parallelism=max_parallelism,
+            rerun_from=rerun_from,
         )
+
+        logger.info("Scheduled resolution with job %s", post_schedule_job.identifier())
         save_resolution(resolution)
+        save_job(post_schedule_job)
 
-    resolution, post_schedule_job = schedule_resolution(
-        resolution=resolution,
-        max_parallelism=max_parallelism,
-        rerun_from=rerun_from,
-    )
+    except MissingSettingsError as e:
+        return jsonify_error(str(e), status=HTTPStatus.BAD_REQUEST)
 
-    logger.info("Scheduled resolution with job %s", post_schedule_job.identifier())
-    save_resolution(resolution)
-    save_job(post_schedule_job)
+    except Exception as e:
+        return jsonify_error(str(e), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
     payload = dict(content=get_resolution_payload(resolution))
 

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -754,14 +754,19 @@ def _raise_for_response(
     exception: Optional[Exception] = None
     url, method = response.url, response.request.method
 
-    error_message = None
+    details = "Please check the Sematic Server logs for more information."
     could_load_json = False
     try:
         response_json = response.json()
         could_load_json = True
+
         error_message = response_json.get("error", None)
         if error_message is not None:
-            error_message = f"The server provided the error message: {error_message}."
+            details = (
+                f"The Server provided the following error message:"
+                f"\n{error_message}\n{details}"
+            )
+
     except Exception:
         pass
 
@@ -771,17 +776,13 @@ def _raise_for_response(
     elif 400 <= response.status_code < 500:
         exception = BadRequestError(
             f"The {method} request to {url} was invalid, "
-            f"response was {response.status_code}. "
-            f"{error_message} "
-            f"Please check the Sematic server logs for more information."
+            f"response was {response.status_code}. {details}"
         )
 
     elif response.status_code >= 500:
         exception = ServerError(
             f"The Sematic server could not handle the "
-            f"{method} request to {url}. "
-            f"{error_message}"
-            f"Please check the Sematic server logs for more information."
+            f"{method} request to {url}. {details}"
         )
 
     if exception is None and validate_json and not could_load_json:


### PR DESCRIPTION
Fixes an issue where the API Client logs a malformed error message:
```
sematic.api_client.ServerError: The Sematic server could not handle the POST request to http://127.0.0.1:5001/api/v1/resolutions/44fe6d5a6a9743fc86206ce13091fb62/schedule. NonePlease check the Sematic server logs for more information.
```

The problem is here: `[...]/schedule. NonePlease check the [...]`

After fixing the error message format:
```
sematic.api_client.ServerError: The Sematic server could not handle the POST request to http://127.0.0.1:5001/api/v1/resolutions/2c8d8da0322644689064cda9390bef5c/schedule. Please check the Sematic Server logs for more information.
```

And after fixing this particular endpoint's error handling:
```
sematic.api_client.BadRequestError: The POST request to http://127.0.0.1:5001/api/v1/resolutions/0b2bc556d6174e79ab8d2c96ab7d0d8f/schedule was invalid, response was 400. The Server provided the following error message:

Missing setting:

Set it with:

    $ sematic server-settings set KUBERNETES_NAMESPACE VALUE

Please check the Sematic Server logs for more information.
```

All endpoints need to be audited and their error handling fixed, but this is out of scope for this fix.
