### PR TITLE
Refactoring "garbage" endpoints into existing search

### DIFF
--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -74,6 +74,7 @@ sematic_py_lib(
         ":payloads",
         ":request_parameters",
         "//sematic/api:app",
+        "//sematic/api/endpoints:request_parameters",
         "//sematic/db:queries",
         "//sematic/db/models:resolution",
         "//sematic/db/models:user",

--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -74,7 +74,6 @@ sematic_py_lib(
         ":payloads",
         ":request_parameters",
         "//sematic/api:app",
-        "//sematic/api/endpoints:request_parameters",
         "//sematic/db:queries",
         "//sematic/db/models:resolution",
         "//sematic/db/models:user",

--- a/sematic/api/endpoints/artifacts.py
+++ b/sematic/api/endpoints/artifacts.py
@@ -25,8 +25,12 @@ logger = logging.getLogger(__name__)
 @sematic_api.route("/api/v1/artifacts", methods=["GET"])
 @authenticate
 def list_artifacts_endpoint(user: Optional[User] = None) -> flask.Response:
-    limit, order, _, _, sql_predicates = get_request_parameters(
-        args=flask.request.args, model=Artifact
+
+    parameters = get_request_parameters(args=flask.request.args, model=Artifact)
+    limit, order, sql_predicates = (
+        parameters.limit,
+        parameters.order,
+        parameters.filters,
     )
 
     with db().get_session() as session:

--- a/sematic/api/endpoints/edges.py
+++ b/sematic/api/endpoints/edges.py
@@ -13,8 +13,11 @@ from sematic.db.models.edge import Edge
 
 @sematic_api.route("/api/v1/edges", methods=["GET"])
 def list_edges_endpoint() -> flask.Response:
-    limit, order, _, _, sql_predicates = get_request_parameters(
-        args=flask.request.args, model=Edge
+    parameters = get_request_parameters(args=flask.request.args, model=Edge)
+    limit, order, sql_predicates = (
+        parameters.limit,
+        parameters.order,
+        parameters.filters,
     )
 
     with db().get_session() as session:

--- a/sematic/api/endpoints/notes.py
+++ b/sematic/api/endpoints/notes.py
@@ -25,9 +25,10 @@ from sematic.db.queries import delete_note, get_note, save_note
 @sematic_api.route("/api/v1/notes", methods=["GET"])
 @authenticate
 def list_notes_endpoint(user: Optional[User]) -> flask.Response:
-    limit, order, _, _, sql_predicates = get_request_parameters(
+    parameters = get_request_parameters(
         args=flask.request.args, model=Note, default_order="asc"
     )
+    order, sql_predicates = parameters.order, parameters.filters
 
     with db().get_session() as session:
         query = session.query(Note)

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -149,9 +149,9 @@ def list_garbage_ids(
             f"Cannot use group by with filter {garbage_filter}",
             status=HTTPStatus.BAD_REQUEST,
         )
-    if parameters.fields != ["id"]:
+    if parameters.fields != [id_field]:
         return jsonify_error(
-            f"Filter {garbage_filter} must have include=['id'] set.",
+            f"Filter {garbage_filter} must have include=['{id_field}'] set.",
             status=HTTPStatus.BAD_REQUEST,
         )
 

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -3,8 +3,19 @@ import json
 import logging
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Any, Callable, Dict, List, Literal, Tuple, Type, Optional, Union, cast
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+from urllib.parse import urlsplit, urlunsplit
 
 # Third-party
 import flask
@@ -40,16 +51,18 @@ class SearchRequestParameters:
     cursor: Optional[str]
     group_by: Optional[sqlalchemy.Column]
     filters: Optional[BooleanClauseList]
-    include_fields: Optional[List[str]]
+    fields: Optional[List[str]]
 
 
-def get_garbage_filters(request_args: Dict[str, str], supported_filters: List[str]) -> Tuple[bool, List[str]]:
+def get_garbage_filters(
+    request_args: Dict[str, str], supported_filters: List[str]
+) -> Tuple[bool, List[str]]:
     filters_json: str = request_args.get("filters", "{}")
     try:
         filters: Dict = json.loads(filters_json)
     except Exception as e:
         raise ValueError(f"Malformed filters: {filters_json}, error: {e}")
-    
+
     operand = list(filters.keys())[0]
     contained_extra_filters = False
 
@@ -63,43 +76,67 @@ def get_garbage_filters(request_args: Dict[str, str], supported_filters: List[st
                 contained_extra_filters = True
                 continue
             if filter_[filter_name] != {"eq": True}:
-                raise ValueError(f"The filter '{filter_name}' must use the predicate {'eq: true'}")
+                raise ValueError(
+                    f"The filter '{filter_name}' must use the predicate {'eq: true'}"
+                )
             garbage_filters.append(filter_name)
-        
+
         return contained_extra_filters, garbage_filters
-        
+
     else:
         filter_ = cast(ColumnPredicate, filters)
         filter_name = list(filter_.keys())[0]
         if filter_name not in supported_filters:
             return True, []
         if filter_[filter_name] != {"eq": True}:
-            raise ValueError(f"The filter '{filter_name}' must use the predicate {'eq: true'}")
+            raise ValueError(
+                f"The filter '{filter_name}' must use the predicate {'eq: true'}"
+            )
         return False, [filter_name]
 
 
-def list_garbage_ids(garbage_filter: str, request_url: str, queries: Dict[str, Callable[[], List[str]]], model: Type[Any], encoded_request_args: str) -> flask.Response:
+def list_garbage_ids(
+    garbage_filter: str,
+    request_url: str,
+    queries: Dict[str, Callable[[], List[str]]],
+    model: Type[Any],
+    encoded_request_args: str,
+    id_field: Optional[str] = None,
+) -> flask.Response:
     request_args = dict(flask.request.args)
     if "limit" in request_args:
-        return jsonify_error(f"Cannot use limit with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
+        return jsonify_error(
+            f"Cannot use limit with filter {garbage_filter}",
+            status=HTTPStatus.BAD_REQUEST,
+        )
     del request_args["filters"]
     try:
         parameters = get_request_parameters(args=request_args, model=model)
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
     if parameters.cursor is not None:
-        return jsonify_error(f"Cannot use pagination with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
+        return jsonify_error(
+            f"Cannot use pagination with filter {garbage_filter}",
+            status=HTTPStatus.BAD_REQUEST,
+        )
     if parameters.group_by is not None:
-        return jsonify_error(f"Cannot use group by with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
-    if parameters.include_fields != ["id"]:
-        return jsonify_error(f"Filter {garbage_filter} must have include=['id'] set.", status=HTTPStatus.BAD_REQUEST)
-    
+        return jsonify_error(
+            f"Cannot use group by with filter {garbage_filter}",
+            status=HTTPStatus.BAD_REQUEST,
+        )
+    if parameters.fields != ["id"]:
+        return jsonify_error(
+            f"Filter {garbage_filter} must have include=['id'] set.",
+            status=HTTPStatus.BAD_REQUEST,
+        )
+
     scheme, netloc, path, _, fragment = urlsplit(request_url)
     current_page_url = urlunsplit(
-        (scheme, netloc, path, urlencode(encoded_request_args), fragment)
+        (scheme, netloc, path, encoded_request_args, fragment)
     )
 
     ids = queries[garbage_filter]()
+    id_field = "id" if id_field is None else id_field
 
     payload = dict(
         current_page_url=current_page_url,
@@ -107,7 +144,7 @@ def list_garbage_ids(garbage_filter: str, request_url: str, queries: Dict[str, C
         limit=len(ids),
         next_cursor=None,
         after_cursor_count=0,
-        content=ids,
+        content=[{id_field: id_ for id_ in ids}],
     )
     return flask.jsonify(payload)
 
@@ -176,7 +213,7 @@ def get_request_parameters(
             f"{list(ORDER_BY_DIRECTIONS.keys())}; got: '{args.get('order')}'"
         )
 
-    include_fields_json: str = args.get("include", "null")
+    include_fields_json: str = args.get("fields", "null")
     try:
         include_fields: Optional[List[str]] = json.loads(include_fields_json)
     except Exception as e:

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -166,6 +166,7 @@ def list_garbage_ids(
         whose key is the string specified by `id_field` and whose value is an id.
     """
     request_args = dict(flask.request.args)
+    id_field = id_field or "id"
     if "limit" in request_args:
         return jsonify_error(
             f"Cannot use limit with filter {garbage_filter}",
@@ -198,7 +199,6 @@ def list_garbage_ids(
     )
 
     ids = queries[garbage_filter]()
-    id_field = "id" if id_field is None else id_field
 
     payload = dict(
         current_page_url=current_page_url,

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -1,8 +1,10 @@
 # Standard Library
 import json
 import logging
+from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Literal, Tuple, Type, Optional, Union, cast
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 # Third-party
 import flask
@@ -31,17 +33,90 @@ Filters = Union[
 ]
 
 
+@dataclass
+class SearchRequestParameters:
+    limit: int
+    order: Callable[[Any], Any]
+    cursor: Optional[str]
+    group_by: Optional[sqlalchemy.Column]
+    filters: Optional[BooleanClauseList]
+    include_fields: Optional[List[str]]
+
+
+def get_garbage_filters(request_args: Dict[str, str], supported_filters: List[str]) -> Tuple[bool, List[str]]:
+    filters_json: str = request_args.get("filters", "{}")
+    try:
+        filters: Dict = json.loads(filters_json)
+    except Exception as e:
+        raise ValueError(f"Malformed filters: {filters_json}, error: {e}")
+    
+    operand = list(filters.keys())[0]
+    contained_extra_filters = False
+
+    if operand in {"AND", "OR"}:
+        filters = cast(BooleanPredicate, filters)
+        operand = cast(Literal["AND", "OR"], operand)
+        garbage_filters = []
+        for filter_ in filters[operand]:
+            filter_name = list(filter_.keys())[0]
+            if filter_name not in supported_filters:
+                contained_extra_filters = True
+                continue
+            if filter_[filter_name] != {"eq": True}:
+                raise ValueError(f"The filter '{filter_name}' must use the predicate {'eq: true'}")
+            garbage_filters.append(filter_name)
+        
+        return contained_extra_filters, garbage_filters
+        
+    else:
+        filter_ = cast(ColumnPredicate, filters)
+        filter_name = list(filter_.keys())[0]
+        if filter_name not in supported_filters:
+            return True, []
+        if filter_[filter_name] != {"eq": True}:
+            raise ValueError(f"The filter '{filter_name}' must use the predicate {'eq: true'}")
+        return False, [filter_name]
+
+
+def list_garbage_ids(garbage_filter: str, request_url: str, queries: Dict[str, Callable[[], List[str]]], model: Type[Any], encoded_request_args: str) -> flask.Response:
+    request_args = dict(flask.request.args)
+    if "limit" in request_args:
+        return jsonify_error(f"Cannot use limit with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
+    del request_args["filters"]
+    try:
+        parameters = get_request_parameters(args=request_args, model=model)
+    except ValueError as e:
+        return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
+    if parameters.cursor is not None:
+        return jsonify_error(f"Cannot use pagination with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
+    if parameters.group_by is not None:
+        return jsonify_error(f"Cannot use group by with filter {garbage_filter}", status=HTTPStatus.BAD_REQUEST)
+    if parameters.include_fields != ["id"]:
+        return jsonify_error(f"Filter {garbage_filter} must have include=['id'] set.", status=HTTPStatus.BAD_REQUEST)
+    
+    scheme, netloc, path, _, fragment = urlsplit(request_url)
+    current_page_url = urlunsplit(
+        (scheme, netloc, path, urlencode(encoded_request_args), fragment)
+    )
+
+    ids = queries[garbage_filter]()
+
+    payload = dict(
+        current_page_url=current_page_url,
+        next_page_url=None,
+        limit=len(ids),
+        next_cursor=None,
+        after_cursor_count=0,
+        content=ids,
+    )
+    return flask.jsonify(payload)
+
+
 def get_request_parameters(
     args: Dict[str, str],
     model: type,
     default_order: Literal["asc", "desc"] = "desc",
-) -> Tuple[
-    int,
-    Callable,
-    Optional[str],
-    Optional[sqlalchemy.Column],
-    Optional[BooleanClauseList],
-]:
+) -> SearchRequestParameters:
     """
     Extract, validate, and format query parameters.
 
@@ -57,13 +132,7 @@ def get_request_parameters(
 
     Returns
     -------
-    Tuple[
-        int,
-        Callable,
-        Optional[str],
-        Optional[sqlalchemy.Column],
-        List[ColumnElement]
-    ] : limit, order, cursor, group_by, filters
+    SearchRequestParameters
     """
     logger.debug("Raw request parameters: %s; model: %s", args, model)
 
@@ -107,7 +176,15 @@ def get_request_parameters(
             f"{list(ORDER_BY_DIRECTIONS.keys())}; got: '{args.get('order')}'"
         )
 
-    return limit, order, cursor, group_by_column, sql_predicates
+    include_fields_json: str = args.get("include", "null")
+    try:
+        include_fields: Optional[List[str]] = json.loads(include_fields_json)
+    except Exception as e:
+        raise ValueError(f"Malformed include fields: {include_fields}, error: {e}")
+
+    return SearchRequestParameters(
+        limit, order, cursor, group_by_column, sql_predicates, include_fields
+    )
 
 
 def jsonify_error(error: str, status: HTTPStatus):

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -128,6 +128,43 @@ def list_garbage_ids(
     encoded_request_args: str,
     id_field: Optional[str] = None,
 ) -> flask.Response:
+    """Return a flask response for a search on ids of garbage data.
+
+    Parameters
+    ----------
+    garbage_filter:
+        A string representing which garbage collection filter is being used.
+    request_url:
+        The URL used to perform the search request.
+    queries:
+        A mapping from garbage collection filter name to a callable to perform
+        the query.
+    model:
+        The ORM model for the object being searched over.
+    encoded_request_args:
+        URL-encoded query parameters for the current search request.
+    id_field:
+        The name of the field representing the id of the object being searched over.
+        When `None`, "id" will be used as the name of the id field. Defaults to None.
+
+    Returns
+    -------
+    A flask response containing the search results. The fields of the response object
+    are:
+    current_page_url
+        URL of the current page.
+    next_page_url
+        Always `None` (present for compatibility with other search APIs).
+    limit
+        The number of results returned.
+    next_cursor
+        Always `None` (present for compatibility with other search APIs).
+    after_cursor_count
+        Always 0 (present for compatibility with other search APIs).
+    content:
+        A list of id JSON payloads. Each element in the returned list is a dict
+        whose key is the string specified by `id_field` and whose value is an id.
+    """
     request_args = dict(flask.request.args)
     if "limit" in request_args:
         return jsonify_error(

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -62,6 +62,9 @@ def get_garbage_filters(
         filters: Dict = json.loads(filters_json)
     except Exception as e:
         raise ValueError(f"Malformed filters: {filters_json}, error: {e}")
+    
+    if len(filters) == 0:
+        return False, []
 
     operand = list(filters.keys())[0]
     contained_extra_filters = False
@@ -90,7 +93,7 @@ def get_garbage_filters(
             return True, []
         if filter_[filter_name] != {"eq": True}:
             raise ValueError(
-                f"The filter '{filter_name}' must use the predicate {'eq: true'}"
+                "The filter '{}' must use the predicate {}".format(filter_name, "{'eq': True}")
             )
         return False, [filter_name]
 

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -169,7 +169,7 @@ def list_garbage_ids(
         limit=len(ids),
         next_cursor=None,
         after_cursor_count=0,
-        content=[{id_field: id_ for id_ in ids}],
+        content=[{id_field: id_} for id_ in ids],
     )
     return flask.jsonify(payload)
 

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -54,15 +54,35 @@ class SearchRequestParameters:
     fields: Optional[List[str]]
 
 
-def get_garbage_filters(
+def get_gc_filters(
     request_args: Dict[str, str], supported_filters: List[str]
 ) -> Tuple[bool, List[str]]:
+    """Get filters for garbage collection (gc).
+
+    Garbage collection filters are either present or not, so
+    when returned they are returned as a list of the names of
+    filters that were present.
+
+    Parameters
+    ----------
+    request_args:
+        The flask request args the filters were specified in.
+    supported_filters:
+        The supported garbage collection filters, as a list of
+        the names of said filters.
+
+    Returns
+    -------
+    A tuple where the first element is a bool indicating if there were
+    extra filters besides the garbage collection ones, and the second
+    element is a list of garbage collection filters that were identified.
+    """
     filters_json: str = request_args.get("filters", "{}")
     try:
         filters: Dict = json.loads(filters_json)
     except Exception as e:
         raise ValueError(f"Malformed filters: {filters_json}, error: {e}")
-    
+
     if len(filters) == 0:
         return False, []
 
@@ -93,7 +113,9 @@ def get_garbage_filters(
             return True, []
         if filter_[filter_name] != {"eq": True}:
             raise ValueError(
-                "The filter '{}' must use the predicate {}".format(filter_name, "{'eq': True}")
+                "The filter '{}' must use the predicate {}".format(
+                    filter_name, "{'eq': True}"
+                )
             )
         return False, [filter_name]
 

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -100,7 +100,9 @@ def get_gc_filters(
                 continue
             if filter_[filter_name] != {"eq": True}:
                 raise ValueError(
-                    f"The filter '{filter_name}' must use the predicate {'eq: true'}"
+                    "The filter '{}' must use the predicate {}".format(
+                        filter_name, {"eq: true"}
+                    )
                 )
             garbage_filters.append(filter_name)
 
@@ -189,7 +191,7 @@ def list_garbage_ids(
         )
     if parameters.fields != [id_field]:
         return jsonify_error(
-            f"Filter {garbage_filter} must have include=['{id_field}'] set.",
+            f"Filter {garbage_filter} must have \"fields=['{id_field}']\" set.",
             status=HTTPStatus.BAD_REQUEST,
         )
 
@@ -279,7 +281,7 @@ def get_request_parameters(
     try:
         include_fields: Optional[List[str]] = json.loads(include_fields_json)
     except Exception as e:
-        raise ValueError(f"Malformed include fields: {include_fields}, error: {e}")
+        raise ValueError(f"Malformed include fields: {include_fields}") from e
 
     return SearchRequestParameters(
         limit, order, cursor, group_by_column, sql_predicates, include_fields

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -460,11 +460,10 @@ def list_resolutions_endpoint(user: Optional[User]) -> flask.Response:
         Cursor to obtain next page. Already included in `next_page_url`.
     after_cursor_count : int
         Number of items remain after the current cursor, i.e. including the current page.
-    content: List[Run]
+    content : List[Dict[str, str]]
         A list of resolution JSON payloads, if the 'fields' request parameter was not set.
         If the 'fields' parameter was set to ['root_id'], returns a list of resolution
         ids. The size of the list is `limit` or less if current page is last page.
-        Defaults to None.
     """
     request_args = dict(flask.request.args)
     contained_extra_filters, garbage_filters = get_gc_filters(

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 from http import HTTPStatus
 from typing import Optional, Tuple, Union
+from urllib.parse import urlencode
 
 # Third-party
 import flask
@@ -23,7 +24,11 @@ from sematic.api.endpoints.events import (
     broadcast_resolution_cancel,
 )
 from sematic.api.endpoints.payloads import get_resolution_payload
-from sematic.api.endpoints.request_parameters import jsonify_error
+from sematic.api.endpoints.request_parameters import (
+    get_gc_filters,
+    jsonify_error,
+    list_garbage_ids,
+)
 from sematic.config.settings import MissingSettingsError
 from sematic.config.user_settings import UserSettingsVar
 from sematic.db.models.factories import clone_resolution, clone_root_run
@@ -49,6 +54,10 @@ from sematic.scheduling.job_scheduler import clean_jobs, schedule_resolution
 from sematic.scheduling.kubernetes import cancel_job
 
 logger = logging.getLogger(__name__)
+
+_GARBAGE_COLLECTION_QUERIES = {
+    "orphaned_jobs": get_resolutions_with_orphaned_jobs,
+}
 
 
 @sematic_api.route("/api/v1/resolutions/<resolution_id>", methods=["GET"])
@@ -419,17 +428,70 @@ def _update_resolution_user(
     return resolution, True
 
 
-@sematic_api.route("/api/v1/resolutions/with_orphaned_jobs", methods=["GET"])
+@sematic_api.route("/api/v1/resolutions", methods=["GET"])
 @authenticate
-def get_orphaned_resolution_job_identifiers_endpoint(
-    user: Optional[User],
-) -> flask.Response:
-    resolution_ids = get_resolutions_with_orphaned_jobs()
+def list_resolutions_endpoint(user: Optional[User]) -> flask.Response:
+    """
+    GET /api/v1/resolutions endpoint.
 
-    return flask.jsonify(
-        dict(
-            content=resolution_ids,
+    The API endpoint to list and filter resolutions. Returns a JSON payload.
+
+    Parameters
+    ----------
+    filters : Optional[str]
+        Filters of the form `{"column_name": {"operator": "value"}}`. Currenrly only
+        a pseudo-column with the name of "orphaned_jobs" and type bool is supported.
+        Defaults to None.
+    fields: Optional[List[str]]
+        The fields of the run object to include in the result. If not set, all fields
+        will be returned. Currently the only supported subset of fields is ["root_id"].
+        The ["root_id"] subset must be used when the "orphaned_jobs" filter is used.
+
+    Response
+    --------
+    current_page_url : str
+        URL of the current page
+    next_page_url : Optional[str]
+        URL of the next page, if any, `null` otherwise
+    limit : int
+        Current page size. The actual number of items returned may be inferior
+        if current page is last page.
+    next_cursor : Optional[str]
+        Cursor to obtain next page. Already included in `next_page_url`.
+    after_cursor_count : int
+        Number of items remain after the current cursor, i.e. including the current page.
+    content: List[Run]
+        A list of resolution JSON payloads, if the 'fields' request parameter was not set.
+        If the 'fields' parameter was set to ['root_id'], returns a list of resolution
+        ids. The size of the list is `limit` or less if current page is last page.
+        Defaults to None.
+    """
+    request_args = dict(flask.request.args)
+    contained_extra_filters, garbage_filters = get_gc_filters(
+        request_args, list(_GARBAGE_COLLECTION_QUERIES.keys())
+    )
+    if len(garbage_filters) != 0:
+        logger.info(
+            "Searching for resolutions to garbage collect with filters: %s",
+            garbage_filters,
         )
+        if contained_extra_filters or len(garbage_filters) > 1:
+            return jsonify_error(
+                f"Filter {garbage_filters[0]} must be used alone",
+                status=HTTPStatus.BAD_REQUEST,
+            )
+        return list_garbage_ids(
+            garbage_filters[0],
+            flask.request.url,
+            _GARBAGE_COLLECTION_QUERIES,
+            Resolution,
+            urlencode(request_args),
+            id_field="root_id",
+        )
+    return jsonify_error(
+        "Currently the only supported resolution search is with the filter "
+        "'orphaned_jobs'.",
+        status=HTTPStatus.BAD_REQUEST,
     )
 
 

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -40,7 +40,7 @@ from sematic.db.queries import (
     get_graph,
     get_jobs_by_run_id,
     get_resolution,
-    get_resolutions_with_orphaned_jobs,
+    get_resolution_ids_with_orphaned_jobs,
     get_resources_by_root_id,
     get_run,
     get_run_graph,
@@ -56,7 +56,7 @@ from sematic.scheduling.kubernetes import cancel_job
 logger = logging.getLogger(__name__)
 
 _GARBAGE_COLLECTION_QUERIES = {
-    "orphaned_jobs": get_resolutions_with_orphaned_jobs,
+    "orphaned_jobs": get_resolution_ids_with_orphaned_jobs,
 }
 
 
@@ -454,7 +454,7 @@ def list_resolutions_endpoint(user: Optional[User]) -> flask.Response:
     next_page_url : Optional[str]
         URL of the next page, if any, `null` otherwise
     limit : int
-        Current page size. The actual number of items returned may be inferior
+        Current page size. The actual number of items returned may be smaller
         if current page is last page.
     next_cursor : Optional[str]
         Cursor to obtain next page. Already included in `next_page_url`.
@@ -469,28 +469,30 @@ def list_resolutions_endpoint(user: Optional[User]) -> flask.Response:
     contained_extra_filters, garbage_filters = get_gc_filters(
         request_args, list(_GARBAGE_COLLECTION_QUERIES.keys())
     )
-    if len(garbage_filters) != 0:
-        logger.info(
-            "Searching for resolutions to garbage collect with filters: %s",
-            garbage_filters,
+    logger.info(
+        "Searching for resolutions to garbage collect with filters: %s",
+        garbage_filters,
+    )
+    if len(garbage_filters) == 0:
+        return jsonify_error(
+            "Currently the only supported resolution search is with the filter "
+            "'orphaned_jobs'.",
+            status=HTTPStatus.BAD_REQUEST,
         )
-        if contained_extra_filters or len(garbage_filters) > 1:
-            return jsonify_error(
-                f"Filter {garbage_filters[0]} must be used alone",
-                status=HTTPStatus.BAD_REQUEST,
-            )
-        return list_garbage_ids(
-            garbage_filters[0],
-            flask.request.url,
-            _GARBAGE_COLLECTION_QUERIES,
-            Resolution,
-            urlencode(request_args),
-            id_field="root_id",
+
+    if contained_extra_filters or len(garbage_filters) > 1:
+        return jsonify_error(
+            f"Filter {garbage_filters[0]} must be used alone",
+            status=HTTPStatus.BAD_REQUEST,
         )
-    return jsonify_error(
-        "Currently the only supported resolution search is with the filter "
-        "'orphaned_jobs'.",
-        status=HTTPStatus.BAD_REQUEST,
+
+    return list_garbage_ids(
+        garbage_filters[0],
+        flask.request.url,
+        _GARBAGE_COLLECTION_QUERIES,
+        Resolution,
+        urlencode(request_args),
+        id_field="root_id",
     )
 
 

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -45,8 +45,8 @@ from sematic.db.queries import (
     get_root_graph,
     get_run,
     get_run_graph,
+    get_run_ids_with_orphaned_jobs,
     get_run_status_details,
-    get_runs_with_orphaned_jobs,
     save_graph,
     save_job,
     save_run,
@@ -66,7 +66,7 @@ class _DetectedRunRaceCondition(Exception):
 
 
 _GARBAGE_COLLECTION_QUERIES = {
-    "orphaned_jobs": get_runs_with_orphaned_jobs,
+    "orphaned_jobs": get_run_ids_with_orphaned_jobs,
 }
 
 
@@ -106,7 +106,7 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     next_page_url : Optional[str]
         URL of the next page, if any, `null` otherwise
     limit : int
-        Current page size. The actual number of items returned may be inferior
+        Current page size. The actual number of items returned may be smaller
         if current page is last page.
     next_cursor : Optional[str]
         Cursor to obtain next page. Already included in `next_page_url`.
@@ -121,23 +121,25 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     contained_extra_filters, garbage_filters = get_gc_filters(
         request_args, list(_GARBAGE_COLLECTION_QUERIES.keys())
     )
-    if len(garbage_filters) != 0:
-        logger.info(
-            "Searching for runs to garbage collect with filters: %s", garbage_filters
+    logger.info(
+        "Searching for runs to garbage collect with filters: %s", garbage_filters
+    )
+    if len(garbage_filters) == 0:
+        return _standard_list_runs(request_args)
+
+    if contained_extra_filters or len(garbage_filters) > 1:
+        return jsonify_error(
+            f"Filter {garbage_filters[0]} must be used alone",
+            status=HTTPStatus.BAD_REQUEST,
         )
-        if contained_extra_filters or len(garbage_filters) > 1:
-            return jsonify_error(
-                f"Filter {garbage_filters[0]} must be used alone",
-                status=HTTPStatus.BAD_REQUEST,
-            )
-        return list_garbage_ids(
-            garbage_filters[0],
-            flask.request.url,
-            _GARBAGE_COLLECTION_QUERIES,
-            Run,
-            urlencode(request_args),
-        )
-    return _standard_list_runs(request_args)
+
+    return list_garbage_ids(
+        garbage_filters[0],
+        flask.request.url,
+        _GARBAGE_COLLECTION_QUERIES,
+        Run,
+        urlencode(request_args),
+    )
 
 
 def _standard_list_runs(args: Dict[str, str]) -> flask.Response:

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -25,7 +25,7 @@ from sematic.api.endpoints.events import broadcast_graph_update, broadcast_job_u
 from sematic.api.endpoints.metrics import MetricEvent, save_event_metrics
 from sematic.api.endpoints.payloads import get_run_payload, get_runs_payload
 from sematic.api.endpoints.request_parameters import (
-    get_garbage_filters,
+    get_gc_filters,
     get_request_parameters,
     jsonify_error,
     list_garbage_ids,
@@ -65,7 +65,7 @@ class _DetectedRunRaceCondition(Exception):
     pass
 
 
-_GARBAGE_QUERIES = {
+_GARBAGE_COLLECTION_QUERIES = {
     "orphaned_jobs": get_runs_with_orphaned_jobs,
 }
 
@@ -112,8 +112,8 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         size of the list is `limit` or less if current page is last page.
     """
     request_args = dict(flask.request.args)
-    contained_extra_filters, garbage_filters = get_garbage_filters(
-        request_args, list(_GARBAGE_QUERIES.keys())
+    contained_extra_filters, garbage_filters = get_gc_filters(
+        request_args, list(_GARBAGE_COLLECTION_QUERIES.keys())
     )
     if len(garbage_filters) != 0:
         if contained_extra_filters or len(garbage_filters) > 1:
@@ -124,7 +124,7 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         return list_garbage_ids(
             garbage_filters[0],
             flask.request.url,
-            _GARBAGE_QUERIES,
+            _GARBAGE_COLLECTION_QUERIES,
             Run,
             urlencode(request_args),
         )

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -112,7 +112,7 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         size of the list is `limit` or less if current page is last page.
     """
     request_args = dict(flask.request.args)
-    contained_extra_filters = garbage_filters = get_garbage_filters(
+    contained_extra_filters, garbage_filters = get_garbage_filters(
         request_args, list(_GARBAGE_QUERIES.keys())
     )
     if len(garbage_filters) != 0:

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -91,7 +91,13 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         Value to group runs by. If not None, the endpoint will return
         a single run by unique value of the field passed in `group_by`.
     filters : Optional[str]
-        Filters of the form `{"column_name": {"operator": "value"}}`. Defaults to None.
+        Filters of the form `{"column_name": {"operator": "value"}}`. A pseudo-column
+        name of "orphaned_jobs" and type bool is supported. Defaults to None.
+    fields: Optional[List[str]]
+        The fields of the run object to include in the result. If not set, all fields
+        will be returned. Currently the only supported subset of fields is ["id"]. The
+        ["id"] subset must be used when the "orphaned_jobs" filter is used. Defaults to
+        None.
 
     Response
     --------
@@ -107,8 +113,8 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     after_cursor_count : int
         Number of items remain after the current cursor, i.e. including the current page.
     content: List[Run]
-        A list of run JSON payloads, if the 'include' request parameter was not set.
-        If the 'include' parameter was set to ['id'], returns a list of run ids. The
+        A list of run JSON payloads, if the 'fields' request parameter was not set.
+        If the 'fields' parameter was set to ['id'], returns a list of run ids. The
         size of the list is `limit` or less if current page is last page.
     """
     request_args = dict(flask.request.args)
@@ -140,9 +146,9 @@ def _standard_list_runs(args: Dict[str, str]) -> flask.Response:
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
-    if parameters.fields is not None:
+    if parameters.fields is not None and parameters.fields != ["id"]:
         return jsonify_error(
-            "'fields' is not supported in combination with the given filters.",
+            "'fields' must be either `None` or `['id']`",
             HTTPStatus.BAD_REQUEST,
         )
 
@@ -230,6 +236,12 @@ def _standard_list_runs(args: Dict[str, str]) -> flask.Response:
         next_page_url = urlunsplit(
             (scheme, netloc, path, urlencode(next_url_params), fragment)
         )
+
+    content = get_runs_payload(runs)
+    if parameters.fields == ["id"]:
+        # TODO: it would be better to push this field subsetting
+        # down to the DB query level, but for now we'll do it here.
+        content = [{"id": run["id"] for run in content}]
 
     payload = dict(
         current_page_url=current_page_url,

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -5,6 +5,7 @@ Module keeping all /api/v*/runs/* API endpoints.
 # Standard Library
 import base64
 import datetime
+import json
 import logging
 from dataclasses import asdict
 from http import HTTPStatus
@@ -26,6 +27,8 @@ from sematic.api.endpoints.metrics import MetricEvent, save_event_metrics
 from sematic.api.endpoints.payloads import get_run_payload, get_runs_payload
 from sematic.api.endpoints.request_parameters import (
     get_request_parameters,
+    list_garbage_ids,
+    get_garbage_filters,
     jsonify_error,
 )
 from sematic.db.db import db
@@ -62,6 +65,10 @@ logger = logging.getLogger(__name__)
 class _DetectedRunRaceCondition(Exception):
     pass
 
+
+_GARBAGE_QUERIES = {
+    "orphaned_jobs": get_runs_with_orphaned_jobs,
+}
 
 @sematic_api.route("/api/v1/runs", methods=["GET"])
 @authenticate
@@ -100,15 +107,41 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
     after_cursor_count : int
         Number of items remain after the current cursor, i.e. including the current page.
     content: List[Run]
-        A list of run JSON payloads. The size of the list is `limit` or less if
-        current page is last page.
+        A list of run JSON payloads, if the 'include' request parameter was not set.
+        If the 'include' parameter was set to ['id'], returns a list of run ids. The
+        size of the list is `limit` or less if current page is last page.
     """
+    request_args = dict(flask.request.args)
+    contained_extra_filters = garbage_filters = get_garbage_filters(request_args, list(_GARBAGE_QUERIES.keys()))
+    if len(garbage_filters) != 0:
+        if contained_extra_filters or len(garbage_filters) > 1:
+            return jsonify_error(
+                f"Filter {garbage_filters[0]} must be used alone",
+                status=HTTPStatus.BAD_REQUEST,
+            )
+        return list_garbage_ids(garbage_filters[0], flask.request.url, _GARBAGE_QUERIES, Run, urlencode(request_args))
+    return _standard_list_runs(request_args)
+
+
+def _standard_list_runs(args: Dict[str, str]) -> flask.Response:
     try:
-        limit, order, cursor, group_by_column, sql_predicates = get_request_parameters(
-            args=flask.request.args, model=Run
-        )
+        parameters = get_request_parameters(args=args, model=Run)
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
+
+    if parameters.include_fields != None:
+        return jsonify_error(
+            "'include' is not supported in combination with the given filters.",
+            HTTPStatus.BAD_REQUEST,
+        )
+
+    limit, order, cursor, group_by_column, sql_predicates = (
+        parameters.limit,
+        parameters.order,
+        parameters.cursor,
+        parameters.group_by,
+        parameters.filters,
+    )
 
     decoded_cursor: Optional[str] = None
     if cursor is not None:

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -5,7 +5,6 @@ Module keeping all /api/v*/runs/* API endpoints.
 # Standard Library
 import base64
 import datetime
-import json
 import logging
 from dataclasses import asdict
 from http import HTTPStatus
@@ -26,10 +25,10 @@ from sematic.api.endpoints.events import broadcast_graph_update, broadcast_job_u
 from sematic.api.endpoints.metrics import MetricEvent, save_event_metrics
 from sematic.api.endpoints.payloads import get_run_payload, get_runs_payload
 from sematic.api.endpoints.request_parameters import (
-    get_request_parameters,
-    list_garbage_ids,
     get_garbage_filters,
+    get_request_parameters,
     jsonify_error,
+    list_garbage_ids,
 )
 from sematic.db.db import db
 from sematic.db.models.artifact import Artifact
@@ -69,6 +68,7 @@ class _DetectedRunRaceCondition(Exception):
 _GARBAGE_QUERIES = {
     "orphaned_jobs": get_runs_with_orphaned_jobs,
 }
+
 
 @sematic_api.route("/api/v1/runs", methods=["GET"])
 @authenticate
@@ -112,14 +112,22 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         size of the list is `limit` or less if current page is last page.
     """
     request_args = dict(flask.request.args)
-    contained_extra_filters = garbage_filters = get_garbage_filters(request_args, list(_GARBAGE_QUERIES.keys()))
+    contained_extra_filters = garbage_filters = get_garbage_filters(
+        request_args, list(_GARBAGE_QUERIES.keys())
+    )
     if len(garbage_filters) != 0:
         if contained_extra_filters or len(garbage_filters) > 1:
             return jsonify_error(
                 f"Filter {garbage_filters[0]} must be used alone",
                 status=HTTPStatus.BAD_REQUEST,
             )
-        return list_garbage_ids(garbage_filters[0], flask.request.url, _GARBAGE_QUERIES, Run, urlencode(request_args))
+        return list_garbage_ids(
+            garbage_filters[0],
+            flask.request.url,
+            _GARBAGE_QUERIES,
+            Run,
+            urlencode(request_args),
+        )
     return _standard_list_runs(request_args)
 
 
@@ -129,9 +137,9 @@ def _standard_list_runs(args: Dict[str, str]) -> flask.Response:
     except ValueError as e:
         return jsonify_error(str(e), HTTPStatus.BAD_REQUEST)
 
-    if parameters.include_fields != None:
+    if parameters.fields is not None:
         return jsonify_error(
-            "'include' is not supported in combination with the given filters.",
+            "'fields' is not supported in combination with the given filters.",
             HTTPStatus.BAD_REQUEST,
         )
 

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -112,7 +112,7 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         Cursor to obtain next page. Already included in `next_page_url`.
     after_cursor_count : int
         Number of items remain after the current cursor, i.e. including the current page.
-    content: List[Run]
+    content : List[Run]
         A list of run JSON payloads, if the 'fields' request parameter was not set.
         If the 'fields' parameter was set to ['id'], returns a list of run ids. The
         size of the list is `limit` or less if current page is last page.

--- a/sematic/api/endpoints/runs.py
+++ b/sematic/api/endpoints/runs.py
@@ -116,6 +116,9 @@ def list_runs_endpoint(user: Optional[User]) -> flask.Response:
         request_args, list(_GARBAGE_COLLECTION_QUERIES.keys())
     )
     if len(garbage_filters) != 0:
+        logger.info(
+            "Searching for runs to garbage collect with filters: %s", garbage_filters
+        )
         if contained_extra_filters or len(garbage_filters) > 1:
             return jsonify_error(
                 f"Filter {garbage_filters[0]} must be used alone",
@@ -616,18 +619,6 @@ def get_run_jobs(user: Optional[User], run_id: str) -> flask.Response:
     return flask.jsonify(
         dict(
             content=jobs,
-        )
-    )
-
-
-@sematic_api.route("/api/v1/runs/with_orphaned_jobs", methods=["GET"])
-@authenticate
-def get_orphaned_job_identifiers_endpoint(user: Optional[User]) -> flask.Response:
-    run_ids = get_runs_with_orphaned_jobs()
-
-    return flask.jsonify(
-        dict(
-            content=run_ids,
         )
     )
 

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -78,7 +78,7 @@ test_list_external_resource_auth = make_auth_test(
 
 
 @pytest.fixture
-def mock_get_resolutions_with_orphaned_jobs():
+def mock_get_resolution_ids_with_orphaned_jobs():
     with mock.patch(
         "sematic.api.endpoints.resolutions._GARBAGE_COLLECTION_QUERIES"
     ) as mock_query_dict:
@@ -379,7 +379,7 @@ def test_clean_resolution_jobs(
 
 def test_list_resolutions_search_orphaned_jobs(
     mock_auth,  # noqa: F811
-    mock_get_resolutions_with_orphaned_jobs,  # noqa: F811
+    mock_get_resolution_ids_with_orphaned_jobs,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
 ):
     resolutions = (
@@ -388,7 +388,7 @@ def test_list_resolutions_search_orphaned_jobs(
         make_resolution(root_id="3"),
         make_resolution(root_id="4"),
     )
-    mock_get_resolutions_with_orphaned_jobs.return_value = [
+    mock_get_resolution_ids_with_orphaned_jobs.return_value = [
         r.root_id for r in resolutions
     ]
 

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -1,10 +1,12 @@
 # Standard Library
+import json
 import time
 import typing
 from copy import copy
 from dataclasses import replace
 from http import HTTPStatus
 from unittest import mock
+from urllib.parse import urlencode
 
 # Third-party
 import flask.testing
@@ -73,6 +75,17 @@ test_rerun_resolution_auth = make_auth_test(
 test_list_external_resource_auth = make_auth_test(
     "/api/v1/resolutions/123/external_resources", method="GET"
 )
+
+
+@pytest.fixture
+def mock_get_resolutions_with_orphaned_jobs():
+    with mock.patch(
+        "sematic.api.endpoints.resolutions._GARBAGE_COLLECTION_QUERIES"
+    ) as mock_query_dict:
+        mock_query = mock.MagicMock()
+        mock_query_dict.keys = lambda: ["orphaned_jobs"]
+        mock_query_dict.__getitem__ = lambda _, __: mock_query
+        yield mock_query
 
 
 class MockPublisher(AbstractPublisher, AbstractPlugin):
@@ -362,6 +375,38 @@ def test_clean_resolution_jobs(
     payload = typing.cast(typing.Dict[str, typing.Any], response.json)
 
     assert payload["content"] == ["DELETED"]
+
+
+def test_list_resolutions_search_orphaned_jobs(
+    mock_auth,  # noqa: F811
+    mock_get_resolutions_with_orphaned_jobs,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    resolutions = (
+        make_resolution(root_id="1"),
+        make_resolution(root_id="2"),
+        make_resolution(root_id="3"),
+        make_resolution(root_id="4"),
+    )
+    mock_get_resolutions_with_orphaned_jobs.return_value = [
+        r.root_id for r in resolutions
+    ]
+
+    filters = {"orphaned_jobs": {"eq": True}}
+    query_params = {
+        "filters": json.dumps(filters),
+        "fields": json.dumps(["root_id"]),
+    }
+    response = test_client.get("/api/v1/resolutions?{}".format(urlencode(query_params)))
+
+    assert response.status_code == 200
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert len(payload["content"]) == len(resolutions)
+    ids = [result["root_id"] for result in payload["content"]]
+    assert set(ids) == {r.root_id for r in resolutions}
 
 
 def test_schedule_resolution_endpoint_auth(

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -76,7 +76,7 @@ def mock_load_log_lines():
 
 
 @pytest.fixture
-def mock_get_runs_with_orphaned_jobs():
+def mock_get_run_ids_with_orphaned_jobs():
     with mock.patch(
         "sematic.api.endpoints.runs._GARBAGE_COLLECTION_QUERIES"
     ) as mock_query_dict:
@@ -419,7 +419,7 @@ def test_list_runs_search_tags(
 
 def test_list_runs_search_orphaned_jobs(
     mock_auth,  # noqa: F811
-    mock_get_runs_with_orphaned_jobs,  # noqa: F811
+    mock_get_run_ids_with_orphaned_jobs,  # noqa: F811
     test_client: flask.testing.FlaskClient,  # noqa: F811
 ):
     runs = (
@@ -428,7 +428,7 @@ def test_list_runs_search_orphaned_jobs(
         make_run(name="Slippy"),
         make_run(name="Peppy"),
     )
-    mock_get_runs_with_orphaned_jobs.return_value = [r.id for r in runs]
+    mock_get_run_ids_with_orphaned_jobs.return_value = [r.id for r in runs]
 
     filters = {"orphaned_jobs": {"eq": True}}
     query_params = {

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -425,8 +425,8 @@ def test_list_runs_search_orphaned_jobs(
     runs = (
         make_run(name="Fox"),
         make_run(name="Falco"),
-        make_run(tags="Slippy"),
-        make_run(tags="Peppy"),
+        make_run(name="Slippy"),
+        make_run(name="Peppy"),
     )
     mock_get_runs_with_orphaned_jobs.return_value = [r.id for r in runs]
 

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -6,6 +6,7 @@ import typing
 import uuid
 from dataclasses import asdict, replace
 from unittest import mock
+from urllib.parse import urlencode
 
 # Third-party
 import flask.testing
@@ -72,6 +73,17 @@ test_get_run_external_resource_auth = make_auth_test(
 def mock_load_log_lines():
     with mock.patch("sematic.api.endpoints.runs.load_log_lines") as mock_load:
         yield mock_load
+
+
+@pytest.fixture
+def mock_get_runs_with_orphaned_jobs():
+    with mock.patch(
+        "sematic.api.endpoints.runs._GARBAGE_COLLECTION_QUERIES"
+    ) as mock_query_dict:
+        mock_query = mock.MagicMock()
+        mock_query_dict.keys = lambda: ["orphaned_jobs"]
+        mock_query_dict.__getitem__ = lambda _, __: mock_query
+        yield mock_query
 
 
 def test_list_runs_empty(
@@ -403,6 +415,36 @@ def test_list_runs_search_tags(
     assert run1.id in ids
     assert run2.id not in ids
     assert run3.id in ids
+
+
+def test_list_runs_search_orphaned_jobs(
+    mock_auth,  # noqa: F811
+    mock_get_runs_with_orphaned_jobs,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    runs = (
+        make_run(name="Fox"),
+        make_run(name="Falco"),
+        make_run(tags="Slippy"),
+        make_run(tags="Peppy"),
+    )
+    mock_get_runs_with_orphaned_jobs.return_value = [r.id for r in runs]
+
+    filters = {"orphaned_jobs": {"eq": True}}
+    query_params = {
+        "filters": json.dumps(filters),
+        "fields": json.dumps(["id"]),
+    }
+    response = test_client.get("/api/v1/runs?{}".format(urlencode(query_params)))
+
+    assert response.status_code == 200
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert len(payload["content"]) == len(runs)
+    ids = [result["id"] for result in payload["content"]]
+    assert set(ids) == {r.id for r in runs}
 
 
 def test_get_run_endpoint(

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -422,7 +422,7 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
     ]
 
 
-def get_runs_with_orphaned_jobs() -> List[str]:
+def get_run_ids_with_orphaned_jobs() -> List[str]:
     """Get ids of runs that have terminated, which still have non-terminal jobs."""
     filters = {"orphaned_jobs": {"eq": True}}
     query_params = {
@@ -439,7 +439,7 @@ def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:
     return response["content"]
 
 
-def get_resolutions_with_orphaned_jobs() -> List[str]:
+def get_resolution_ids_with_orphaned_jobs() -> List[str]:
     """Get ids of resolutions that have terminated which still have non-terminal jobs."""
     filters = {"orphaned_jobs": {"eq": True}}
     query_params = {

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -444,10 +444,10 @@ def get_resolutions_with_orphaned_jobs() -> List[str]:
     filters = {"orphaned_jobs": {"eq": True}}
     query_params = {
         "filters": json.dumps(filters),
-        "fields": json.dumps(["id"]),
+        "fields": json.dumps(["root_id"]),
     }
     response = _get("/resolutions?{}".format(urlencode(query_params)))
-    return [resolution["id"] for resolution in response["content"]]
+    return [resolution["root_id"] for resolution in response["content"]]
 
 
 def clean_orphaned_jobs_for_resolution(root_run_id: str, force: bool) -> List[str]:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -441,8 +441,13 @@ def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:
 
 def get_resolutions_with_orphaned_jobs() -> List[str]:
     """Get ids of resolutions that have terminated which still have non-terminal jobs."""
-    response = _get("/resolutions/with_orphaned_jobs")
-    return response["content"]
+    filters = {"orphaned_jobs": {"eq": True}}
+    query_params = {
+        "filters": json.dumps(filters),
+        "fields": json.dumps(["id"]),
+    }
+    response = _get("/resolutions?{}".format(urlencode(query_params)))
+    return [resolution["id"] for resolution in response["content"]]
 
 
 def clean_orphaned_jobs_for_resolution(root_run_id: str, force: bool) -> List[str]:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, cast
+from urllib.parse import urlencode
 
 # Third-party
 import requests
@@ -423,8 +424,13 @@ def get_resources_by_root_run_id(root_run_id: str) -> List[AbstractExternalResou
 
 def get_runs_with_orphaned_jobs() -> List[str]:
     """Get ids of runs that have terminated, which still have non-terminal jobs."""
-    response = _get("/runs/with_orphaned_jobs")
-    return response["content"]
+    filters = {"orphaned_jobs": {"eq": True}}
+    query_params = {
+        "filters": json.dumps(filters),
+        "fields": json.dumps(["id"]),
+    }
+    response = _get("/runs?{}".format(urlencode(query_params)))
+    return [run["id"] for run in response["content"]]
 
 
 def clean_jobs_for_run(run_id: str, force: bool) -> List[str]:

--- a/sematic/cli/clean.py
+++ b/sematic/cli/clean.py
@@ -80,7 +80,7 @@ def clean(orphaned_jobs: bool, orphaned_resources: bool, force: bool):
 
 
 def clean_orphaned_jobs(force: bool) -> List[str]:
-    resolution_ids: List[str] = api_client.get_resolutions_with_orphaned_jobs()
+    resolution_ids: List[str] = api_client.get_resolution_ids_with_orphaned_jobs()
     resolution_updates_by_kind: Counter = Counter()
     for root_id in resolution_ids:
         try:
@@ -92,7 +92,7 @@ def clean_orphaned_jobs(force: bool) -> List[str]:
         except Exception:
             logger.exception("Error cleaning jobs for resolution %s", root_id)
 
-    run_ids = api_client.get_runs_with_orphaned_jobs()
+    run_ids = api_client.get_run_ids_with_orphaned_jobs()
     run_updates_by_kind: Counter = Counter()
     for run_id in run_ids:
         try:

--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -332,7 +332,7 @@ def save_job(job: Job) -> Job:
         return job
 
 
-def get_runs_with_orphaned_jobs() -> List[str]:
+def get_run_ids_with_orphaned_jobs() -> List[str]:
     with db().get_session() as session:
         query_results = list(
             session.query(
@@ -365,7 +365,7 @@ def get_runs_with_orphaned_jobs() -> List[str]:
     return list(run_ids)
 
 
-def get_resolutions_with_orphaned_jobs() -> List[str]:
+def get_resolution_ids_with_orphaned_jobs() -> List[str]:
     with db().get_session() as session:
         query_results = list(
             session.query(

--- a/sematic/db/tests/test_queries.py
+++ b/sematic/db/tests/test_queries.py
@@ -29,12 +29,12 @@ from sematic.db.queries import (
     get_jobs_by_run_id,
     get_orphaned_resource_records,
     get_resolution,
-    get_resolutions_with_orphaned_jobs,
+    get_resolution_ids_with_orphaned_jobs,
     get_resources_by_root_id,
     get_root_graph,
     get_run,
     get_run_graph,
-    get_runs_with_orphaned_jobs,
+    get_run_ids_with_orphaned_jobs,
     save_external_resource_record,
     save_graph,
     save_job,
@@ -479,7 +479,7 @@ def test_save_read_jobs(test_db):  # noqa: F811
         save_job(retry_job_from_scratch)
 
 
-def test_get_runs_with_orphaned_jobs(test_db):  # noqa: F811
+def test_get_run_ids_with_orphaned_jobs(test_db):  # noqa: F811
     root_run = make_run()
     child_run_1 = make_run(root_id=root_run.id)
     child_run_2 = make_run(root_id=root_run.id)
@@ -509,11 +509,11 @@ def test_get_runs_with_orphaned_jobs(test_db):  # noqa: F811
     child_run_2.future_state = FutureState.RESOLVED
     save_run(child_run_2)
 
-    run_ids = get_runs_with_orphaned_jobs()
+    run_ids = get_run_ids_with_orphaned_jobs()
     assert run_ids == [child_run_2.id]
 
 
-def test_get_resolutions_with_orphaned_jobs(test_db):  # noqa: F811
+def test_get_resolution_ids_with_orphaned_jobs(test_db):  # noqa: F811
     root_run_1 = make_run()
     root_run_2 = make_run()
     save_run(root_run_1)
@@ -552,5 +552,5 @@ def test_get_resolutions_with_orphaned_jobs(test_db):  # noqa: F811
     )
     save_job(job_2)
 
-    resolution_ids = get_resolutions_with_orphaned_jobs()
+    resolution_ids = get_resolution_ids_with_orphaned_jobs()
     assert resolution_ids == [resolution_2.root_id]


### PR DESCRIPTION
Refactor the orphaned run/resolution query endpoints to look like run/resolution searches.

Queries look something like:
```
/api/v1/runs?filters='{"orphaned_jobs": {"eq": true}}'
```

Testing
-------
In addition to unit tests, intentionally orphaned some jobs and then deployed these changes (including the cleaner) and confirmed the runs/resolutions had their jobs cleaned. Intentionally [orphaned run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/62dfd02dec0b478cb1b4406965dcde7c#panel=run&run=0809100fcd3b4d3b890f44cea3aac94f&tab=pod_lifecycle)
