### PR TITLE
Constrain plotly version for MNIST example

### DIFF
--- a/sematic/examples/mnist/pytorch/requirements.txt
+++ b/sematic/examples/mnist/pytorch/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchvision
 torchmetrics
-plotly
+plotly>=5.5.0
 pandas
 scikit-learn


### PR DESCRIPTION
The MNIST code uses plotly APIs that are only available after 5.5.0.