### PR TITLE
A component to allow creating tag filters dynamically

### DIFF
--- a/sematic/ui/packages/common/src/component/TagsInput.tsx
+++ b/sematic/ui/packages/common/src/component/TagsInput.tsx
@@ -1,0 +1,122 @@
+import styled from '@emotion/styled';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+import { useCallback, useRef, useState } from 'react';
+import theme from 'src/theme/new';
+
+interface OverflowComponentProps {
+  overflow: boolean;
+  isEmpty: boolean;
+}
+
+const TagsContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: ${theme.spacing(0.8)};
+    column-gap: ${theme.spacing(0.8)};
+`;
+
+const MaskLayer = styled('div', {
+  shouldForwardProp: (prop) => !["overflow", "isEmpty"].includes(prop as any),
+})<OverflowComponentProps>`
+  position: absolute;
+  left: 0px;
+  top: 0;
+  right: 0px;
+  bottom: 0;
+  width: 100%;
+  user-select: none;
+  pointer-events: none;
+  overflow-x: ${({ overflow }) => overflow ? 'hidden' : 'visible'};
+  visibility: ${({ overflow, isEmpty }) => overflow || isEmpty ? 'hidden' : 'visible'};
+
+  & > div {
+    width: min-content;
+    color: transparent;
+    position: relative;
+
+    &::after {
+      content: '↵';
+      position: absolute;
+      left: calc(100% + 1px);
+      top: 4px;
+      color: ${theme.palette.lightGrey.main};
+    }
+  }
+`;
+
+const InputContainer = styled('div', {
+  shouldForwardProp: (prop) => !["overflow", "isEmpty"].includes(prop as any),
+})<OverflowComponentProps>`
+  position: relative;
+  width: 100%;
+
+  &::after {
+    content: '↵';
+    position: absolute;
+    left: 100%;
+    top: 4px;
+    color: ${theme.palette.lightGrey.main};
+    display: ${({ overflow, isEmpty }) => overflow && !isEmpty ? 'block' : 'none'};
+  }
+`;
+
+const TagsInput = () => {
+  const [tags, setTags] = useState<string[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [overflow, setOverflow] = useState(false);
+  const inputRef = useRef<HTMLInputElement>();
+  const maskLayer = useRef<HTMLDivElement>(null);
+
+  const syncOverflowState = useCallback(() => {
+    setOverflow(inputRef.current!.clientWidth <= maskLayer.current!.clientWidth);
+  }, []);
+
+  const handleAddTag = useCallback(() => {
+    if (inputValue.trim() !== '') {
+      setTags([...tags, inputValue.trim()]);
+      setInputValue('');
+      syncOverflowState();
+    }
+  }, [tags, inputValue, syncOverflowState]);
+
+  const handleRemoveTag = useCallback((tag: string) => {
+    const updatedTags = tags.filter((t) => t !== tag);
+    setTags(updatedTags);
+  }, [tags]);
+
+  const handleInputChange = useCallback((e: any) => {
+    setInputValue(e.target.value);
+  }, []);
+
+  return (
+    <>
+      <TagsContainer>
+        {tags.map((tag, index) => (
+          <Chip key={index} label={tag} variant={'tag'} onDelete={() => handleRemoveTag(tag)} />
+        ))}
+      </TagsContainer>
+      <InputContainer overflow={overflow} isEmpty={inputValue === ''}>
+        <TextField value={inputValue} variant="standard" onChange={handleInputChange} placeholder={"Tags..."}
+          inputRef={inputRef}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleAddTag();
+            }
+            syncOverflowState();
+          }}
+          style={{ width: '100%' }}
+        />
+        <MaskLayer overflow={overflow} isEmpty={inputValue === ''} >
+          <div ref={maskLayer}>
+            {inputValue}
+          </div>
+        </MaskLayer>
+      </InputContainer>
+    </>
+  );
+};
+
+export default TagsInput;

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -10,6 +10,8 @@ import theme from 'src/theme/new';
 const StyledButton = styled(Button)`
     margin: 0 -${theme.spacing(5)};
     height: 50px;
+    flex-shrink: 0;
+    flex-grow: 0;
 `;
 
 const SearchFilters = () => {

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
@@ -3,6 +3,8 @@ import { KeyboardArrowDown } from "@mui/icons-material";
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
+import { collapseClasses } from '@mui/material/Collapse';
+import { paperClasses } from '@mui/material/Paper';
 import { SectionWithBorder } from 'src/component/Section';
 import theme from 'src/theme/new';
 
@@ -18,20 +20,38 @@ interface CollapseableFilterSectionProps {
     title: string;
     children: React.ReactNode;
     className?: string;
+    onChange?: (event: React.SyntheticEvent, expanded: boolean) => void;
 }
 
 const CollapseableFilterSection = (props: CollapseableFilterSectionProps) => {
-    const { title, children, className } = props;
+    const { title, children, className, onChange } = props;
     return <SectionWithBorder className={className}>
-        <StyledAccordion>
+        <StyledAccordion onChange={onChange}>
             <AccordionSummary expandIcon={<KeyboardArrowDown />} >
                 <BoldHeader>{title}</BoldHeader>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails style={{minHeight: 50}}>
                 {children}
             </AccordionDetails>
         </StyledAccordion>
     </SectionWithBorder>;
 }
+
+export const ScrollableCollapseableFilterSection = styled(CollapseableFilterSection)`
+    flex-grow: 0;
+    flex-shrink: 1!important;
+    
+    & .${paperClasses.root} {
+        display: flex;
+        flex-direction: column;
+    }
+
+    & .${collapseClasses.root} {
+        flex-grow: 0;
+        flex-shrink: 1;
+        overflow-y: auto;
+        margin: 0 -${theme.spacing(5)};
+    }
+`;
 
 export default CollapseableFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
@@ -3,9 +3,8 @@ import Checkbox from '@mui/material/Checkbox';
 import { collapseClasses } from '@mui/material/Collapse';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
-import { paperClasses } from '@mui/material/Paper';
 import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
-import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
+import { ScrollableCollapseableFilterSection } from 'src/pages/RunSearch/filters/CollapseableFilterSection';
 import { ResettableHandle } from 'src/pages/RunSearch/filters/common';
 import theme from "src/theme/new";
 
@@ -20,23 +19,6 @@ const Container = styled.div`
     margin-bottom: 2px;
 
     overflow-y: auto;
-`;
-
-const StyledCollapseableFilterSection = styled(CollapseableFilterSection)`
-    flex-grow: 0;
-    flex-shrink: 1!important;
-    
-    & .${paperClasses.root} {
-        display: flex;
-        flex-direction: column;
-    }
-
-    & .${collapseClasses.root} {
-        flex-grow: 0;
-        flex-shrink: 1;
-        overflow-y: auto;
-        margin: 0 -${theme.spacing(5)};
-    }
 `;
 
 const StyledFormControlLabel = styled(FormControlLabel)`
@@ -73,7 +55,7 @@ const OwnersFilterSection = forwardRef<ResettableHandle, OwnersFilterSectionProp
         }
     }));
 
-    return <StyledCollapseableFilterSection title={"Owner"} >
+    return <ScrollableCollapseableFilterSection title={"Owner"} >
         <Container>
             <FormGroup>
                 <StyledFormControlLabel control={<Checkbox
@@ -88,7 +70,7 @@ const OwnersFilterSection = forwardRef<ResettableHandle, OwnersFilterSectionProp
                 )}
             </FormGroup>
         </Container>
-    </StyledCollapseableFilterSection>;
+    </ScrollableCollapseableFilterSection>;
 })
 
 export default OwnersFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
@@ -9,7 +9,8 @@ import { ResettableHandle } from 'src/pages/RunSearch/filters/common';
 
 const StyledChip = styled(Chip)`
     padding-left: ${theme.spacing(1)};
-    border: 1px solid transparent;
+    border-width: 1px;
+    border-style: solid;
 
     & .${chipClasses.label} {
         padding-left: ${theme.spacing(2)};

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
@@ -1,26 +1,38 @@
-import TextField from "@mui/material/TextField";
-import CollapseableFilterSection from 'src/pages/RunSearch/filters/CollapseableFilterSection';
 import styled from '@emotion/styled';
+import { useState } from 'react';
+import TagsInput from "src/component/TagsInput";
+import { ScrollableCollapseableFilterSection } from 'src/pages/RunSearch/filters/CollapseableFilterSection';
 import theme from "src/theme/new";
 
 const Container = styled.div`
     margin: -${theme.spacing(2.4)} 0;
-    height: 50px;
+    min-height: 50px;
     flex-direction: column;
     justify-content: center;
     display: flex;
+    padding-left: ${theme.spacing(5)};
+    padding-right: ${theme.spacing(5)};
+    padding-bottom: ${theme.spacing(1)};
 `;
 
+const StyledScrollableSection = styled(ScrollableCollapseableFilterSection) <{
+    expanded: boolean;
+}>`
+    justify-content: start;
+    min-height: ${({ expanded }) => expanded ? 100 : 50}px;
+    transition: min-height 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+`;
+
+
 const TagsFilterSection = () => {
-    return <CollapseableFilterSection title={"Tags"} >
+    const [expanded, setExpanded] = useState(false);
+
+    return <StyledScrollableSection title={"Tags"} expanded={expanded}
+        onChange={(_, expanded) => setExpanded(expanded)}>
         <Container>
-            <TextField
-                variant="standard"
-                fullWidth={true}
-                placeholder={"Tags..."}
-            />
+            <TagsInput />
         </Container>
-    </CollapseableFilterSection>;
+    </StyledScrollableSection>;
 }
 
 export default TagsFilterSection;

--- a/sematic/ui/packages/common/src/theme/new/componnets.ts
+++ b/sematic/ui/packages/common/src/theme/new/componnets.ts
@@ -183,7 +183,12 @@ const components: Components = {
                     }
                 })
             }
-        ]
+        ],
+        styleOverrides: {
+            deleteIcon: {
+                marginLeft: 0
+            }
+        }
     },
     MuiButton: {
         variants: [

--- a/sematic/ui/packages/storybook/src/stories/Tags.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Tags.stories.tsx
@@ -1,6 +1,7 @@
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from "@mui/material/styles";
 import TagsListComponent from '@sematic/common/src/component/TagsList';
+import TagsInputComponent from '@sematic/common/src/component/TagsInput';
 import theme from '@sematic/common/src/theme/new';
 import { Meta, StoryObj } from '@storybook/react';
 
@@ -17,15 +18,9 @@ export default {
 } as Meta<StoryProps>;
 
 interface StoryProps {
-  width: keyof typeof sizeOptions;
+  width: number;
   onTagClick: (value: string) => void;
   onAddTag: () => void;
-}
-
-const sizeOptions = {
-  "100px (small)": 100,
-  "200px (medium)": 200,
-  "400px (large)": 400
 }
 
 const commonArgTypes = {
@@ -47,10 +42,21 @@ export const TagsList: StoryObj<StoryProps> = {
   render: (props) => {
     const { width, onTagClick, onAddTag } = props;
 
-    return <div style={{ maxWidth: width }}>
+    return <div style={{ maxWidth: width || 200 }}>
       <TagsListComponent tags={['example', 'torch', 'mnist']}
         onClick={onTagClick} onAddTag={onAddTag} />
     </div>;
-  }
+  },
+  argTypes: commonArgTypes
 };
-TagsList.argTypes = commonArgTypes;
+
+export const TagsInput: StoryObj<StoryProps> = {
+  render: (props) => {
+    const { width } = props;
+
+    return <div style={{ maxWidth: width || 200 }}>
+      <TagsInputComponent />
+    </div>;
+  },
+  argTypes: commonArgTypes
+};


### PR DESCRIPTION
1. A new component `<TagInput />` is implemented to allow users to dynamically input tags.
2. Added to the Run Search page.
3. Created a dedicated story for such  a `<TagInput />` component.

![capture1](https://user-images.githubusercontent.com/1046489/235801086-65e7e815-c7b5-4238-b383-2f489e741e6f.gif)


Demo: https://story.dev-usw2-sematic0.sematic.cloud/iframe.html?args=&id=sematic-page--run-search&viewMode=story