### PR TITLE
Add horizontal pod autoscaling and pod disruption budget for API server

### DIFF
--- a/helm/sematic-server/templates/hpa.yaml
+++ b/helm/sematic-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}
@@ -10,19 +10,23 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}
-  minReplicas: {{ .Values.deployment.autoscaling.min_replicas | default 1 }}
-  maxReplicas: {{ .Values.deployment.autoscaling.max_replicas | default 1 }}
+  minReplicas: {{ .Values.deployment.autoscaling.min_replicas | default 2 }}
+  maxReplicas: {{ .Values.deployment.autoscaling.max_replicas | default 2 }}
   metrics:
     {{- if .Values.deployment.autoscaling.target_cpu_utilization_pct }}
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.deployment.autoscaling.target_cpu_utilization_pct }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.deployment.autoscaling.target_cpu_utilization_pct }}
     {{- end }}
     {{- if .Values.deployment.autoscaling.target_memory_utilization_pct }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.deployment.autoscaling.target_memory_utilization_pct }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.deployment.autoscaling.target_memory_utilization_pct }}
     {{- end }}
 {{- end }}

--- a/helm/sematic-server/templates/pdb.yaml
+++ b/helm/sematic-server/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.deployment.replica_count) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sematic-server-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "sematic-server.labels" . | nindent 6 }}
+      {{- if .Values.deployment.socket_io.dedicated }}
+      app.kubernetes.io/component: api
+      {{- else }}
+      app.kubernetes.io/component: all
+      {{- end }}
+{{- end }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -32,24 +32,24 @@ deployment:
   socket_io:
     dedicated: false
   worker_count: 1 # if you want to increase this, enable socket_io.dedicated above
-  replica_count: 1
+  replica_count: 2
   affinity: {}
   annotations: {}
   tolerations: {}
   node_selector: {}
   resources:
     limits:
-      cpu: 500m
-      memory: 4000Mi
+      cpu: 250m
+      memory: 2000Mi
     requests:
-      cpu: 500m
-      memory: 4000Mi
+      cpu: 250m
+      memory: 2000Mi
   autoscaling:
     enabled: false
-    min_replicas: 1
-    max_replicas: 1
+    min_replicas: 2
+    max_replicas: 5
     target_cpu_utilization_pct: 80
-    # target_memory_utilization_pct: 80
+    target_memory_utilization_pct: 80
   security_context: {}
     # fs_group: 2000
   container_security_context: {}


### PR DESCRIPTION
fixes #743.

all changes listed below apply only to the api server.  socket io server is unaffected, disruptions on it are considered "acceptable" since it is not mission critical for correctness.

- increases default replica count to 2.  this is required for fault tolerance and so that the pod disruption budget of 1 does not prevent nodes from draining.
- adds horizontal pod autoscaling (hpa) support, can be optionally enabled
- adds pod disruption budget of min 1 pod available, enabled by default
- hpa is now supported via the latest kube api version `autoscaling/v2`
- server cpu/memory resource request/limits are both halved to prior values, to account for 2 replicas being deployed by default compared to 1 before.

helm doc changes to follow in a separate pr.