### PR TITLE
Fix calculator_path client backwards compatibility

### DIFF
--- a/sematic/api/endpoints/payloads.py
+++ b/sematic/api/endpoints/payloads.py
@@ -49,7 +49,13 @@ def _get_collection_payload_with_user(
     for item in items:
         item_payload = item.to_json_encodable()
         item_payload["user"] = None
-        item_payload["calculator_path"] = item_payload["function_path"]
+
+        # this code is also used for the `notes` endpoint, which does not specify a run,
+        # so the function_path path could be not set
+        # but the `runs` endpoints needs calculator_path to be set for
+        # backwards-compatibility
+        if item_payload.get("function_path") is not None:
+            item_payload["calculator_path"] = item_payload["function_path"]
 
         if item.user_id is not None:
             item_payload["user"] = users_by_id[item.user_id]

--- a/sematic/api/endpoints/payloads.py
+++ b/sematic/api/endpoints/payloads.py
@@ -49,6 +49,7 @@ def _get_collection_payload_with_user(
     for item in items:
         item_payload = item.to_json_encodable()
         item_payload["user"] = None
+        item_payload["calculator_path"] = item_payload["function_path"]
 
         if item.user_id is not None:
             item_payload["user"] = users_by_id[item.user_id]


### PR DESCRIPTION
Due to a missing `function_path` -> `calculator_path` adaptor in the Server Run `list` endpoint, older clients are not supported.

This PR introduces the adaptor, as on the `get` endpoint.

![image](https://user-images.githubusercontent.com/1894533/236952028-ea40dee9-ea58-4730-a892-354eaf25ac05.png)
