### PR TITLE
CI Test Config A: Control

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+# Config A
 
 # Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
 # See: https://circleci.com/docs/2.0/orb-intro/


### PR DESCRIPTION
## Related PRs:
#802 : No slow tests
#804 : No PYTHONBUFFERED
#805 : Beefier VM
#809 : Parallelize tests by splitting across python versions

## Control Results
[Trial 1](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3498/workflows/bf51ae15-1190-4819-8a8e-1d54eacbb198/jobs/10975): 11m39s
[Trial 2](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3498/workflows/c623ea9a-e9eb-4f15-b726-ed53bfd02464/jobs/11010): 11m47s
[Trial 3](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3498/workflows/16078d56-16f5-477d-95ef-43674fa042f5/jobs/11066): 10m1s
[Trial 4](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3498/workflows/34b65183-1947-4ce7-99ba-dd4b9da7d228/jobs/11087): 10m55s
[Trial 5](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3498/workflows/1e13c079-a5b1-4e6b-a9c9-3c4d196eed1a/jobs/11191): 12m3s

11m10s +/- 50s

## Result Summary

All results consist of 5 trials, except for the parallelization PR. That consists of one trial, where each parallel branch is considered a trial contributing to the final calculation. Uncertainties given are std deviations (typical deviation from the mean), not standard errors (uncertainty in the calculated mean). For std errors, you can divide stddevs by sqrt(n trials), which is ~2 for each result (uncertainties in uncertainties are always bad so no need to be too exact). So for the control, the stderr is about +/- 25s. The numbers are for the unit test step ONLY, not end-to-end CI time (to eliminate variance from other steps).

Control: 11m10s +/- 50s
No slow tests: 9m50s +/- 40s
No PYTHONBUFFERED: 9m50s +/- 40s
Beefier VM: 8m40s +/- 50s
Parallelize across python versions: 8m50s +/- 70s

From this I conclude that the only option of the ones explored that may meaningfully reduce CI time are the beefier VM and parallelization across python branches. However, these options roughly double or triple (respectively) CI costs. To get real, meaningful improvement in CI time without excessive cost, we likely need something like a remote bazel cache that can persist across instances, plus parallelizing across python versions. Alternatively, we could only test ONE python version for normal PRs, and run across all python versions only nightly or for release PRs.