### PR TITLE
Search table static page

### DIFF
--- a/sematic/ui/package-lock.json
+++ b/sematic/ui/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.2.0",
       "workspaces": [
         "packages/*"
-      ],
-      "devDependencies": {}
+      ]
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -6988,6 +6987,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-table/-/react-table-8.9.1.tgz",
+      "integrity": "sha512-yHs2m6lk5J5RNcu2dNtsDGux66wNXZjEgzxos6MRCX8gL+nqxeW3ZglqP6eANN0bGElPnjvqiUHGQvdACOr3Cw==",
+      "dependencies": {
+        "@tanstack/table-core": "8.9.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/table-core/-/table-core-8.9.1.tgz",
+      "integrity": "sha512-2+R83n8vMZND0q3W1lSiF7co9nFbeWbjAErFf27xwbeA9E0wtUu5ZDfgj+TZ6JzdAEQAgfxkk/QNFAKiS8E4MA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -27246,7 +27268,9 @@
       "name": "@sematic/common",
       "version": "0.2.0",
       "license": "ISC",
-      "devDependencies": {}
+      "dependencies": {
+        "@tanstack/react-table": "^8.9.1"
+      }
     },
     "packages/eslint-config": {
       "name": "@sematic/eslint-config",
@@ -30448,7 +30472,10 @@
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
     "@sematic/common": {
-      "version": "file:packages/common"
+      "version": "file:packages/common",
+      "requires": {
+        "@tanstack/react-table": "^8.9.1"
+      }
     },
     "@sematic/eslint-config": {
       "version": "file:packages/eslint-config"
@@ -32466,6 +32493,19 @@
         "@svgr/plugin-svgo": "^5.5.0",
         "loader-utils": "^2.0.0"
       }
+    },
+    "@tanstack/react-table": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-table/-/react-table-8.9.1.tgz",
+      "integrity": "sha512-yHs2m6lk5J5RNcu2dNtsDGux66wNXZjEgzxos6MRCX8gL+nqxeW3ZglqP6eANN0bGElPnjvqiUHGQvdACOr3Cw==",
+      "requires": {
+        "@tanstack/table-core": "8.9.1"
+      }
+    },
+    "@tanstack/table-core": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/table-core/-/table-core-8.9.1.tgz",
+      "integrity": "sha512-2+R83n8vMZND0q3W1lSiF7co9nFbeWbjAErFf27xwbeA9E0wtUu5ZDfgj+TZ6JzdAEQAgfxkk/QNFAKiS8E4MA=="
     },
     "@testing-library/dom": {
       "version": "8.13.0",

--- a/sematic/ui/package.json
+++ b/sematic/ui/package.json
@@ -2,7 +2,6 @@
   "name": "ui",
   "version": "0.2.0",
   "private": true,
-  "dependencies": {},
   "scripts": {
     "start": "npm run start --workspace @sematic/main",
     "build": "npm run build --workspace @sematic/main",
@@ -13,7 +12,6 @@
     "cypress:component": "cypress run --headless --component --project packages/tests",
     "storybook": "npm run storybook --workspace @sematic/storybook"
   },
-  "devDependencies": {},
   "workspaces": [
     "packages/*"
   ]

--- a/sematic/ui/packages/common/package.json
+++ b/sematic/ui/packages/common/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "lint": "eslint --ext .ts ."
   },
-  "devDependencies": {
-  },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "@tanstack/react-table": "^8.9.1"
+  }
 }

--- a/sematic/ui/packages/common/src/component/DateTime.tsx
+++ b/sematic/ui/packages/common/src/component/DateTime.tsx
@@ -17,26 +17,18 @@ const DateTime = (props: DateTimeProps) => {
     </Typography>
 }
 
-export const DateTimeLong = (datetime: Date | string) => {
-    let date = datetime instanceof Date ? datetime : parseJSON(datetime);
-
-    return format(date, "M/d/yyyy 'at' h:mmaaa")
+export const DateTimeLong = (datetime: Date) => {
+    return format(datetime, "M/d/yyyy 'at' h:mmaaa")
 }
 
-export const DateTimeLongConcise = (datetime: Date | string) => {
-    let date = datetime instanceof Date ? datetime : parseJSON(datetime);
-
-    return format(date, "M/d/yyyy h:mmaaa")
+export const DateTimeLongConcise = (datetime: Date) => {
+    return format(datetime, "M/d/yyyy h:mmaaa")
 }
 
-export const Duration = (start: Date | string, end: Date | string) => {
-    let startTime = start instanceof Date ? start : parseJSON(start);
-
-    let endTime = end instanceof Date ? end : parseJSON(end);
-
+export const Duration = (start: Date, end: Date) => {
     const duration = intervalToDuration({
-        start: startTime,
-        end: endTime
+        start,
+        end
     });
 
     const formatString = formatDuration(duration, { format: ["minutes", "seconds"], zero: true});
@@ -44,7 +36,7 @@ export const Duration = (start: Date | string, end: Date | string) => {
     return formatString.replace(/\s0\sseconds$/g, "");
 }
 
-export function DurationShort(start: Date | string, end: Date | string) {
+export function DurationShort(start: Date, end: Date) {
     return Duration(start, end).replace(/minutes/g, "m").replace(/seconds/g, "s");
 }
 

--- a/sematic/ui/packages/common/src/component/DateTime.tsx
+++ b/sematic/ui/packages/common/src/component/DateTime.tsx
@@ -23,6 +23,12 @@ export const DateTimeLong = (datetime: Date | string) => {
     return format(date, "M/d/yyyy 'at' h:mmaaa")
 }
 
+export const DateTimeLongConcise = (datetime: Date | string) => {
+    let date = datetime instanceof Date ? datetime : parseJSON(datetime);
+
+    return format(date, "M/d/yyyy h:mmaaa")
+}
+
 export const Duration = (start: Date | string, end: Date | string) => {
     let startTime = start instanceof Date ? start : parseJSON(start);
 
@@ -31,9 +37,15 @@ export const Duration = (start: Date | string, end: Date | string) => {
     const duration = intervalToDuration({
         start: startTime,
         end: endTime
-    })
+    });
 
-    return formatDuration(duration, { format: ["minutes", "seconds"]});
+    const formatString = formatDuration(duration, { format: ["minutes", "seconds"], zero: true});
+
+    return formatString.replace(/\s0\sseconds$/g, "");
+}
+
+export function DurationShort(start: Date | string, end: Date | string) {
+    return Duration(start, end).replace(/minutes/g, "m").replace(/seconds/g, "s");
 }
 
 

--- a/sematic/ui/packages/common/src/component/RunReferenceLink.tsx
+++ b/sematic/ui/packages/common/src/component/RunReferenceLink.tsx
@@ -1,15 +1,16 @@
 import Link from "@mui/material/Link";
-
+import { TypographyProps } from '@mui/material/Typography';
 
 interface RunReferenceLinkProps {
     runId: string;
     className?: string;
+    variant?: TypographyProps['variant'];
 }
 
 const RunReferenceLink = (props: RunReferenceLinkProps) => {
-    const { runId, className } = props;
+    const { runId, className, variant="small" } = props;
 
-    return <Link href={`/runs/${runId}`} variant={"small"} type={"code"} className={className}>
+    return <Link href={`/runs/${runId}`} variant={variant} type={"code"} className={className}>
             {runId.substring(0, 7)}
         </Link>
 }

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -2,6 +2,7 @@ import BoltIcon from '@mui/icons-material/Bolt';
 import Check from "@mui/icons-material/Check";
 import ClearIcon from '@mui/icons-material/Clear';
 import StopIcon from '@mui/icons-material/Stop';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
 import { useMemo } from "react";
 interface StateChipBaseProps {
     size?: "small" | "medium" | "large";
@@ -51,5 +52,8 @@ export const CanceledStateChip = (props: StateChipBaseProps) => {
     return <StopIcon color={"error"} style={styles} />;
 }
 
-
-
+export const SubmittedStateChip = (props: StateChipBaseProps) => {
+    const { size } = props;
+    const styles = useStylesHook({ size });
+    return <ArrowUpward color={"lightGrey"} style={styles} />;
+}

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -1,8 +1,8 @@
-import BoltIcon from '@mui/icons-material/Bolt';
+import BoltIcon from "@mui/icons-material/Bolt";
 import Check from "@mui/icons-material/Check";
-import ClearIcon from '@mui/icons-material/Clear';
-import StopIcon from '@mui/icons-material/Stop';
-import ArrowUpward from '@mui/icons-material/ArrowUpward';
+import ClearIcon from "@mui/icons-material/Clear";
+import StopIcon from "@mui/icons-material/Stop";
+import ArrowUpward from "@mui/icons-material/ArrowUpward";
 import { useMemo } from "react";
 interface StateChipBaseProps {
     size?: "small" | "medium" | "large";
@@ -56,4 +56,24 @@ export const SubmittedStateChip = (props: StateChipBaseProps) => {
     const { size } = props;
     const styles = useStylesHook({ size });
     return <ArrowUpward color={"lightGrey"} style={styles} />;
+}
+
+export function getRunStateChipByState(futureState: string, size: StateChipBaseProps['size'] ="large") {
+    if (futureState === 'SUCCESS') {
+        return <SuccessStateChip size={size} />;
+    }
+    if (futureState === 'FAILED') {
+        return <FailedStateChip size={size} />;
+    }
+    if (futureState === 'RUNNING') {
+        return <RunningStateChip size={size} />;
+    }
+    if (futureState === 'CANCELLED') {
+        return <CanceledStateChip size={size} />;
+    }
+    if (futureState === 'SCHEDULED') {
+        return <SubmittedStateChip size={size} />;
+    }
+
+    return null;
 }

--- a/sematic/ui/packages/common/src/component/RunStateText.ts
+++ b/sematic/ui/packages/common/src/component/RunStateText.ts
@@ -1,0 +1,26 @@
+import { parseJSON } from 'date-fns';
+import { DurationShort } from 'src/component/DateTime';
+
+export function getRunStateText(futureState: string,
+    timestamps: { createdAt: string, resolvedAt?: string, failedAt?: string, canceledAt?: string }) {
+    const { createdAt, resolvedAt, failedAt, canceledAt } = timestamps;
+
+    if (futureState === 'SUCCESS') {
+        return `Completed in ${DurationShort(parseJSON(resolvedAt!), parseJSON(createdAt))}`;
+    }
+    if (futureState === 'FAILED') {
+        return `Failed after ${DurationShort(parseJSON(failedAt!), parseJSON(createdAt))}`;
+    }
+    if (futureState === 'RUNNING') {
+        return `Running for ${DurationShort(new Date(), parseJSON(createdAt))}`;
+    }
+    if (futureState === 'CANCELLED') {
+        return `Canceled after ${DurationShort(parseJSON(canceledAt!), parseJSON(createdAt))}`;
+    }
+    if (futureState === 'SCHEDULED') {
+        return 'Submitted';
+    }
+    return null;
+}
+
+export default getRunStateText;

--- a/sematic/ui/packages/common/src/component/Table.tsx
+++ b/sematic/ui/packages/common/src/component/Table.tsx
@@ -14,6 +14,9 @@ const TableScroller = styled.div`
     overflow-x: hidden;
     flex-grow: 1;
     flex-shrink: 1;
+    position: relative;
+    margin-left: -${theme.spacing(5)};
+    padding-left: ${theme.spacing(5)};
 `;
 
 const StyledHeader = styled(TableHead, {

--- a/sematic/ui/packages/common/src/component/Table.tsx
+++ b/sematic/ui/packages/common/src/component/Table.tsx
@@ -1,0 +1,102 @@
+import styled from "@emotion/styled";
+import TableMui from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { Table, flexRender } from "@tanstack/react-table";
+import theme from "src/theme/new";
+
+const TableScroller = styled.div`
+    @supports(overflow: overlay) {
+        overflow-y: overlay;
+    }
+    overflow-x: hidden;
+    flex-grow: 1;
+    flex-shrink: 1;
+`;
+
+const StyledHeader = styled(TableHead, {
+    shouldForwardProp: (prop) => prop !== 'stickyHeader'
+}) <{
+    stickyHeader: boolean;
+}>`
+    height: 50px;
+    position: absolute;
+    z-index: 255;
+
+    ${props => props.stickyHeader && ` 
+            position: sticky;
+            top: 0;
+
+            & th {
+                background: ${theme.palette.white.main};
+            }
+        `
+    }
+    
+    &:after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        height: 1px;
+        width: calc(100% + ${theme.spacing(10)});
+        margin-left: -${theme.spacing(5)};
+        background: ${theme.palette.p3border.main};
+    }
+`;
+
+const TableDataRow = styled(TableRow)`
+    height: 50px;
+
+    & td {
+        padding-left: 0;
+        padding-right: ${theme.spacing(2.5)};
+        padding-top: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+
+        &:last-of-type {
+            padding-right: 0
+        };
+    }
+`;
+
+interface TableComponentProps<T> {
+    table: Table<T>;
+    stickyHeader?: boolean;
+}
+
+const TableComponent = <T,>(props: TableComponentProps<T>) => {
+    const { table, stickyHeader = true } = props;
+    const { getLeafHeaders } = table;
+
+    return <TableScroller>
+        <TableMui>
+            <StyledHeader stickyHeader={stickyHeader}>
+                <TableRow>
+                    {getLeafHeaders().map(header =>
+                        <th key={header.id} style={(header.column.columnDef.meta! as any).columnStyles}>
+                            {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                            )}
+                        </th>)}
+                </TableRow>
+            </StyledHeader>
+            <TableBody>
+                {table.getRowModel().rows.map(row => (
+                    <TableDataRow key={row.id}>
+                        {row.getVisibleCells().map(cell => (
+                            <TableCell key={cell.id} style={(cell.column.columnDef.meta as any).columnStyles}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </TableCell>
+                        ))}
+                    </TableDataRow>
+                ))}
+            </TableBody>
+        </TableMui>
+    </TableScroller>
+}
+
+export default TableComponent;

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -1,9 +1,21 @@
-import Chip, { chipClasses } from '@mui/material/Chip';
-import Box from '@mui/material/Box';
-import Button, { buttonClasses } from '@mui/material/Button';
-import styled from '@emotion/styled';
-import theme from 'src/theme/new';
-import { useMemo } from 'react';
+import styled from "@emotion/styled";
+import Box from "@mui/material/Box";
+import { buttonClasses } from "@mui/material/Button";
+import Chip, { chipClasses } from "@mui/material/Chip";
+import take from "lodash/take";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import useMeasure from "react-use/lib/useMeasure";
+import theme, { SPACING } from "src/theme/new";
+
+const MeasurementContainer = styled.div`
+    position: absolute;
+    visibility: hidden;
+    width: max-content;
+
+    & .${chipClasses.root}:not(*:last-of-type) {
+        margin-right: ${theme.spacing(1)};
+    }
+`;
 
 const StyledBox = styled(Box)`
     display: flex;
@@ -32,27 +44,68 @@ interface TagsListProps {
     tags: string[];
     fold?: number;
     onClick?: (tag: string) => void;
-    onAddTag?: () => void;
 }
 
 const TagsList = (props: TagsListProps) => {
-    const { tags = [], fold, onClick, onAddTag } = props;
-    const tagsToShow = useMemo(() => fold ? tags.slice(0, fold) : tags, [tags, fold]);
-    const plusMore = useMemo(() => {
-        if (!fold) {
-            return null;
-        }
-        if (tags.length <= fold) {
-            return null;
-        }
-        return <Chip label={`+${tags.length - fold}`} variant={"tag"} />
-    }, [tags, fold]);
+    const { tags = [], onClick } = props;
+    const [ref, { width }] = useMeasure();
+    const [refMeasure, { width: measureWidth }] = useMeasure<HTMLDivElement>();
+    const refMeasureDom = useRef<HTMLDivElement>();
 
-    return <StyledBox>
-        {tagsToShow.map(tag => <Chip key={tag} label={tag} variant={"tag"} onClick={() => onClick?.(tag)} />)}
-        {plusMore}
-        {fold === undefined && <Button variant={"text"} size={"small"} onClick={onAddTag}>add tags</Button>}
-    </StyledBox>;
+    const setRef = useCallback((element: HTMLDivElement) => {
+        refMeasureDom.current = element as HTMLDivElement;
+        refMeasure(element);
+    }, [refMeasure]);
+
+    const [fold, setFold] = useState<number>(tags.length);
+
+    const minFoldValue = useMemo(() => fold === 0 ? 1 : fold, [fold]);
+
+    const plusMore = useMemo(() => {
+        if (minFoldValue === tags.length) {
+            return null;
+        }
+        return <Chip label={`+${tags.length - minFoldValue}`} variant={"tag"} />
+    }, [tags, minFoldValue]);
+
+    useEffect(() => {
+        if (width < measureWidth) {
+            const chips = refMeasureDom.current!.querySelectorAll('.tag-candiate');
+            const widths = (Array.from(chips).map(chip => chip.getBoundingClientRect().width));
+            let fold = 0, sum = 0; const gap = 40; // 40 is an estimation of the width of the "+{N}" chip
+
+            while (fold < tags.length) {
+                if (sum + widths[fold] + SPACING + gap > width) {
+                    break;
+                }
+                sum += widths[fold] + SPACING;
+                fold++;
+            }
+            setFold(fold);
+        } else {
+            setFold(tags.length);
+        }
+
+    }, [width, measureWidth, refMeasure, tags.length]);
+
+    // Limit to 20 tags in trial rendering, to avoid too many tags in the UI
+    // (Assume that the user will not need to see more than 20 tags in the actual display)
+    const TagsInTrialRenderingLimit = useMemo(() => take(tags, 20), [tags]);
+
+    return <div style={{ position: 'relative', width: '100%' }}>
+        <MeasurementContainer ref={setRef}>
+            {TagsInTrialRenderingLimit.map(tag => <Chip key={tag} className={"tag-candiate"} label={tag} variant={"tag"} />)}
+        </MeasurementContainer>
+        <StyledBox ref={ref}>
+            {tags.map((tag, index) => {
+                if (index >= minFoldValue) {
+                    return null;
+                }
+                return <Chip key={tag} label={tag} variant={"tag"} onClick={() => onClick?.(tag)} />
+            })}
+            {plusMore}
+        </StyledBox>
+    </div>;
 }
 
 export default TagsList;

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Button, { buttonClasses } from '@mui/material/Button';
 import styled from '@emotion/styled';
 import theme from 'src/theme/new';
+import { useMemo } from 'react';
 
 const StyledBox = styled(Box)`
     display: flex;
@@ -29,15 +30,28 @@ const StyledBox = styled(Box)`
 
 interface TagsListProps {
     tags: string[];
+    fold?: number;
     onClick?: (tag: string) => void;
     onAddTag?: () => void;
 }
 
 const TagsList = (props: TagsListProps) => {
-    const { tags = [], onClick, onAddTag } = props;
+    const { tags = [], fold, onClick, onAddTag } = props;
+    const tagsToShow = useMemo(() => fold ? tags.slice(0, fold) : tags, [tags, fold]);
+    const plusMore = useMemo(() => {
+        if (!fold) {
+            return null;
+        }
+        if (tags.length <= fold) {
+            return null;
+        }
+        return <Chip label={`+${tags.length - fold}`} variant={"tag"} />
+    }, [tags, fold]);
+
     return <StyledBox>
-        {tags.map(tag => <Chip key={tag} label={tag} variant={"tag"} onClick={() => onClick?.(tag)} />)}
-        <Button variant={"text"} size={"small"} onClick={onAddTag}>add tags</Button>
+        {tagsToShow.map(tag => <Chip key={tag} label={tag} variant={"tag"} onClick={() => onClick?.(tag)} />)}
+        {plusMore}
+        {fold === undefined && <Button variant={"text"} size={"small"} onClick={onAddTag}>add tags</Button>}
     </StyledBox>;
 }
 

--- a/sematic/ui/packages/common/src/layout/TwoColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/TwoColumns.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
-import { Container, Left, Right as RightBase } from 'src/layout/ThreeColumns';
-import styled from '@emotion/styled';
-import theme from 'src/theme/new';
+import styled from "@emotion/styled";
+import { useMemo } from "react";
+import { Container, Left, Right as RightBase } from "src/layout/ThreeColumns";
+import theme from "src/theme/new";
 
 const Right = styled(RightBase)`
     width: auto;

--- a/sematic/ui/packages/common/src/layout/TwoColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/TwoColumns.tsx
@@ -1,5 +1,13 @@
 import { useMemo } from 'react';
-import { Container, Left, Right } from 'src/layout/ThreeColumns';
+import { Container, Left, Right as RightBase } from 'src/layout/ThreeColumns';
+import styled from '@emotion/styled';
+import theme from 'src/theme/new';
+
+const Right = styled(RightBase)`
+    width: auto;
+    flex-grow: 1;
+    padding: 0 ${theme.spacing(5)};
+`
 
 export interface TwoColumnsProps {
     onRenderLeft: () => React.ReactNode;

--- a/sematic/ui/packages/common/src/muitypes.d.ts
+++ b/sematic/ui/packages/common/src/muitypes.d.ts
@@ -52,4 +52,10 @@ declare module '@mui/material/Chip' {
     }
 }
 
+declare module '@mui/material/SvgIcon' {
+    interface SvgIconPropsColorOverrides {
+        lightGrey: true;
+    }
+}
+
 export const notAModule = 1;

--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
+import Button from "@mui/material/Button";
+import parseJSON from 'date-fns/parseJSON';
 import { DateTimeLong, Duration } from 'src/component/DateTime';
 import Headline from 'src/component/Headline';
 import ImportPath from 'src/component/ImportPath';
@@ -64,6 +66,12 @@ const ImportPathContainer = styled(Box)`
     margin-bottom: ${theme.spacing(4)};
 `
 
+const TagsContainer = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
 const StyledRunReferenceLink = styled(RunReferenceLink)`
     font-size: ${theme.typography.fontSize}px ;
 `;
@@ -83,7 +91,9 @@ const FunctionSection = () => {
                 </FunctionName>
                 <div>
                     <StyledRunReferenceLink runId={"qwc2ldf"} />
-                    {`Completed in ${Duration("2012-04-23T18:14:23.511Z", "2012-04-23T18:25:43.511Z")} on ${DateTimeLong(new Date())}`}
+                    {`Completed in ${Duration(
+                        parseJSON("2012-04-23T18:14:23.511Z"), parseJSON("2012-04-23T18:25:43.511Z")
+                        )} on ${DateTimeLong(new Date())}`}
                 </div>
             </div>
         </BoxContainer>
@@ -91,7 +101,11 @@ const FunctionSection = () => {
             <ImportPath>examples.mnist.train_eval.evaluate_model</ImportPath>
         </ImportPathContainer>
         <StyledVertButton />
-        <TagsList tags={['example', 'torch', 'mnist']} />
+        <TagsContainer>
+            <div><TagsList tags={['example', 'torch', 'mnist']} /></div>
+            <Button variant={"text"} size={"small"}>add tags</Button>
+        </TagsContainer>
+        
     </StyledSection>;
 }
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import Typography, { typographyClasses } from "@mui/material/Typography";
 import Headline from "src/component/Headline";
 import MoreVertButton from "src/component/MoreVertButton";
 import RunsDropdown from "src/component/RunsDropdown";
@@ -19,6 +20,7 @@ const StyledVertButton = styled(MoreVertButton)`
 
 const BoxContainer = styled(Box)`
   display: flex;
+  align-items: center;
 `;
 
 const StyledTypography = styled(Typography)`
@@ -40,7 +42,8 @@ const RunSection = () => {
         <Typography variant="small">CloudResolver</Typography>
       </BoxContainer>
       <BoxContainer>
-        <TagsList tags={["example", "torch", "mnist"]} />
+        <div><TagsList tags={["example", "torch", "mnist"]} /></div>
+        <Button variant={"text"} size={"small"}>add tags</Button>
       </BoxContainer>
     </StyledSection>
   );

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -1,0 +1,196 @@
+import styled from '@emotion/styled';
+import { ChevronLeft, ChevronRight } from "@mui/icons-material";
+import Typography from '@mui/material/Typography';
+import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { DateTimeLongConcise } from 'src/component/DateTime';
+import ImportPath from 'src/component/ImportPath';
+import PipelineTitle from 'src/component/PipelineTitle';
+import RunReferenceLink from 'src/component/RunReferenceLink';
+import TableComponent from 'src/component/Table';
+import TagsList from 'src/component/TagsList';
+import RunStatusColumn from 'src/pages/RunSearch/RunStatusColumn';
+import theme from 'src/theme/new';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin-right: -${theme.spacing(5)};
+`;
+
+const Stats = styled.div`
+    height: 50px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+`;
+
+const Pagination = styled.div`
+    height: 50px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    padding-right: ${theme.spacing(6)};
+
+    svg {
+        cursor: pointer;
+    }
+`;
+
+const NameSection = styled.div`
+    display: flex;
+    flex-direction: row;
+    column-gap: ${theme.spacing(2)};
+    overflow-x: hidden;
+    min-width: 100px;
+    position: relative;
+`;
+
+const StyledRunReferenceLink = styled(RunReferenceLink)`
+    color: ${theme.palette.mediumGrey.main};
+`;
+
+const RunData = {
+    ID: '3es92wd',
+    created: '2021-10-01T12:00:00Z',
+    name: 'MNIST PyTorch Example',
+    importPath: 'examples.mnist.pipeline',
+    tags: ['example', 'pytorch', 'mnist', 'demo'],
+    owner: 'Demo User',
+    status: 'RUNNING',
+    failedAt: undefined as undefined | string,
+    resolvedAt: undefined as undefined | string,
+    canceledAt: undefined as undefined | string,
+}
+
+const columnHelper = createColumnHelper<typeof RunData>()
+
+const columns = [
+    columnHelper.accessor('ID', {
+        meta: {
+            columnStyles: {
+                width: "5.923%",
+            }
+        },
+        header: 'ID',
+        cell: info => <StyledRunReferenceLink variant={'inherit'} runId={info.getValue()} />,
+    }),
+    columnHelper.accessor('created', {
+        meta: {
+            columnStyles: {
+                width: "12.3396%",
+                minWidth: "140px"
+            }
+        },
+        header: 'Submitted at',
+        cell: info => DateTimeLongConcise(info.getValue()),
+    }),
+    columnHelper.accessor(data => [data.name, data.importPath], {
+        meta: {
+            columnStyles: {
+                width: "1px",
+                maxWidth: "calc(100vw - 1090px)"
+            }
+        },
+        header: 'Name',
+        cell: info => {
+            const [name, importPath] = info.getValue();
+            return <NameSection>
+                <PipelineTitle>{name}</PipelineTitle>
+                <ImportPath>{importPath}</ImportPath>
+            </NameSection>
+        },
+    }),
+    columnHelper.accessor('tags', {
+        meta: {
+            columnStyles: {
+                width: "14.5114%",
+                minWidth: "160px"
+            }
+        },
+        header: 'Tags',
+        cell: info => <TagsList tags={info.getValue()} fold={2} />,
+    }),
+    columnHelper.accessor('owner', {
+        meta: {
+            columnStyles: {
+                width: "8.39092%",
+                minWidth: "100px"
+            }
+        },
+        header: 'Owner',
+        cell: info => info.getValue(),
+    }),
+    columnHelper.accessor(data => ({
+        futureState: data.status,
+        createdAt: data.created,
+        failedAt: data.failedAt,
+        canceledAt: data.canceledAt,
+        resolvedAt: data.resolvedAt
+    }), {
+        meta: {
+            columnStyles: {
+                width: "15.7947%",
+                minWidth: "200px"
+            }
+        },
+        header: 'Status',
+        cell: info => <RunStatusColumn {...info.getValue()} />,
+    }),
+    columnHelper.display({
+        meta: {
+            columnStyles: {
+                width: "2.46792%",
+                minWidth: "40px"
+            }
+        },
+        header: '',
+        id: 'goto',
+        cell: _ => <ChevronRight />,
+    }),
+]
+
+const data: Array<typeof RunData> = [
+    RunData,
+    RunData,
+    { ...RunData, resolvedAt: '2021-10-01T12:10:00Z', status: 'SUCCESS' },
+    { ...RunData, failedAt: '2021-10-01T12:10:00Z', status: 'FAILED' },
+    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
+    { ...RunData, status: 'SCHEDULED' },
+    RunData,
+    RunData,
+    RunData,
+    RunData,
+    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
+    { ...RunData, status: 'SCHEDULED' },
+    RunData,
+    RunData,
+    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
+]
+
+const RunList = () => {
+    const tableInstance = useReactTable({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel()
+    });
+
+    return <Container>
+        <Stats>
+            <Typography variant={'bold'}>142 Runs</Typography>
+        </Stats>
+        <TableComponent table={tableInstance} />
+        <Pagination>
+            <ChevronLeft /> 
+                {'1 / 4'} 
+            <ChevronRight />
+        </Pagination>
+    </Container>
+}
+
+export default RunList;

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -1,15 +1,16 @@
-import styled from '@emotion/styled';
+import styled from "@emotion/styled";
 import { ChevronLeft, ChevronRight } from "@mui/icons-material";
-import Typography from '@mui/material/Typography';
-import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import { DateTimeLongConcise } from 'src/component/DateTime';
-import ImportPath from 'src/component/ImportPath';
-import PipelineTitle from 'src/component/PipelineTitle';
-import RunReferenceLink from 'src/component/RunReferenceLink';
-import TableComponent from 'src/component/Table';
-import TagsList from 'src/component/TagsList';
-import RunStatusColumn from 'src/pages/RunSearch/RunStatusColumn';
-import theme from 'src/theme/new';
+import Typography from "@mui/material/Typography";
+import { createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { parseJSON } from "date-fns";
+import { DateTimeLongConcise } from "src/component/DateTime";
+import ImportPath from "src/component/ImportPath";
+import PipelineTitle from "src/component/PipelineTitle";
+import RunReferenceLink from "src/component/RunReferenceLink";
+import TableComponent from "src/component/Table";
+import TagsList from "src/component/TagsList";
+import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
+import theme from "src/theme/new";
 
 const Container = styled.div`
     display: flex;
@@ -88,7 +89,7 @@ const columns = [
             }
         },
         header: 'Submitted at',
-        cell: info => DateTimeLongConcise(info.getValue()),
+        cell: info => DateTimeLongConcise(parseJSON(info.getValue())),
     }),
     columnHelper.accessor(data => [data.name, data.importPath], {
         meta: {
@@ -151,7 +152,7 @@ const columns = [
         },
         header: '',
         id: 'goto',
-        cell: _ => <ChevronRight />,
+        cell: _ => <ChevronRight style={{cursor: 'pointer'}}/>,
     }),
 ]
 

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { DurationShort } from 'src/component/DateTime';
+import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip, SubmittedStateChip } from 'src/component/RunStateChips';
+import styled from '@emotion/styled';
+import theme from 'src/theme/new';
+
+const StyledContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    & svg {
+        margin-right: ${theme.spacing(1)};
+    }
+`;
+
+interface RunStatusColumnProps {
+    futureState: string;
+    createdAt: string;
+    failedAt?: string;
+    resolvedAt?: string;
+    canceledAt?: string;
+}
+
+const RunStatusColumn = (props: RunStatusColumnProps) => {
+    const { futureState, createdAt, failedAt, resolvedAt, canceledAt } = props;
+
+    const runStateChip = useMemo(() => {
+        if (futureState === 'SUCCESS') {
+            return <SuccessStateChip size={'large'} />;
+        }
+        if (futureState === 'FAILED') {
+            return <FailedStateChip size={'large'} />;
+        }
+        if (futureState === 'RUNNING') {
+            return <RunningStateChip size={'large'} />;
+        }
+        if (futureState === 'CANCELLED') {
+            return <CanceledStateChip size={'large'} />;
+        }
+        if (futureState === 'SCHEDULED') {
+            return <SubmittedStateChip size={'large'} />;
+        }
+    }, [futureState])
+
+    const runStateText = useMemo(() => {
+        if (futureState === 'SUCCESS') {
+            return `Completed in ${DurationShort(resolvedAt!, createdAt)}`;
+        }
+        if (futureState === 'FAILED') {
+            return `Failed after ${DurationShort(failedAt!, createdAt)}`;
+        }
+        if (futureState === 'RUNNING') {
+            return `Running for ${DurationShort(new Date(), createdAt)}`;
+        }
+        if (futureState === 'CANCELLED') {
+            return `Canceled after ${DurationShort(canceledAt!, createdAt)}`;
+        }
+        if (futureState === 'SCHEDULED') {
+            return 'Submitted';
+        }
+        return null;
+    }, [futureState, createdAt, failedAt, resolvedAt, canceledAt]);
+
+    return <StyledContainer>{runStateChip} {runStateText}</StyledContainer>;
+}
+
+export default RunStatusColumn;

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
-import { DurationShort } from 'src/component/DateTime';
-import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip, SubmittedStateChip } from 'src/component/RunStateChips';
 import styled from '@emotion/styled';
+import { useMemo } from 'react';
+import { getRunStateChipByState } from 'src/component/RunStateChips';
+import getRunStateText from 'src/component/RunStateText';
 import theme from 'src/theme/new';
 
 const StyledContainer = styled.div`
@@ -25,42 +25,12 @@ interface RunStatusColumnProps {
 const RunStatusColumn = (props: RunStatusColumnProps) => {
     const { futureState, createdAt, failedAt, resolvedAt, canceledAt } = props;
 
-    const runStateChip = useMemo(() => {
-        if (futureState === 'SUCCESS') {
-            return <SuccessStateChip size={'large'} />;
-        }
-        if (futureState === 'FAILED') {
-            return <FailedStateChip size={'large'} />;
-        }
-        if (futureState === 'RUNNING') {
-            return <RunningStateChip size={'large'} />;
-        }
-        if (futureState === 'CANCELLED') {
-            return <CanceledStateChip size={'large'} />;
-        }
-        if (futureState === 'SCHEDULED') {
-            return <SubmittedStateChip size={'large'} />;
-        }
-    }, [futureState])
+    const runStateChip = useMemo(() => getRunStateChipByState(futureState), [futureState]);
 
-    const runStateText = useMemo(() => {
-        if (futureState === 'SUCCESS') {
-            return `Completed in ${DurationShort(resolvedAt!, createdAt)}`;
-        }
-        if (futureState === 'FAILED') {
-            return `Failed after ${DurationShort(failedAt!, createdAt)}`;
-        }
-        if (futureState === 'RUNNING') {
-            return `Running for ${DurationShort(new Date(), createdAt)}`;
-        }
-        if (futureState === 'CANCELLED') {
-            return `Canceled after ${DurationShort(canceledAt!, createdAt)}`;
-        }
-        if (futureState === 'SCHEDULED') {
-            return 'Submitted';
-        }
-        return null;
-    }, [futureState, createdAt, failedAt, resolvedAt, canceledAt]);
+    const runStateText = useMemo(() => getRunStateText(
+        futureState,
+        {createdAt, failedAt, resolvedAt, canceledAt}
+    ), [futureState, createdAt, failedAt, resolvedAt, canceledAt]);
 
     return <StyledContainer>{runStateChip} {runStateText}</StyledContainer>;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -12,6 +12,7 @@ const StyledButton = styled(Button)`
     height: 50px;
     flex-shrink: 0;
     flex-grow: 0;
+    border-radius: 2px;
 `;
 
 const SearchFilters = () => {

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import TwoColumns from "src/layout/TwoColumns";
+import RunList from 'src/pages/RunSearch/RunList';
 import SearchFilters from 'src/pages/RunSearch/SearchFilters';
 
 const RunSearch = () => {
@@ -9,7 +10,7 @@ const RunSearch = () => {
     }, []);
 
     const onRenderRight = useCallback(() => {
-        return <></>;
+        return <RunList />;
     }, []);
 
     return <TwoColumns onRenderLeft={onRenderLeft} onRenderRight={onRenderRight} />;

--- a/sematic/ui/packages/common/src/theme/new/components.ts
+++ b/sematic/ui/packages/common/src/theme/new/components.ts
@@ -30,7 +30,6 @@ const components: Components = {
                 marginBottom: 0,
                 color: theme.palette.black.main,
                 fontSize: theme.typography.fontSize,
-                fontStyle: 'italic',
 
                 '&:hover': {
                     color: theme.palette.primary.main,
@@ -196,7 +195,6 @@ const components: Components = {
                 props: { variant: 'text' },
                 style: ({ theme }) => {
                     return {
-                        fontStyle: 'italic',
                         color: theme.palette.lightGrey.main,
                         '&:hover': {
                             color: theme.palette.primary.main,

--- a/sematic/ui/packages/common/src/theme/new/components.ts
+++ b/sematic/ui/packages/common/src/theme/new/components.ts
@@ -284,8 +284,15 @@ const components: Components = {
                 'padding': `${theme.spacing(2.4)} 0`,
             })) as any
         }
+    },
+    MuiTableHead: {
+        styleOverrides: {
+            root: (({ theme }: { theme: Theme }) => ({
+                'fontSize': `${theme.typography.fontSize}px`,
+                'textAlign': 'left',
+            })) as any
+        }
     }
-
 }
 
 export default components;

--- a/sematic/ui/packages/common/src/theme/new/index.ts
+++ b/sematic/ui/packages/common/src/theme/new/index.ts
@@ -5,10 +5,12 @@ import components from "src/theme/new/components";
 import palette from "src/theme/new/palette";
 import typography from "src/theme/new/typography";
 
+export const SPACING = 5;
+
 export const createTheme = () => {
     return createMuiTheme(
         {
-            spacing: 5,
+            spacing: SPACING,
             breakpoints,
             palette,
             typography,

--- a/sematic/ui/packages/common/src/theme/new/index.ts
+++ b/sematic/ui/packages/common/src/theme/new/index.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../muitypes.d.ts" />
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import breakpoints from "src/theme/mira/breakpoints";
-import components from "src/theme/new/componnets";
+import components from "src/theme/new/components";
 import palette from "src/theme/new/palette";
 import typography from "src/theme/new/typography";
 

--- a/sematic/ui/packages/storybook/src/stories/RunStateChip.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunStateChip.stories.tsx
@@ -2,7 +2,8 @@ import { ThemeProvider } from "@mui/material/styles";
 import { SuccessStateChip as SuccessStateChipComponent, 
   FailedStateChip as FailedStateChipComponent,
   RunningStateChip as RunningStateChipComponent,
-  CanceledStateChip as CanceledStateChipComponent
+  CanceledStateChip as CanceledStateChipComponent,
+  SubmittedStateChip as SubmittedStateChipComponent
  } from '@sematic/common/src/component/RunStateChips';
 import theme from '@sematic/common/src/theme/new';
 import { Meta, StoryFn } from '@storybook/react';
@@ -14,7 +15,8 @@ const typeOptions = {
   "Success": SuccessStateChipComponent,
   "Failed": FailedStateChipComponent,
   "Running": RunningStateChipComponent,
-  "Canceled": CanceledStateChipComponent
+  "Canceled": CanceledStateChipComponent,
+  "Submitted": SubmittedStateChipComponent
 }
 
 export default {
@@ -66,4 +68,9 @@ RunningStateChip.args = {
 export const CanceledStateChip = Template.bind({});
 CanceledStateChip.args = {
   type: "Canceled",
+}
+
+export const SubmittedStateChip = Template.bind({});
+SubmittedStateChip.args = {
+  type: "Submitted",
 }


### PR DESCRIPTION
1. This PR implements the static elements for the Run search table in the new style.

1. Introduced: [@tanstack/react-table](https://tanstack.com/table/v8) library

1. added border-radius: 2px to the filter buttons.

Preview: https://story.dev-usw2-sematic0.sematic.cloud/iframe.html?args=&id=sematic-page--run-search&viewMode=story


