### PR TITLE
Storybook for the new Run Search page

### DIFF
--- a/sematic/ui/packages/common/src/component/Section.tsx
+++ b/sematic/ui/packages/common/src/component/Section.tsx
@@ -3,6 +3,25 @@ import theme from 'src/theme/new';
 
 const Section = styled.section`
     padding-top: ${theme.spacing(2.4)};
-`
+`;
+
+export const SectionWithBorder = styled(Section)`
+    min-height: 50px;
+    padding-top: 0;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    &:after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        height: 1px;
+        width: calc(100% + ${theme.spacing(10)});
+        left: -${theme.spacing(5)};
+        background: ${theme.palette.p3border.main};
+    }
+`;
 
 export default Section;

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -36,7 +36,7 @@ interface TagsListProps {
 const TagsList = (props: TagsListProps) => {
     const { tags = [], onClick, onAddTag } = props;
     return <StyledBox>
-        {tags.map(tag => <Chip key={tag} label={tag} onClick={() => onClick?.(tag)} />)}
+        {tags.map(tag => <Chip key={tag} label={tag} variant={"tag"} onClick={() => onClick?.(tag)} />)}
         <Button variant={"text"} size={"small"} onClick={onAddTag}>add tags</Button>
     </StyledBox>;
 }

--- a/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
@@ -24,6 +24,7 @@ const Center = styled.div`
     height: 100%;
     flex-grow: 1;
     padding: 0 25px;
+    border-right: 1px solid ${theme.palette.p3border.main};
 `;
 
 export const Right = styled.div`
@@ -34,7 +35,6 @@ export const Right = styled.div`
     height: 100%;
     padding: 0 ${theme.spacing(2.4)};
     box-sizing: border-box;
-    border-left: 1px solid ${theme.palette.p3border.main};
 `;
 
 export const Container = styled.div`

--- a/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import styled from '@emotion/styled';
 import theme from 'src/theme/new';
 
-const Left = styled.div`
+export const Left = styled.div`
     min-width: 300px;
     width: 300px;
     height: 100%;
@@ -26,7 +26,7 @@ const Center = styled.div`
     padding: 0 25px;
 `;
 
-const Right = styled.div`
+export const Right = styled.div`
     display: flex;
     flex-direction: column;
     min-width: 300px;
@@ -37,7 +37,7 @@ const Right = styled.div`
     border-left: 1px solid ${theme.palette.p3border.main};
 `;
 
-const Container = styled.div`
+export const Container = styled.div`
     width: 100%;
     height: 100%;
     display: flex;

--- a/sematic/ui/packages/common/src/layout/TwoColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/TwoColumns.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { Container, Left, Right } from 'src/layout/ThreeColumns';
+
+export interface TwoColumnsProps {
+    onRenderLeft: () => React.ReactNode;
+    onRenderRight: () => React.ReactNode;
+}
+
+const TwoColumns = (props: TwoColumnsProps) => {
+    const { onRenderLeft, onRenderRight } = props;
+
+    const leftPane = useMemo(() => onRenderLeft(), [onRenderLeft]);
+    const rightPane = useMemo(() => onRenderRight(), [onRenderRight]);
+
+    return (
+        <Container>
+            <Left>{leftPane}</Left>
+            <Right >{rightPane}</Right>
+        </Container>
+    );
+};
+
+export default TwoColumns;

--- a/sematic/ui/packages/common/src/muitypes.d.ts
+++ b/sematic/ui/packages/common/src/muitypes.d.ts
@@ -20,6 +20,7 @@ declare module '@mui/material/styles' {
         lightGrey: PaletteColor;
         mediumGrey: PaletteColor;
         p3border: PaletteColor;
+        white: PaletteColor;
     }
 }
 
@@ -27,6 +28,9 @@ declare module '@mui/material/Button' {
     interface ButtonPropsVariantOverrides {
         logo: true;
         menu: true;
+    }
+    interface ButtonPropsColorOverrides {
+        white: true;
     }
 }
 
@@ -39,6 +43,12 @@ declare module '@mui/material/Typography' {
         logo: true;
         menu: true;
         code: true;
+    }
+}
+
+declare module '@mui/material/Chip' {
+    interface ChipPropsVariantOverrides {
+        tag: true;
     }
 }
 

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -1,4 +1,3 @@
-import OrderSection from 'src/pages/RunSearch/filters/OrderSection';
 import OtherFiltersSection from 'src/pages/RunSearch/filters/OtherFilterSection';
 import OwnersFilterSection from 'src/pages/RunSearch/filters/OwnersFilterSection';
 import SearchTextSection from 'src/pages/RunSearch/filters/SearchTextSection';
@@ -20,7 +19,7 @@ const SearchFilters = () => {
         <StatusFilterSection />
         <OwnersFilterSection />
         <OtherFiltersSection />
-        <OrderSection />
+        {/* <OrderSection /> disabled for now */}
         <StyledButton variant="contained" disableElevation>Filter runs</StyledButton>
         <StyledButton variant="contained" disableElevation color={"white"}>Clear filters</StyledButton>
     </>;

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -1,0 +1,29 @@
+import OrderSection from 'src/pages/RunSearch/filters/OrderSection';
+import OtherFiltersSection from 'src/pages/RunSearch/filters/OtherFilterSection';
+import OwnersFilterSection from 'src/pages/RunSearch/filters/OwnersFilterSection';
+import SearchTextSection from 'src/pages/RunSearch/filters/SearchTextSection';
+import StatusFilterSection from 'src/pages/RunSearch/filters/StatusFilterSection';
+import TagsFilterSection from 'src/pages/RunSearch/filters/TagsFilterSection';
+import Button from '@mui/material/Button';
+import styled from '@emotion/styled';
+import theme from 'src/theme/new';
+
+const StyledButton = styled(Button)`
+    margin: 0 -${theme.spacing(5)};
+    height: 50px;
+`;
+
+const SearchFilters = () => {
+    return <>
+        <SearchTextSection />
+        <TagsFilterSection />
+        <StatusFilterSection />
+        <OwnersFilterSection />
+        <OtherFiltersSection />
+        <OrderSection />
+        <StyledButton variant="contained" disableElevation>Filter runs</StyledButton>
+        <StyledButton variant="contained" disableElevation color={"white"}>Clear filters</StyledButton>
+    </>;
+}
+
+export default SearchFilters;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { KeyboardArrowDown } from "@mui/icons-material";
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import { SectionWithBorder } from 'src/component/Section';
+import theme from 'src/theme/new';
+
+const BoldHeader = styled.div`
+    font-weight: ${theme.typography.fontWeightBold};
+`;
+
+const StyledAccordion = styled(Accordion)`
+    max-height: 100%;
+`;
+
+interface CollapseableFilterSectionProps {
+    title: string;
+    children: React.ReactNode;
+    className?: string;
+}
+
+const CollapseableFilterSection = (props: CollapseableFilterSectionProps) => {
+    const { title, children, className } = props;
+    return <SectionWithBorder className={className}>
+        <StyledAccordion>
+            <AccordionSummary expandIcon={<KeyboardArrowDown />} >
+                <BoldHeader>{title}</BoldHeader>
+            </AccordionSummary>
+            <AccordionDetails>
+                {children}
+            </AccordionDetails>
+        </StyledAccordion>
+    </SectionWithBorder>;
+}
+
+export default CollapseableFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OrderSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OrderSection.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { KeyboardArrowDown } from "@mui/icons-material";
+import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import theme from "src/theme/new";
+import Typography from '@mui/material/Typography';
+import { useState, useCallback } from "react";
+
+const Container = styled.div`
+    margin: -${theme.spacing(2.4)} 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: 50px;
+    align-items: center;
+`;
+
+type State = 'asc' | 'desc';
+
+type SortButtonProps = {
+    state: State;
+}
+
+const StyledSortButton = styled(KeyboardArrowDown)<SortButtonProps>`
+    cursor: pointer;
+    color: ${theme.palette.black.main};
+    transform: ${({state}) => state === 'asc' ? "rotate(180deg)" : "rotate(0deg)"};
+    transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+`;
+
+interface OwnersFilterSectionProps {
+    onFiltersChanged?: (filters: string[]) => void;
+}
+
+const OrderSection = (props: OwnersFilterSectionProps) => {
+    const [state, setState] = useState<State>('desc');
+
+    const onSortClick = useCallback(() => {
+        setState((state) => state === 'asc' ? 'desc' : 'asc');
+    }, [setState]);
+
+    return <CollapseableFilterSection title={"Order"} >
+        <Container>
+            <Typography>Most recent</Typography>
+            <StyledSortButton state={state} onClick={onSortClick}/>
+        </Container>
+    </CollapseableFilterSection>;
+}
+
+export default OrderSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OtherFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OtherFilterSection.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import Checkbox from '@mui/material/Checkbox';
+import { collapseClasses } from '@mui/material/Collapse';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import theme from "src/theme/new";
+
+const Container = styled.div`
+    margin-top: -${theme.spacing(2)};
+    margin-bottom: -${theme.spacing(2.4)};
+`;
+
+const StyledCollapseableFilterSection = styled(CollapseableFilterSection)`
+    & .${collapseClasses.root} {
+        flex-grow: 0;
+        flex-shrink: 1;
+        overflow-y: auto;
+        margin: 0 -${theme.spacing(5)};
+    }
+`;
+
+const StyledFormControlLabel = styled(FormControlLabel)`
+    height: 50px;
+    margin-left: ${theme.spacing(2.9)};
+`;
+
+interface OwnersFilterSectionProps {
+    onFiltersChanged?: (filters: string[]) => void;
+}
+
+const OtherFiltersSection = (props: OwnersFilterSectionProps) => {
+    return <StyledCollapseableFilterSection title={"Filters"} >
+        <Container>
+            <FormGroup>
+                <StyledFormControlLabel control={<Checkbox defaultChecked />} label="Root runs only" />
+            </FormGroup>
+        </Container>
+    </StyledCollapseableFilterSection>;
+}
+
+export default OtherFiltersSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled';
+import Checkbox from '@mui/material/Checkbox';
+import { collapseClasses } from '@mui/material/Collapse';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import { paperClasses } from '@mui/material/Paper';
+import { forwardRef, useCallback, useState, useImperativeHandle } from "react";
+import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+import theme from "src/theme/new";
+
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: ${theme.spacing(2)};
+    row-gap: ${theme.spacing(2)};
+    margin-top: -${theme.spacing(2)};
+    margin-bottom: 2px;
+
+    overflow-y: auto;
+`;
+
+const StyledCollapseableFilterSection = styled(CollapseableFilterSection)`
+    flex-grow: 0;
+    flex-shrink: 1!important;
+    
+    & .${paperClasses.root} {
+        display: flex;
+        flex-direction: column;
+    }
+
+    & .${collapseClasses.root} {
+        flex-grow: 0;
+        flex-shrink: 1;
+        overflow-y: auto;
+        margin: 0 -${theme.spacing(5)};
+    }
+`;
+
+const StyledFormControlLabel = styled(FormControlLabel)`
+    height: 50px;
+    margin-left: ${theme.spacing(2.9)};
+`;
+
+interface OwnersFilterSectionProps {
+    onFiltersChanged?: (filters: string[]) => void;
+}
+
+const OwnersFilterSection = forwardRef<ResettableHanlde, OwnersFilterSectionProps>((props, ref) => {
+    const { onFiltersChanged } = props;
+    const [filters, setFilters] = useState<Set<string>>(() => new Set());
+
+    const toogleFilter = useCallback((filter: string, checked: boolean) => {
+        let newFilters: any;
+        setFilters((filters) => {
+            if (checked) {
+                filters.add(filter);
+            } else {
+                filters.delete(filter);
+            }
+            filters.delete('current_user_id');
+            newFilters = new Set(filters);
+            onFiltersChanged?.(Array.from(newFilters));
+            return newFilters;
+        });
+
+    }, [onFiltersChanged, setFilters]);
+
+    /***
+     * This clears all other filters but the current user filter
+     */
+    const toogleJustMeFilter = useCallback((checked: boolean) => {
+        let newFilters: any;
+        setFilters(() => {
+            if (checked) {
+                newFilters = new Set(['current_user_id']);
+            } else {
+                newFilters = new Set();
+            }
+            onFiltersChanged?.(Array.from(newFilters));
+            return newFilters;
+        });
+
+    }, [onFiltersChanged, setFilters]);
+
+    useImperativeHandle(ref, () => ({
+        reset: () => {
+            setFilters(new Set());
+        }
+    }));
+
+    return <StyledCollapseableFilterSection title={"Owner"} >
+        <Container>
+            <FormGroup>
+                <StyledFormControlLabel control={<Checkbox
+                    checked={filters.has('current_user_id')}
+                    onChange={(e, checked) => toogleJustMeFilter(checked)} />} label="My runs only"
+                />
+                {['Alice', 'Bob', 'Clark', 'David', 'Edison', 'Frank'].map(
+                    (owner) =>
+                        <StyledFormControlLabel control={<Checkbox
+                            onChange={(e, checked) => toogleFilter(owner, checked)} />} label={owner}
+                            checked={filters.has(owner)} />
+                )}
+            </FormGroup>
+        </Container>
+    </StyledCollapseableFilterSection>;
+})
+
+export default OwnersFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
@@ -4,9 +4,9 @@ import { collapseClasses } from '@mui/material/Collapse';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import { paperClasses } from '@mui/material/Paper';
-import { forwardRef, useCallback, useState, useImperativeHandle } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
 import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
-import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+import { ResettableHandle } from 'src/pages/RunSearch/filters/common';
 import theme from "src/theme/new";
 
 
@@ -48,7 +48,7 @@ interface OwnersFilterSectionProps {
     onFiltersChanged?: (filters: string[]) => void;
 }
 
-const OwnersFilterSection = forwardRef<ResettableHanlde, OwnersFilterSectionProps>((props, ref) => {
+const OwnersFilterSection = forwardRef<ResettableHandle, OwnersFilterSectionProps>((props, ref) => {
     const { onFiltersChanged } = props;
     const [filters, setFilters] = useState<Set<string>>(() => new Set());
 
@@ -60,25 +60,7 @@ const OwnersFilterSection = forwardRef<ResettableHanlde, OwnersFilterSectionProp
             } else {
                 filters.delete(filter);
             }
-            filters.delete('current_user_id');
             newFilters = new Set(filters);
-            onFiltersChanged?.(Array.from(newFilters));
-            return newFilters;
-        });
-
-    }, [onFiltersChanged, setFilters]);
-
-    /***
-     * This clears all other filters but the current user filter
-     */
-    const toogleJustMeFilter = useCallback((checked: boolean) => {
-        let newFilters: any;
-        setFilters(() => {
-            if (checked) {
-                newFilters = new Set(['current_user_id']);
-            } else {
-                newFilters = new Set();
-            }
             onFiltersChanged?.(Array.from(newFilters));
             return newFilters;
         });
@@ -96,11 +78,11 @@ const OwnersFilterSection = forwardRef<ResettableHanlde, OwnersFilterSectionProp
             <FormGroup>
                 <StyledFormControlLabel control={<Checkbox
                     checked={filters.has('current_user_id')}
-                    onChange={(e, checked) => toogleJustMeFilter(checked)} />} label="My runs only"
+                    onChange={(e, checked) => toogleFilter("current_user_id", checked)} />} label="Your runs"
                 />
                 {['Alice', 'Bob', 'Clark', 'David', 'Edison', 'Frank'].map(
-                    (owner) =>
-                        <StyledFormControlLabel control={<Checkbox
+                    (owner, index) =>
+                        <StyledFormControlLabel key={index} control={<Checkbox
                             onChange={(e, checked) => toogleFilter(owner, checked)} />} label={owner}
                             checked={filters.has(owner)} />
                 )}

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/SearchTextSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/SearchTextSection.tsx
@@ -1,0 +1,15 @@
+import { SectionWithBorder } from 'src/component/Section';
+import TextField from "@mui/material/TextField";
+
+
+function SearchTextSection() {
+    return <SectionWithBorder >
+        <TextField
+        variant="standard"
+        fullWidth={true}
+        placeholder={"Search..."}
+        />
+    </SectionWithBorder>
+}
+
+export default SearchTextSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
@@ -5,7 +5,7 @@ import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip 
 import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
 import theme from "src/theme/new";
 import memoize from 'lodash/memoize';
-import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+import { ResettableHandle } from 'src/pages/RunSearch/filters/common';
 
 const StyledChip = styled(Chip)`
     padding-left: ${theme.spacing(1)};
@@ -56,7 +56,7 @@ const toogleFilterGenerator = memoize((
         onFiltersChanged?.(Array.from(newFilters));
     }, []));
 
-const StatusFilterSection = forwardRef<ResettableHanlde, StatusFilterSectionProps>((props, ref) => {
+const StatusFilterSection = forwardRef<ResettableHandle, StatusFilterSectionProps>((props, ref) => {
     const { onFiltersChanged } = props;
     const [filters, setFilters] = useState<Set<string>>(() => new Set());
 

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
@@ -1,0 +1,90 @@
+import styled from '@emotion/styled';
+import Chip, { chipClasses } from "@mui/material/Chip";
+import { useCallback, useImperativeHandle, forwardRef, useState } from "react";
+import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip } from "src/component/RunStateChips";
+import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import theme from "src/theme/new";
+import memoize from 'lodash/memoize';
+import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+
+const StyledChip = styled(Chip)`
+    padding-left: ${theme.spacing(1)};
+    border: 1px solid transparent;
+
+    & .${chipClasses.label} {
+        padding-left: ${theme.spacing(2)};
+    }
+
+    &.${chipClasses.filled} {
+        svg {
+            color: ${theme.palette.common.white};
+        }
+    }
+`;
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: ${theme.spacing(2)};
+    row-gap: ${theme.spacing(2)};
+    margin-bottom: 2px;
+`;
+
+interface StatusFilterSectionProps {
+    onFiltersChanged?: (filters: string[]) => void;
+}
+
+const toogleFilterGenerator = memoize((
+    filter: string,
+    setFilters: React.Dispatch<React.SetStateAction<Set<string>>>,
+    onFiltersChanged: StatusFilterSectionProps['onFiltersChanged']
+) =>
+    () => useCallback(() => {
+        let newFilters: any;
+        setFilters((filters) => {
+            if (filters.has(filter)) {
+                filters.delete(filter);
+            } else {
+                filters.add(filter);
+            }
+
+            newFilters = filters;
+            return new Set(filters);
+        });
+
+        onFiltersChanged?.(Array.from(newFilters));
+    }, []));
+
+const StatusFilterSection = forwardRef<ResettableHanlde, StatusFilterSectionProps>((props, ref) => {
+    const { onFiltersChanged } = props;
+    const [filters, setFilters] = useState<Set<string>>(() => new Set());
+
+    const toggleFilterComplete = toogleFilterGenerator("completed", setFilters, onFiltersChanged!)();
+    const toggleFilterFailed = toogleFilterGenerator("failed", setFilters, onFiltersChanged!)();
+    const toggleFilterRunning = toogleFilterGenerator("running", setFilters, onFiltersChanged!)();
+    const toggleFilterCanceled = toogleFilterGenerator("canceled", setFilters, onFiltersChanged!)();
+
+    useImperativeHandle(ref, () => ({
+        reset: () => setFilters(new Set())
+    }), []);
+
+    return <CollapseableFilterSection title={"Status"} >
+        <Container>
+            <StyledChip icon={<SuccessStateChip size={"large"} />}
+                variant={filters.has("completed") ? undefined : "outlined"}
+                color="success" label={"Completed"} onClick={() => toggleFilterComplete()} />
+            <StyledChip icon={<FailedStateChip size={"large"} />}
+                variant={filters.has("failed") ? undefined : "outlined"}
+                color="error" label={"Failed"} onClick={() => toggleFilterFailed()} />
+            <StyledChip icon={<RunningStateChip size={"large"} />}
+                variant={filters.has("running") ? undefined : "outlined"}
+                color="primary" label={"Running"} onClick={() => toggleFilterRunning()} />
+            <StyledChip icon={<CanceledStateChip size={"large"} />}
+                variant={filters.has("canceled") ? undefined : "outlined"}
+                color="error" label={"Canceled"} onClick={() => toggleFilterCanceled()} />
+        </Container>
+    </CollapseableFilterSection>;
+})
+
+export default StatusFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
@@ -1,0 +1,26 @@
+import TextField from "@mui/material/TextField";
+import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import styled from '@emotion/styled';
+import theme from "src/theme/new";
+
+const Container = styled.div`
+    margin: -${theme.spacing(2.4)} 0;
+    height: 50px;
+    flex-direction: column;
+    justify-content: center;
+    display: flex;
+`;
+
+const TagsFilterSection = () => {
+    return <CollapseableFilterSection title={"Tags"} >
+        <Container>
+            <TextField
+                variant="standard"
+                fullWidth={true}
+                placeholder={"Tags..."}
+            />
+        </Container>
+    </CollapseableFilterSection>;
+}
+
+export default TagsFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
@@ -1,3 +1,3 @@
-export interface ResettableHanlde {
+export interface ResetTableHandle {
     reset: () => void;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
@@ -1,0 +1,3 @@
+export interface ResettableHanlde {
+    reset: () => void;
+}

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
@@ -1,3 +1,3 @@
-export interface ResetTableHandle {
+export interface ResettableHandle {
     reset: () => void;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import TwoColumns from "src/layout/TwoColumns";
+import SearchFilters from 'src/pages/RunSearch/SearchFilters';
+
+const RunSearch = () => {
+
+    const onRenderLeft = useCallback(() => {
+        return <SearchFilters />;
+    }, []);
+
+    const onRenderRight = useCallback(() => {
+        return <></>;
+    }, []);
+
+    return <TwoColumns onRenderLeft={onRenderLeft} onRenderRight={onRenderRight} />;
+}
+
+export default RunSearch;

--- a/sematic/ui/packages/common/src/theme/new/componnets.ts
+++ b/sematic/ui/packages/common/src/theme/new/componnets.ts
@@ -3,6 +3,7 @@ import { fontFamilyCode, fontWeightBold } from 'src/theme/new/typography';
 import { KeyboardArrowDown } from "@mui/icons-material";
 import { selectClasses } from '@mui/material/Select'
 import { inputBaseClasses } from '@mui/material/InputBase'
+import { chipClasses } from '@mui/material/Chip'
 
 const components: Components = {
     MuiCssBaseline: {
@@ -169,16 +170,20 @@ const components: Components = {
         }
     },
     MuiChip: {
-        styleOverrides: {
-            root: {
-                height: 25,
-                borderRadius: 0,
-            },
-            label: (({ theme }: { theme: Theme }) => ({
-                fontSize: theme.typography.small.fontSize,
-                padding: 5
-            })) as any
-        }
+        variants: [
+            {
+                props: { variant: 'tag' },
+                style: ({ theme }) => ({
+                    height: 25,
+                    borderRadius: 0,
+
+                    [`& .${chipClasses.label}`]: {
+                        fontSize: theme.typography.small.fontSize,
+                        padding: 5
+                    }
+                })
+            }
+        ]
     },
     MuiButton: {
         variants: [
@@ -194,8 +199,12 @@ const components: Components = {
                         }
                     }
                 }
-
-
+            },
+            {
+                props: { variant: 'contained' },
+                style: {
+                    borderRadius: 0,
+                }
             },
             {
                 props: { size: 'small' },
@@ -230,6 +239,44 @@ const components: Components = {
                 "&.Mui-selected": {
                     'color': `${theme.palette.black.main}`
                 }
+            })) as any
+        }
+    },
+    MuiAccordion: {
+        styleOverrides: {
+            root: {
+                'boxShadow': 'none',
+            }
+        }
+    },
+    MuiAccordionSummary: {
+        styleOverrides: {
+            root: {
+                'padding': '0',
+                'minHeight': '50px',
+                '&.Mui-expanded': {
+                    'minHeight': '50px'
+                }
+            },
+            content: (({ theme }: { theme: Theme }) => ({
+                '&.Mui-expanded': {
+                    'marginTop': theme.spacing(2.4),
+                    'marginBottom': theme.spacing(2.4)
+                }
+            })) as any,
+            expandIconWrapper: (({ theme }: { theme: Theme }) => ({
+                'color': theme.palette.black.main,
+
+                '&.Mui-expanded': {
+                    'color': theme.palette.primary.main,
+                }
+            })) as any
+        }
+    },
+    MuiAccordionDetails: {
+        styleOverrides: {
+            root: (({ theme }: { theme: Theme }) => ({
+                'padding': `${theme.spacing(2.4)} 0`,
             })) as any
         }
     }

--- a/sematic/ui/packages/common/src/theme/new/palette.ts
+++ b/sematic/ui/packages/common/src/theme/new/palette.ts
@@ -17,6 +17,11 @@ const pallette: Record<string, PaletteColorOptions> = {
     },
     p3border: {
         main: 'rgba(0, 0, 0, 0.03)'
+    },
+    white: {
+        main: common['white'],
+        contrastText: '#2D2C2E',
+        dark: grey[50]
     }
 }
 

--- a/sematic/ui/packages/storybook/src/stories/Color.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Color.stories.tsx
@@ -62,7 +62,7 @@ export default {
 const Template: ComponentStory<typeof ColorBlock> = (args) => <ColorBlock {...args} />;
 
 export const AllColors = () => {
-  const cases = [Primary, PrimaryLight, Error, Warning, Success, LightGray, Black, p3border];
+  const cases = [Primary, PrimaryLight, Error, Warning, Success, LightGray, Black, p3border, white];
 
   return <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
     {Array.from(cases).map((c, index) => (
@@ -119,3 +119,9 @@ export const p3border = Template.bind({});
 p3border.args = {
   paletteColorName: 'p3border'
 };
+
+export const white = Template.bind({});
+white.args = {
+  paletteColorName: 'white'
+};
+

--- a/sematic/ui/packages/storybook/src/stories/Page.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Page.stories.tsx
@@ -1,31 +1,50 @@
 import Shell from "@sematic/common/src/layout/Shell";
-import RunDetails from "@sematic/common/src/pages/RunDetails";
+import RunDetailsComponent from "@sematic/common/src/pages/RunDetails";
+import RunSearchComponent from "@sematic/common/src/pages/RunSearch";
 import { Meta, StoryObj } from '@storybook/react';
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from "react-router-dom";
 
-const router = createBrowserRouter(
+const runDetailsRouter = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/" element={<Shell />}>
-      <Route path="*" element={<RunDetails />} />
+      <Route path="*" element={<RunDetailsComponent />} />
     </Route>
   ));
 
-function Router() {
-  return <RouterProvider router={router} />;
+function RunDetailsRouter() {
+  return <RouterProvider router={runDetailsRouter} />;
 }
 
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: 'Sematic/Page',
-  component: Router,
+  component: RunDetailsRouter,
 
-} as Meta<typeof Router>;
+} as Meta<typeof RunDetailsRouter>;
 
-type Story = StoryObj<typeof Router>;
+export const RunDetails: StoryObj<typeof RunDetailsRouter> = {
+  render: () => <RunDetailsRouter />,
 
-export const Page: Story = {
-  render: () => <Router />,
+  parameters : {
+    layout: 'fullscreen' 
+  }
+};
+
+const runSearchRouter = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path="/" element={<Shell />}>
+      <Route path="*" element={<RunSearchComponent />} />
+    </Route>
+  ));
+
+function RunSearchRouter() {
+  return <RouterProvider router={runSearchRouter} />;
+}
+
+
+export const RunSearch: StoryObj<typeof RunSearchRouter> = {
+  render: () => <RunSearchRouter />,
 
   parameters : {
     layout: 'fullscreen' 

--- a/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
@@ -1,0 +1,63 @@
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from "@mui/material/styles";
+import StatusFilterSection from '@sematic/common/src/pages/RunSearch/filters/StatusFilterSection';
+import OwnersFilterSection from '@sematic/common/src/pages/RunSearch/filters/OwnersFilterSection';
+
+import { useRef } from '@sematic/common/src/reactHooks';
+import theme from '@sematic/common/src/theme/new';
+import { Meta, StoryObj } from '@storybook/react';
+import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+
+export default {
+  title: 'Sematic/RunFilters',
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as Meta<StoryProps>;
+
+interface StoryProps {
+  onFilterChange: (filters: string[]) => void;
+}
+
+const commonArgTypes = {
+  onFilterChange: { action: 'filter change' },
+};
+
+function StatusFilterStory(props: StoryProps) {
+  const ref = useRef<ResettableHanlde>(null);
+  const { onFilterChange } = props;
+
+  return <div style={{ width: '300px' }}>
+    <StatusFilterSection ref={ref} onFiltersChanged={onFilterChange} />
+    <button onClick={() => { ref.current?.reset()}} >Clear</button>
+  </div>;
+}
+
+export const StatusFilter: StoryObj<StoryProps> = {
+  render: (props) => {
+    return <StatusFilterStory {...props} />;
+  },
+  argTypes: commonArgTypes
+};
+
+function OwnerFilterStory(props: StoryProps) {
+  const ref = useRef<ResettableHanlde>(null);
+  const { onFilterChange } = props;
+
+  return <div style={{ width: '300px' }}>
+    <OwnersFilterSection ref={ref} onFiltersChanged={onFilterChange} />
+    <button onClick={() => { ref.current?.reset()}} >Clear</button>
+  </div>;
+}
+
+export const OwnerFilter: StoryObj<StoryProps> = {
+  render: (props) => {
+    return <OwnerFilterStory {...props} />;
+  },
+  argTypes: commonArgTypes
+};

--- a/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
@@ -6,7 +6,7 @@ import OwnersFilterSection from '@sematic/common/src/pages/RunSearch/filters/Own
 import { useRef } from '@sematic/common/src/reactHooks';
 import theme from '@sematic/common/src/theme/new';
 import { Meta, StoryObj } from '@storybook/react';
-import { ResettableHanlde } from 'src/pages/RunSearch/filters/common';
+import { ResettableHandle } from 'src/pages/RunSearch/filters/common';
 
 export default {
   title: 'Sematic/RunFilters',
@@ -29,7 +29,7 @@ const commonArgTypes = {
 };
 
 function StatusFilterStory(props: StoryProps) {
-  const ref = useRef<ResettableHanlde>(null);
+  const ref = useRef<ResettableHandle>(null);
   const { onFilterChange } = props;
 
   return <div style={{ width: '300px' }}>
@@ -46,7 +46,7 @@ export const StatusFilter: StoryObj<StoryProps> = {
 };
 
 function OwnerFilterStory(props: StoryProps) {
-  const ref = useRef<ResettableHanlde>(null);
+  const ref = useRef<ResettableHandle>(null);
   const { onFilterChange } = props;
 
   return <div style={{ width: '300px' }}>


### PR DESCRIPTION
The PR covers the new Run Search page -- the filters section.

It can be previewed at:

https://story.dev-usw2-sematic0.sematic.cloud/iframe.html?args=&id=sematic-page--run-search&viewMode=story

Two small side stories are added to demonstrate interactivity:
[Status Filter](https://story.dev-usw2-sematic0.sematic.cloud/?path=/story/sematic-runfilters--status-filter)
[Owner Filter](https://story.dev-usw2-sematic0.sematic.cloud/?path=/story/sematic-runfilters--owner-filter)