### PR TITLE
[2/N] Native Build System starting from base images

### DIFF
--- a/sematic/plugins/abstract_builder.py
+++ b/sematic/plugins/abstract_builder.py
@@ -36,6 +36,12 @@ class AbstractBuilder(AbstractPlugin):
     def build_and_launch(self, target: str) -> None:
         """
         Builds a container image and launches the specified target launch script.
+
+        Parameters
+        ----------
+        target: str
+            The path to the pipeline target to launch; the built image must support this
+            target's execution.
         """
 
         pass

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -499,7 +499,7 @@ def _build_image_from_base(
         return image, ImageURI.from_image(image)
 
     for status_update in status_updates:
-        if "error" in status_update:
+        if "error" in status_update.keys():
             logger.error(
                 "Image build error details: '%s'", str(status_update.get("errorDetail"))
             )
@@ -664,7 +664,7 @@ def _push_image(
         return _reload_image_uri(image=image)
 
     for status_update in status_updates:
-        if "error" in status_update:
+        if "error" in status_update.keys():
             logger.error(
                 "Image push error details: '%s'", str(status_update.get("errorDetail"))
             )

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -180,7 +180,6 @@ class BuildConfig:
     """
 
     version: int
-    project: str
     image_script: Optional[str] = None
     base_uri: Optional[ImageURI] = None
     build: Optional[SourceBuildConfig] = None
@@ -201,9 +200,6 @@ class BuildConfig:
                 f"Unsupported build schema version! Expected: {BUILD_SCHEMA_VERSION}; "
                 f"got: {self.version}"
             )
-
-        if self.project is None or len(self.project) == 0:
-            raise BuildConfigurationError("`project` must be specified and non-empty!")
 
         if (
             self.image_script is None
@@ -452,11 +448,7 @@ def _build_image_from_base(
     """
     Builds the container image to use by adding layers to an existing base image.
     """
-    if build_config.push is None:
-        built_image_name = f"{build_config.project}:default"
-    else:
-        built_image_name = f"{build_config.project}:{build_config.push.get_tag()}"
-
+    built_image_name = _get_local_image_name(target=target, build_config=build_config)
     logger.info(
         "Building image '%s' starting from base: %s",
         built_image_name,
@@ -717,3 +709,19 @@ def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]
         return f"{k}={str(v).strip()}"
 
     return " ".join(sorted([f"{k}={str(v).strip()}" for k, v in status_update.items()]))
+
+
+def _get_local_image_name(target: str, build_config: BuildConfig) -> str:
+    """
+    Returns a local name to give to an image build for the specified target script,
+    according to the specified build configuration.
+    """
+    # TODO: switch from project-relative paths to build file-relative paths
+    dir_name = os.path.basename(os.path.dirname(os.path.abspath(target)))
+    if dir_name == "/":
+        dir_name = "default"
+
+    if build_config.push is None:
+        return f"{dir_name}:default"
+
+    return f"{dir_name}:{build_config.push.get_tag()}"

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -180,7 +180,6 @@ class BuildConfig:
     """
 
     version: int
-    project: str
     image_script: Optional[str] = None
     base_uri: Optional[ImageURI] = None
     build: Optional[SourceBuildConfig] = None
@@ -201,9 +200,6 @@ class BuildConfig:
                 f"Unsupported build schema version! Expected: {BUILD_SCHEMA_VERSION}; "
                 f"got: {self.version}!"
             )
-
-        if not self.project:
-            raise BuildConfigurationError("`project` must be non-empty!")
 
         if (
             self.image_script is None

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # isort: off
 # there is a collision between the docker-py library and the sematic/docker directory
@@ -47,12 +47,12 @@ FROM {base_uri}
 WORKDIR /
 
 RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python3.9-distutils
+RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{{sys.version_info.major}}.{{sys.version_info.minor}}')")-distutils
 
 ENV PATH="/sematic/bin/:${{PATH}}"
-RUN echo '#!/bin/sh' > launch.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> launch.sh
-RUN chmod +x /launch.sh
-ENTRYPOINT ["/launch.sh"]
+RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 """  # noqa: E501
 
 _DOCKERFILE_REQUIREMENTS_TEMPLATE = """
@@ -180,6 +180,7 @@ class BuildConfig:
     """
 
     version: int
+    project: str
     image_script: Optional[str] = None
     base_uri: Optional[ImageURI] = None
     build: Optional[SourceBuildConfig] = None
@@ -198,8 +199,11 @@ class BuildConfig:
             # TODO: implement migration mechanism
             raise BuildConfigurationError(
                 f"Unsupported build schema version! Expected: {BUILD_SCHEMA_VERSION}; "
-                f"got: {self.version}!"
+                f"got: {self.version}"
             )
+
+        if self.project is None or len(self.project) == 0:
+            raise BuildConfigurationError("`project` must be specified and non-empty!")
 
         if (
             self.image_script is None
@@ -318,7 +322,7 @@ def _build(target: str) -> ImageURI:
     image, image_uri = _build_image(
         target=target, build_config=build_config, docker_client=docker_client
     )
-    logger.info("Built image: %s", repr(image_uri))
+    logger.info("Built local image: %s", repr(image_uri))
 
     build_image_uri = _push_image(
         image=image,
@@ -327,7 +331,7 @@ def _build(target: str) -> ImageURI:
         docker_client=docker_client,
     )
 
-    logger.info("Using image: '%s'", repr(build_image_uri))
+    logger.info("Using image: %s", repr(build_image_uri))
 
     return build_image_uri
 
@@ -448,18 +452,27 @@ def _build_image_from_base(
     """
     Builds the container image to use by adding layers to an existing base image.
     """
-    logger.info("Building image starting from base: %s", effective_base_uri)
+    if build_config.push is None:
+        built_image_name = f"{build_config.project}:default"
+    else:
+        built_image_name = f"{build_config.project}:{build_config.push.get_tag()}"
+
+    logger.info(
+        "Building image '%s' starting from base: %s",
+        built_image_name,
+        effective_base_uri,
+    )
 
     dockerfile_contents = _generate_dockerfile_contents(
         base_uri=effective_base_uri,
         source_build_config=build_config.build,
         target=target if build_config.base_uri is not None else None,
     )
-    logger.info("Using Dockerfile:\n%s", dockerfile_contents)
+    logger.debug("Using Dockerfile:\n%s", dockerfile_contents)
 
     # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
     # of the docker_client, because it does not work with contexts, so operations like
-    # COPY do not work, as there exists no working dir context to copy them from
+    # COPY do not work, as there exists no working dir context to copy the targets from
     # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
     # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
     with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
@@ -475,13 +488,13 @@ def _build_image_from_base(
             # use the project root as the context
             # TODO: switch from project-relative paths to build file-relative paths
             path=os.getcwd(),
-            tag=str(effective_base_uri),
+            tag=built_image_name,
             decode=True,
             **optional_kwargs,
         )
 
     if status_updates is None:
-        logger.warning("Built image '%s' without any response", effective_base_uri)
+        logger.warning("Built image '%s' without any response", built_image_name)
         image = docker_client.images.get(str(effective_base_uri))
         return image, ImageURI.from_image(image)
 
@@ -490,12 +503,15 @@ def _build_image_from_base(
             logger.error(
                 "Image build error details: '%s'", str(status_update.get("errorDetail"))
             )
-            raise BuildError(f"Unable to build image: {status_update['error']}")
+            raise BuildError(
+                f"Unable to build image '{built_image_name}': {status_update['error']}"
+            )
 
-        update_str = " ".join(sorted([f"{k}={v}" for k, v in status_update.items()]))
-        logger.info("Image build update: %s", update_str.strip())
+        update_str = _docker_status_update_to_str(status_update)
+        if update_str is not None:
+            logger.info("Image build update: %s", update_str)
 
-    image = docker_client.images.get(str(effective_base_uri))
+    image = docker_client.images.get(built_image_name)
     return image, ImageURI.from_image(image)
 
 
@@ -513,14 +529,14 @@ def _generate_dockerfile_contents(
     dockerfile_contents = _DOCKERFILE_BASE_TEMPLATE.format(base_uri=base_uri)
 
     if source_build_config is not None and source_build_config.requirements is not None:
-        logger.info("Adding requirements file: %s", source_build_config.requirements)
+        logger.debug("Adding requirements file: %s", source_build_config.requirements)
         requirements_contents = _DOCKERFILE_REQUIREMENTS_TEMPLATE.format(
             requirements_file=source_build_config.requirements
         )
         dockerfile_contents = f"{dockerfile_contents}{requirements_contents}"
 
     if source_build_config is not None and source_build_config.data is not None:
-        logger.info("Adding data files: %s", source_build_config.data)
+        logger.debug("Adding data files: %s", source_build_config.data)
         for data_glob in source_build_config.data:
             data_files = glob.glob(data_glob)
             if len(data_files) > 0:
@@ -530,7 +546,7 @@ def _generate_dockerfile_contents(
                     )
 
     if source_build_config is not None and source_build_config.src is not None:
-        logger.info("Adding source files: %s", source_build_config.src)
+        logger.debug("Adding source files: %s", source_build_config.src)
         for src_glob in source_build_config.src:
             src_files = glob.glob(src_glob)
             if len(src_files) > 0:
@@ -540,7 +556,7 @@ def _generate_dockerfile_contents(
                     )
 
     elif target is not None:
-        logger.info("Adding target source file: %s", target)
+        logger.debug("Adding target source file: %s", target)
         dockerfile_contents = f"{dockerfile_contents}\nCOPY {target} {target}"
 
     return dockerfile_contents
@@ -631,10 +647,7 @@ def _push_image(
         )
 
     logger.info(
-        "Tagged image '%s' in repository '%s' with tag '%s'",
-        image_uri,
-        repository,
-        tag,
+        "Tagged image '%s' in repository '%s' with tag '%s'", image_uri, repository, tag
     )
 
     status_updates = docker_client.images.push(
@@ -657,8 +670,9 @@ def _push_image(
             )
             raise BuildError(f"Unable to push image: {status_update['error']}")
 
-        update_str = " ".join(sorted([f"{k}={v}" for k, v in status_update.items()]))
-        logger.info("Image push update: %s", update_str.strip())
+        update_str = _docker_status_update_to_str(status_update)
+        if update_str is not None:
+            logger.info("Image push update: %s", update_str)
 
     return _reload_image_uri(image=image)
 
@@ -683,3 +697,23 @@ def _reload_image_uri(image: Image) -> ImageURI:  # type: ignore
     repository, tag = image.attrs["RepoTags"][0].split(":")
 
     return ImageURI(repository=repository, tag=tag, digest=digest)
+
+
+def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]:
+    """
+    Returns a textual representation of the status update dict received from the Docker
+    server, or None if it was devoid of useful information.
+    """
+    length = len(status_update)
+
+    if length == 0:
+        return None
+
+    if length == 1:
+        k, v = next(iter(status_update.items()))
+        if v is None or len(str(v).strip()) == 0:
+            # only one key with an empty value
+            return None
+        return f"{k}={str(v).strip()}"
+
+    return " ".join(sorted([f"{k}={str(v).strip()}" for k, v in status_update.items()]))

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -2,15 +2,17 @@
 The native Docker Builder plugin implementation.
 """
 # Standard Library
+import glob
 import logging
 import os
 import re
 import runpy
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # isort: off
 # there is a collision between the docker-py library and the sematic/docker directory
@@ -18,6 +20,7 @@ from typing import List, Optional
 # Third-party
 import docker
 import yaml
+from docker.models.images import Image  # type: ignore
 
 # isort: on
 
@@ -38,6 +41,24 @@ BUILD_SCHEMA_VERSION = 0
 
 # TODO: bump to 0.1.0 when the build system is exposed to users
 _PLUGIN_VERSION = (0, 0, 1)
+
+_DOCKERFILE_BASE_TEMPLATE = """
+FROM {base_uri}
+WORKDIR /
+
+RUN which pip3 || apt update -y && apt install -y python3-pip
+RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python3.9-distutils
+
+ENV PATH="/sematic/bin/:${{PATH}}"
+RUN echo '#!/bin/sh' > launch.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> launch.sh
+RUN chmod +x /launch.sh
+ENTRYPOINT ["/launch.sh"]
+"""  # noqa: E501
+
+_DOCKERFILE_REQUIREMENTS_TEMPLATE = """
+COPY {requirements_file} requirements.txt
+RUN pip3 install --no-cache -r requirements.txt
+"""
 
 
 @dataclass
@@ -73,6 +94,23 @@ class ImageURI:
             repository=match.group(1), tag=match.group(2), digest=match.group(3)
         )
 
+    @classmethod
+    def from_image(cls, image: Image) -> "ImageURI":
+        """
+        Returns an `ImageURI` that identifies the specified image.
+
+        Raises
+        ------
+        ValueError:
+            The specified image does not have a defined repository/tag, which is required
+            for generating a URI in the `<repository>:<tag>@<digest>` format.
+        """
+        if len(image.attrs.get("RepoTags", [])) == 0:
+            raise ValueError(f"Container image '{image.id}' does not have a defined tag!")
+
+        repository, tag = image.attrs["RepoTags"][0].split(":")
+        return ImageURI(repository=repository, tag=tag, digest=image.id)
+
     def __str__(self):
         """
         Returns a short `<repository>:<tag>` version of this image URI.
@@ -92,6 +130,7 @@ class SourceBuildConfig:
     A packaged build source file configuration.
     """
 
+    platform: Optional[str] = None
     requirements: Optional[str] = None
     data: Optional[str] = None
     src: Optional[str] = None
@@ -139,6 +178,7 @@ class BuildConfig:
     """
 
     version: int
+    project: str
     image_script: Optional[str] = None
     base_uri: Optional[ImageURI] = None
     build: Optional[SourceBuildConfig] = None
@@ -159,6 +199,9 @@ class BuildConfig:
                 f"Unsupported build schema version! Expected: {BUILD_SCHEMA_VERSION}; "
                 f"got: {self.version}!"
             )
+
+        if not self.project:
+            raise BuildConfigurationError("`project` must be non-empty!")
 
         if (
             self.image_script is None
@@ -240,63 +283,73 @@ class DockerBuilder(AbstractBuilder):
     def get_version() -> PluginVersion:
         return _PLUGIN_VERSION
 
-    def build_and_launch(self, target: str):
+    def build_and_launch(self, target: str) -> None:
         """
         Builds a container image and launches the specified target launch script, based on
         proprietary build configuration files.
+
+        Parameters
+        ----------
+        target: str
+            The path to the pipeline target to launch; the built image must support this
+            target's execution.
+
+        Raises
+        ------
+        BuildError:
+            There was an error when executing the specified build script.
+        BuildConfigurationError:
+            There was an error when validating the specified build configuration.
         """
-        image_uri = self._build(target=target)
-        self._launch(target=target, image_uri=image_uri)
+        image_uri = _build(target=target)
+        _launch(target=target, image_uri=image_uri)
 
-    def _build(self, target: str) -> ImageURI:
-        """
-        Builds the container image, returning the image URI that can be used to launch
-        executions.
-        """
-        build_config = _get_build_config(script_path=target)
-        logger.info("Loaded build configuration: %s", build_config)
 
-        base_image_uri = _build_image(build_config=build_config, target=target)
-        logger.info("Using container base image URI: %s", repr(base_image_uri))
+def _build(target: str) -> ImageURI:
+    """
+    Builds the container image, returning the image URI that can be used to launch
+    executions.
+    """
+    build_config = _get_build_config(script_path=target)
+    logger.info("Loaded build configuration: %s", build_config)
 
-        # TODO: configure the docker service connection string in the build file
-        docker_client = docker.from_env()  # type: ignore
+    # TODO: configure the docker service connection string in the build file
+    docker_client = docker.from_env()  # type: ignore
+    logger.info(
+        "Instantiated docker client for server: %s", docker_client.api.base_url
+    )
 
-        # TODO: pull if it is not available locally
-        image = docker_client.images.get(str(base_image_uri))
-        if image.id != base_image_uri.digest:
-            raise BuildError(
-                f"Digest mismatch for image '{base_image_uri}'; "
-                f"expected: {base_image_uri.digest} got: {image.id}"
-            )
+    image, image_uri = _build_image(
+        target=target, build_config=build_config, docker_client=docker_client
+    )
+    logger.info("Built image: %s", repr(image_uri))
 
-        logger.info("Found base image: '%s'", base_image_uri)
+    build_image_uri = _push_image(
+        image=image,
+        image_uri=image_uri,
+        push_config=build_config.push,
+        docker_client=docker_client,
+    )
 
-        build_image_uri = _push_image(
-            image=image,
-            image_uri=base_image_uri,
-            push_config=build_config.push,
-            docker_client=docker_client,
-        )
+    logger.info("Using image: '%s'", repr(build_image_uri))
 
-        logger.info("Finished building image: '%s'", repr(build_image_uri))
+    return build_image_uri
 
-        return build_image_uri
 
-    def _launch(self, target: str, image_uri: ImageURI) -> None:
-        """
-        Launches the specified user code target, using the specified image.
-        """
-        sys.path.append(os.getcwd())
-        # TODO: revert this overwrite after finishing execution
-        #  promote the `environment_variables` testing fixture to a utility
-        os.environ[CONTAINER_IMAGE_ENV_VAR] = repr(image_uri)
+def _launch(target: str, image_uri: ImageURI) -> None:
+    """
+    Launches the specified user code target, using the specified image.
+    """
+    sys.path.append(os.getcwd())
+    # TODO: revert this overwrite after finishing execution
+    #  promote the `environment_variables` testing fixture to a utility
+    os.environ[CONTAINER_IMAGE_ENV_VAR] = repr(image_uri)
 
-        logger.info("Launching target: '%s'", target)
+    logger.info("Launching target: '%s'", target)
 
-        runpy.run_path(path_name=target, run_name="__main__")
+    runpy.run_path(path_name=target, run_name="__main__")
 
-        logger.info("Finished launching target: '%s'", target)
+    logger.info("Finished launching target: '%s'", target)
 
 
 def _get_build_config(script_path: str) -> BuildConfig:
@@ -339,30 +392,167 @@ def _find_build_config_files(script_path: str) -> List[str]:
     return [file_candidate] if os.path.isfile(file_candidate) else []
 
 
-def _build_image(build_config: BuildConfig, target: str) -> ImageURI:
+def _build_image(
+    target: str,
+    build_config: BuildConfig,
+    docker_client: docker.DockerClient,  # type: ignore
+) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use, according to the build configuration, and returns
     an `ImageURI` that identifies it.
 
+    Parameters
+    ----------
+    target: str
+        The path to the pipeline target to launch; the built image must support this
+        target's execution.
+    build_config: BuildConfig
+        The configuration that controls the image build.
+    docker_client: docker.DockerClient
+        The client to use for executing the operations.
+
+    Returns
+    -------
+    Tuple[Image, ImageURI]:
+        The build container image and a URI that identifies the image.
+
     Raises
     ------
     BuildError:
-        There was an error when executing the specified build script.
+        There was an error when building the image.
     BuildConfigurationError:
         There was an error when validating the specified build configuration.
+    SystemExit:
+        A subprocess exited with an unexpected code.
     """
     if build_config.base_uri is not None:
-        # TODO: honor configurations in build_config.build
-        return build_config.base_uri
-
-    if build_config.image_script is None:
-        # appease mypy
-        raise BuildConfigurationError(
-            "Exactly one of `image_script` and `base_uri` must be specified!"
+        return _build_image_from_base(
+            target=target, build_config=build_config, docker_client=docker_client
         )
 
+    if build_config.image_script is not None:
+        return _execute_build_script(
+            target=target,
+            image_script=build_config.image_script,
+            docker_client=docker_client,
+        )
+
+    # should be unreachable code, here for a sanity check
+    raise BuildConfigurationError(
+        "Exactly one of `image_script` and `base_uri` must be specified!"
+    )
+
+
+def _build_image_from_base(
+    target: str,
+    build_config: BuildConfig,
+    docker_client: docker.DockerClient,  # type: ignore
+) -> Tuple[Image, ImageURI]:
+    """
+    Builds the container image to use by adding layers to an existing base image.
+    """
+    image_name = f"{build_config.project}:{build_config.push.get_tag()}"
+    logger.error("Building container image %s", image_name)
+
+    dockerfile_contents = _generate_dockerfile_contents(
+        target=target, build_config=build_config
+    )
+    logger.error("Using Dockerfile:\n%s", dockerfile_contents)
+
+    # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
+    # of the docker_client, because it does not work with contexts, so operations like
+    # COPY do not work, as there exists no working dir context to copy them from
+    # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
+    # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
+        dockerfile.write(dockerfile_contents)
+        dockerfile.flush()
+
+        optional_kwargs = dict()
+        if build_config.build.platform is not None:
+            optional_kwargs["platform"] = build_config.build.platform
+
+        status_updates = docker_client.api.build(
+            dockerfile=dockerfile.name,
+            # use the project root as the context
+            path=os.getcwd(),
+            tag=image_name,
+            pull=True,
+            decode=True,
+            **optional_kwargs
+        )
+
+    if status_updates is None:
+        logger.warning("Built image '%s' without any response", build_config.base_uri)
+        image = docker_client.images.get(image_name)
+        return image, ImageURI.from_image(image)
+
+    for status_update in status_updates:
+        if "error" in status_update:
+            logger.error(
+                "Image push error details: '%s'", str(status_update.get("errorDetail"))
+            )
+            raise BuildError(f"Unable to build image: {status_update['error']}")
+
+        update_str = " ".join(sorted([f"{k}={v}" for k, v in status_update.items()]))
+        logger.error("Image build update: %s", update_str.strip())
+
+    image = docker_client.images.get(image_name)
+    return image, ImageURI.from_image(image)
+
+
+def _generate_dockerfile_contents(target: str, build_config: BuildConfig) -> str:
+    """
+    Generates the Dockerfile contents based on the config, using templates.
+    """
+    dockerfile_contents = _DOCKERFILE_BASE_TEMPLATE.format(base_uri=build_config.base_uri)
+
+    if build_config.build.requirements is not None:
+        logger.error("Adding requirements file")
+        requirements_contents = _DOCKERFILE_REQUIREMENTS_TEMPLATE.format(
+            requirements_file=build_config.build.requirements
+        )
+        dockerfile_contents = f"{dockerfile_contents}{requirements_contents}"
+
+    if build_config.build.data is not None:
+        logger.error("Adding data files")
+        for data_glob in build_config.build.data:
+            data_files = glob.glob(data_glob)
+            if len(data_files) > 0:
+                for data_file in data_files:
+                    dockerfile_contents = (
+                        f"{dockerfile_contents}\nCOPY {data_file} {data_file}"
+                    )
+
+    if build_config.build.src is not None:
+        logger.error("Adding source files")
+        for src_glob in build_config.build.src:
+            src_files = glob.glob(src_glob)
+            if len(src_files) > 0:
+                for scr_file in src_files:
+                    dockerfile_contents = (
+                        f"{dockerfile_contents}\nCOPY {scr_file} {scr_file}"
+                    )
+
+    elif build_config.base_uri is not None:
+        logger.error("Adding target source file")
+        dockerfile_contents = (
+            f"{dockerfile_contents}\nCOPY {target} {target}"
+        )
+
+    return dockerfile_contents
+
+
+def _execute_build_script(
+    target: str,
+    image_script: str,
+    docker_client: docker.DockerClient,  # type: ignore
+) -> Tuple[Image, ImageURI]:
+    """
+    Builds the container image to use by executing the specified script.
+    """
     try:
-        script_dir, script_file = os.path.split(build_config.image_script)
+        script_dir, script_file = os.path.split(image_script)
         if script_dir == "":
             script_dir = None  # type: ignore
         script_file = f"./{script_file}"
@@ -381,23 +571,23 @@ def _build_image(build_config: BuildConfig, target: str) -> ImageURI:
             text=True,
         ) as subproc:
 
-            image_uri, _ = subproc.communicate()
+            raw_uri, _ = subproc.communicate()
 
             if subproc.returncode != 0:
                 raise SystemExit(subproc.returncode)
 
-            image_uri = image_uri.strip()
+            image_uri = ImageURI.from_uri(uri=raw_uri.strip())
+            image = docker_client.images.get(str(image_uri))
+            return image, image_uri
 
     except BaseException as e:
         raise BuildError(
-            f"Unable to source container image URI from '{build_config.image_script}'!"
+            f"Unable to source container image URI from '{image_script}'!"
         ) from e
-
-    return ImageURI.from_uri(uri=image_uri)
 
 
 def _push_image(
-    image: docker.models.images.Image,  # type: ignore
+    image: Image,  # type: ignore
     image_uri: ImageURI,
     push_config: Optional[ImagePushConfig],
     docker_client: docker.DockerClient,  # type: ignore
@@ -409,7 +599,7 @@ def _push_image(
 
     Parameters
     ----------
-    image: docker.models.images.Image
+    image: Image
         The image to push
     image_uri: ImageURI
         The initial URI of the image to push
@@ -450,11 +640,11 @@ def _push_image(
         tag,
     )
 
-    response = docker_client.images.push(
+    status_updates = docker_client.images.push(
         repository=repository, tag=tag, stream=True, decode=True
     )
 
-    if response is None:
+    if status_updates is None:
         logger.warning(
             "Pushed image '%s' to repository '%s' with tag '%s', without any response",
             image_uri,
@@ -463,7 +653,7 @@ def _push_image(
         )
         return _reload_image_uri(image=image)
 
-    for status_update in response:
+    for status_update in status_updates:
         if "error" in status_update:
             logger.error(
                 "Image push error details: '%s'", str(status_update.get("errorDetail"))
@@ -471,12 +661,12 @@ def _push_image(
             raise BuildError(f"Unable to push image: {status_update['error']}")
 
         update_str = " ".join(sorted([f"{k}={v}" for k, v in status_update.items()]))
-        logger.info("Image push update: %s", update_str)
+        logger.info("Image push update: %s", update_str.strip())
 
     return _reload_image_uri(image=image)
 
 
-def _reload_image_uri(image: docker.models.images.Image) -> ImageURI:  # type: ignore
+def _reload_image_uri(image: Image) -> ImageURI:  # type: ignore
     """
     Reloads an image's tags and digest after it has been pushed to a repository, returning
     an `ImageURI` that locates it in that repository.
@@ -488,6 +678,8 @@ def _reload_image_uri(image: docker.models.images.Image) -> ImageURI:  # type: i
         image.reload()
 
     # couldn't find any better way of doing this
+    # we know "RepoTags" and "RepoDigests" exist because we just pushed the image,
+    # filling in those attrs
     digest = image.attrs["RepoDigests"][0].split("@")[1]
     # "RepoDigests" does not contain the fully qualified repo and tag;
     # we must use "RepoTags"

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -106,7 +106,9 @@ class ImageURI:
             for generating a URI in the `<repository>:<tag>@<digest>` format.
         """
         if len(image.attrs.get("RepoTags", [])) == 0:
-            raise ValueError(f"Container image '{image.id}' does not have a defined tag!")
+            raise ValueError(
+                f"Container image '{image.id}' does not have a defined tag!"
+            )
 
         repository, tag = image.attrs["RepoTags"][0].split(":")
         return ImageURI(repository=repository, tag=tag, digest=image.id)
@@ -315,9 +317,7 @@ def _build(target: str) -> ImageURI:
 
     # TODO: configure the docker service connection string in the build file
     docker_client = docker.from_env()  # type: ignore
-    logger.info(
-        "Instantiated docker client for server: %s", docker_client.api.base_url
-    )
+    logger.info("Instantiated docker client for server: %s", docker_client.api.base_url)
 
     image, image_uri = _build_image(
         target=target, build_config=build_config, docker_client=docker_client
@@ -425,39 +425,41 @@ def _build_image(
     SystemExit:
         A subprocess exited with an unexpected code.
     """
-    if build_config.base_uri is not None:
-        return _build_image_from_base(
-            target=target, build_config=build_config, docker_client=docker_client
-        )
+    effective_base_uri = build_config.base_uri
 
     if build_config.image_script is not None:
-        return _execute_build_script(
-            target=target,
-            image_script=build_config.image_script,
-            docker_client=docker_client,
+        effective_base_uri = _execute_build_script(
+            target=target, image_script=build_config.image_script
         )
 
-    # should be unreachable code, here for a sanity check
-    raise BuildConfigurationError(
-        "Exactly one of `image_script` and `base_uri` must be specified!"
+    # appease mypy
+    assert effective_base_uri is not None
+
+    return _build_image_from_base(
+        target=target,
+        effective_base_uri=effective_base_uri,
+        build_config=build_config,
+        docker_client=docker_client,
     )
 
 
 def _build_image_from_base(
     target: str,
+    effective_base_uri: ImageURI,
     build_config: BuildConfig,
     docker_client: docker.DockerClient,  # type: ignore
 ) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use by adding layers to an existing base image.
     """
-    image_name = f"{build_config.project}:{build_config.push.get_tag()}"
-    logger.error("Building container image %s", image_name)
+    logger.info("Building image starting from base: %s", effective_base_uri)
 
     dockerfile_contents = _generate_dockerfile_contents(
-        target=target, build_config=build_config
+        base_uri=effective_base_uri,
+        source_build_config=build_config.build,
+        target=target if build_config.base_uri is not None else None,
     )
-    logger.error("Using Dockerfile:\n%s", dockerfile_contents)
+    logger.info("Using Dockerfile:\n%s", dockerfile_contents)
 
     # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
     # of the docker_client, because it does not work with contexts, so operations like
@@ -469,54 +471,61 @@ def _build_image_from_base(
         dockerfile.flush()
 
         optional_kwargs = dict()
-        if build_config.build.platform is not None:
+        if build_config.build is not None and build_config.build.platform is not None:
             optional_kwargs["platform"] = build_config.build.platform
 
         status_updates = docker_client.api.build(
             dockerfile=dockerfile.name,
             # use the project root as the context
+            # TODO: switch from project-relative paths to build file-relative paths
             path=os.getcwd(),
-            tag=image_name,
-            pull=True,
+            tag=str(effective_base_uri),
             decode=True,
-            **optional_kwargs
+            **optional_kwargs,
         )
 
     if status_updates is None:
-        logger.warning("Built image '%s' without any response", build_config.base_uri)
-        image = docker_client.images.get(image_name)
+        logger.warning("Built image '%s' without any response", effective_base_uri)
+        image = docker_client.images.get(str(effective_base_uri))
         return image, ImageURI.from_image(image)
 
     for status_update in status_updates:
         if "error" in status_update:
             logger.error(
-                "Image push error details: '%s'", str(status_update.get("errorDetail"))
+                "Image build error details: '%s'", str(status_update.get("errorDetail"))
             )
             raise BuildError(f"Unable to build image: {status_update['error']}")
 
         update_str = " ".join(sorted([f"{k}={v}" for k, v in status_update.items()]))
-        logger.error("Image build update: %s", update_str.strip())
+        logger.info("Image build update: %s", update_str.strip())
 
-    image = docker_client.images.get(image_name)
+    image = docker_client.images.get(str(effective_base_uri))
     return image, ImageURI.from_image(image)
 
 
-def _generate_dockerfile_contents(target: str, build_config: BuildConfig) -> str:
+def _generate_dockerfile_contents(
+    base_uri: ImageURI,
+    source_build_config: Optional[SourceBuildConfig],
+    target: Optional[str],
+) -> str:
     """
     Generates the Dockerfile contents based on the config, using templates.
-    """
-    dockerfile_contents = _DOCKERFILE_BASE_TEMPLATE.format(base_uri=build_config.base_uri)
 
-    if build_config.build.requirements is not None:
-        logger.error("Adding requirements file")
+    If the `target` parameter is specified, then the Dockerfile will be generated to copy
+    it even if no other source files are specified.
+    """
+    dockerfile_contents = _DOCKERFILE_BASE_TEMPLATE.format(base_uri=base_uri)
+
+    if source_build_config is not None and source_build_config.requirements is not None:
+        logger.info("Adding requirements file: %s", source_build_config.requirements)
         requirements_contents = _DOCKERFILE_REQUIREMENTS_TEMPLATE.format(
-            requirements_file=build_config.build.requirements
+            requirements_file=source_build_config.requirements
         )
         dockerfile_contents = f"{dockerfile_contents}{requirements_contents}"
 
-    if build_config.build.data is not None:
-        logger.error("Adding data files")
-        for data_glob in build_config.build.data:
+    if source_build_config is not None and source_build_config.data is not None:
+        logger.info("Adding data files: %s", source_build_config.data)
+        for data_glob in source_build_config.data:
             data_files = glob.glob(data_glob)
             if len(data_files) > 0:
                 for data_file in data_files:
@@ -524,9 +533,9 @@ def _generate_dockerfile_contents(target: str, build_config: BuildConfig) -> str
                         f"{dockerfile_contents}\nCOPY {data_file} {data_file}"
                     )
 
-    if build_config.build.src is not None:
-        logger.error("Adding source files")
-        for src_glob in build_config.build.src:
+    if source_build_config is not None and source_build_config.src is not None:
+        logger.info("Adding source files: %s", source_build_config.src)
+        for src_glob in source_build_config.src:
             src_files = glob.glob(src_glob)
             if len(src_files) > 0:
                 for scr_file in src_files:
@@ -534,20 +543,14 @@ def _generate_dockerfile_contents(target: str, build_config: BuildConfig) -> str
                         f"{dockerfile_contents}\nCOPY {scr_file} {scr_file}"
                     )
 
-    elif build_config.base_uri is not None:
-        logger.error("Adding target source file")
-        dockerfile_contents = (
-            f"{dockerfile_contents}\nCOPY {target} {target}"
-        )
+    elif target is not None:
+        logger.info("Adding target source file: %s", target)
+        dockerfile_contents = f"{dockerfile_contents}\nCOPY {target} {target}"
 
     return dockerfile_contents
 
 
-def _execute_build_script(
-    target: str,
-    image_script: str,
-    docker_client: docker.DockerClient,  # type: ignore
-) -> Tuple[Image, ImageURI]:
+def _execute_build_script(target: str, image_script: str) -> ImageURI:
     """
     Builds the container image to use by executing the specified script.
     """
@@ -576,9 +579,7 @@ def _execute_build_script(
             if subproc.returncode != 0:
                 raise SystemExit(subproc.returncode)
 
-            image_uri = ImageURI.from_uri(uri=raw_uri.strip())
-            image = docker_client.images.get(str(image_uri))
-            return image, image_uri
+            return ImageURI.from_uri(uri=raw_uri.strip())
 
     except BaseException as e:
         raise BuildError(


### PR DESCRIPTION
This is the second PR in a chain that introduces a Build System plugin with an implementation that uses native Python+Docker capabilities to build a container image and launch a pipeline, without requiring Bazel. The previous PR in the chain is #777.

This PR implements functionality that installs requirements, data files, source files, and an entry point on top of the base image. The base image can either be supplied directly in the build config file, or the result of executing the build script. This takes away responsibility from the user supplying a complete image.

Updated https://github.com/sematic-ai/example_docker/pull/1 with the changes from this PR. Of note, removed the entry point requirements from the advanced case, and added the `project` field.

## Testing

Unit tests will be introduced in a subsequent PR.

Manually confirmed the custom image case from #777 still works (Dashboard execution [link](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/057af0b4ea124fd6968f37273c04d823#tab=output)).

Manually tested the base image case (Dashboard execution [link](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/192a4fef27194040b1d1ff1439314cd6)). Full logs in [this gist](https://gist.github.com/tscurtu/4b8f7026ac8b0c04f92bdf29c904fffe) for a completely clean installation (no locally-cached layers), and for more verbose logs than in the final PR version.

```bash
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$ time sematic run intermediate/main.py --build -- /intermediate/data/message.txt
Building image and launching: '['intermediate/main.py', '/intermediate/data/message.txt']'
INFO:sematic.plugins.building.docker_builder:Script 'intermediate/main.py' has these corresponding build files: ['intermediate/main.yaml']
INFO:sematic.plugins.building.docker_builder:Loaded build configuration: BuildConfig(version=0, project='example_docker', image_script=None, base_uri=sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c, build=SourceBuildConfig(platform='linux/amd64', requirements='requirements.txt', data=['intermediate/data/message.txt'], src=['intermediate/**.py']), push=ImagePushConfig(registry='558717131297.dkr.ecr.us-west-2.amazonaws.com', repository='sematic-dev', tag_suffix='example_docker_intermediate'))
INFO:sematic.plugins.building.docker_builder:Instantiated docker client for server: http+docker://localhost
INFO:sematic.plugins.building.docker_builder:Building image 'example_docker:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
INFO:sematic.plugins.building.docker_builder:Using Dockerfile:

FROM sematicai/sematic-worker-base:latest
WORKDIR /

RUN which pip3 || apt update -y && apt install -y python3-pip
RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils

ENV PATH="/sematic/bin/:${PATH}"
RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
RUN chmod +x /entrypoint.sh
ENTRYPOINT ["/entrypoint.sh"]

COPY requirements.txt requirements.txt
RUN pip3 install --no-cache -r requirements.txt

COPY intermediate/data/message.txt intermediate/data/message.txt
COPY intermediate/__init__.py intermediate/__init__.py
COPY intermediate/pipeline.py intermediate/pipeline.py
COPY intermediate/main.py intermediate/main.py
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 1/14 : FROM sematicai/sematic-worker-base:latest
INFO:sematic.plugins.building.docker_builder:Image build update: id=latest status=Pulling from sematicai/sematic-worker-base

[...]

INFO:sematic.plugins.building.docker_builder:Image push update: id=e5bf7c06a727 progress=[==================================================>]  325.6MB progressDetail={'current': 325576704, 'total': 319684905} status=Pushing
INFO:sematic.plugins.building.docker_builder:Image push update: id=e5bf7c06a727 progressDetail={} status=Pushed
INFO:sematic.plugins.building.docker_builder:Image push update: status=default_example_docker_intermediate: digest: sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119 size: 4920
INFO:sematic.plugins.building.docker_builder:Image push update: aux={'Tag': 'default_example_docker_intermediate', 'Digest': 'sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119', 'Size': 4920} progressDetail={}
INFO:sematic.plugins.building.docker_builder:Using image: 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119
INFO:sematic.plugins.building.docker_builder:Launching target: 'intermediate/main.py'
INFO:sematic.plugins.building.docker_builder:Finished launching target: 'intermediate/main.py'
192a4fef27194040b1d1ff1439314cd6
Launched 'intermediate/main.py'

real    15m41.130s
user    0m2.293s
sys     0m1.677s
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$
```

Example full logs from a submission when all layers are cached:

```bash
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$ time sematic run intermediate/main.py --build -- /intermediate/data/message.txt 2>&1 | tee cached.log
Building image and launching: '['intermediate/main.py', '/intermediate/data/message.txt']'
INFO:sematic.plugins.building.docker_builder:Script 'intermediate/main.py' has these corresponding build files: ['intermediate/main.yaml']
INFO:sematic.plugins.building.docker_builder:Loaded build configuration: BuildConfig(version=0, project='example_docker', image_script=None, base_uri=sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c, build=SourceBuildConfig(platform='linux/amd64', requirements='requirements.txt', data=['intermediate/data/message.txt'], src=['intermediate/**.py']), push=ImagePushConfig(registry='558717131297.dkr.ecr.us-west-2.amazonaws.com', repository='sematic-dev', tag_suffix='example_docker_intermediate'))
INFO:sematic.plugins.building.docker_builder:Instantiated docker client for server: http+docker://localhost
INFO:sematic.plugins.building.docker_builder:Building image 'example_docker:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 1/14 : FROM sematicai/sematic-worker-base:latest
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 99fcf4928f3b
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 2/14 : WORKDIR /
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 846f9fbcfe0b
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 3/14 : RUN which pip3 || apt update -y && apt install -y python3-pip
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 14834a2a7e0b
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 4/14 : RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 92ea8dd37695
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 5/14 : ENV PATH="/sematic/bin/:${PATH}"
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 69faf484bd68
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 6/14 : RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 40f6eff59617
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 7/14 : RUN chmod +x /entrypoint.sh
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 8b2f09e94702
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 8/14 : ENTRYPOINT ["/entrypoint.sh"]
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> a9037eab9c85
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 9/14 : COPY requirements.txt requirements.txt
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 47cae5bee1e8
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 10/14 : RUN pip3 install --no-cache -r requirements.txt
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> a8b3f2d31a36
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 11/14 : COPY intermediate/data/message.txt intermediate/data/message.txt
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> c9e6bfc48b72
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 12/14 : COPY intermediate/__init__.py intermediate/__init__.py
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> 92adf19db3e4
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 13/14 : COPY intermediate/pipeline.py intermediate/pipeline.py
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> b354cf186608
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Step 14/14 : COPY intermediate/main.py intermediate/main.py
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> Using cache
INFO:sematic.plugins.building.docker_builder:Image build update: stream=---> d053226096b6
INFO:sematic.plugins.building.docker_builder:Image build update: aux={'ID': 'sha256:d053226096b6b395cae173a54eeb9d120f245b8bc83414aaf0fe97e6ae5cd218'}
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Successfully built d053226096b6
INFO:sematic.plugins.building.docker_builder:Image build update: stream=Successfully tagged example_docker:default_example_docker_intermediate
INFO:sematic.plugins.building.docker_builder:Built local image: 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:d053226096b6b395cae173a54eeb9d120f245b8bc83414aaf0fe97e6ae5cd218
INFO:sematic.plugins.building.docker_builder:Tagged image '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_intermediate'
INFO:sematic.plugins.building.docker_builder:Image push update: status=The push refers to repository [558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev]
INFO:sematic.plugins.building.docker_builder:Image push update: id=947fdf6f9f71 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=bb0a64732df3 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=268a8e99abb4 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=f9218f1a3d20 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=6f3d1fb3828a progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=b826f9d02a82 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=4f31ab6e0672 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=0f563d8843cf progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=b826f9d02a82 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=4f31ab6e0672 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=c220ecdf56e3 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=e5bf7c06a727 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=0f563d8843cf progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=c220ecdf56e3 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=88606090f580 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=48c32d9bdc4d progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=c4cc4bb05252 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=e5bf7c06a727 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=fb265646f04f progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=88606090f580 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=9e5b01064a07 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=48c32d9bdc4d progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=26aa9c02e99e progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=2b42b338bc03 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=c4cc4bb05252 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=dd2937225788 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=26aa9c02e99e progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=9e5b01064a07 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=2b42b338bc03 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=34200e553ba3 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=dd2937225788 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=fb265646f04f progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=69e041190553 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=34200e553ba3 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=af4418d96ca6 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=69e041190553 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=e59fc9495612 progressDetail={} status=Preparing
INFO:sematic.plugins.building.docker_builder:Image push update: id=af4418d96ca6 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=e59fc9495612 progressDetail={} status=Waiting
INFO:sematic.plugins.building.docker_builder:Image push update: id=f9218f1a3d20 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=268a8e99abb4 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=6f3d1fb3828a progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=bb0a64732df3 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=947fdf6f9f71 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=4f31ab6e0672 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=0f563d8843cf progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=b826f9d02a82 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=c220ecdf56e3 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=e5bf7c06a727 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=c4cc4bb05252 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=48c32d9bdc4d progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=88606090f580 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=9e5b01064a07 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=fb265646f04f progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=69e041190553 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=2b42b338bc03 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=26aa9c02e99e progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=dd2937225788 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=34200e553ba3 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=e59fc9495612 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: id=af4418d96ca6 progressDetail={} status=Layer already exists
INFO:sematic.plugins.building.docker_builder:Image push update: status=default_example_docker_intermediate: digest: sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119 size: 4920
INFO:sematic.plugins.building.docker_builder:Image push update: aux={'Tag': 'default_example_docker_intermediate', 'Digest': 'sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119', 'Size': 4920} progressDetail={}
INFO:sematic.plugins.building.docker_builder:Using image: 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:9e7e6228d70eac7f2fd67fb8f07e2d96c5f6ebbe880cc517ab5838806f5a2119
INFO:sematic.plugins.building.docker_builder:Launching target: 'intermediate/main.py'
INFO:sematic.plugins.building.docker_builder:Finished launching target: 'intermediate/main.py'
24534f8e1f214158ada8bf162d4f240c
Launched 'intermediate/main.py'

real    0m6.393s
user    0m1.557s
sys     0m0.885s
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$
```
