### PR TITLE
[4/N] Build System configurable Docker connection

### DIFF
--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -2,6 +2,7 @@
 The native Docker Builder plugin implementation.
 """
 # Standard Library
+import distutils.util
 import glob
 import json
 import logging
@@ -202,12 +203,12 @@ class DockerClientConfig:
             self.timeout = int(self.timeout)
         if self.tls is not None and isinstance(self.tls, str):
             # TODO: extract settings.as_bool to utilities, and use that instead
-            self.tls = self.tls == "True"
+            self.tls = bool(distutils.util.strtobool(self.tls))
         if self.credstore_env is not None and isinstance(self.credstore_env, str):
             self.credstore_env = json.loads(self.credstore_env)
         if self.use_ssh_client is not None and isinstance(self.use_ssh_client, str):
             # TODO: extract settings.as_bool to utilities, and use that instead
-            self.use_ssh_client = self.use_ssh_client == "True"
+            self.use_ssh_client = bool(distutils.util.strtobool(self.use_ssh_client))
         if self.max_pool_size is not None and isinstance(self.max_pool_size, str):
             self.max_pool_size = int(self.max_pool_size)
 
@@ -401,7 +402,7 @@ def _build(target: str) -> ImageURI:
     build_config = _get_build_config(script_path=target)
     logger.info("Loaded build configuration: %s", build_config)
 
-    docker_client = _get_docker_client(build_config.docker)
+    docker_client = _make_docker_client(build_config.docker)
     logger.info("Instantiated docker client for server: %s", docker_client.api.base_url)
 
     image, image_uri = _build_image(
@@ -477,7 +478,7 @@ def _find_build_config_files(script_path: str) -> List[str]:
     return [file_candidate] if os.path.isfile(file_candidate) else []
 
 
-def _get_docker_client(
+def _make_docker_client(
     docker_config: Optional[DockerClientConfig],
 ) -> docker.DockerClient:  # type: ignore
     """

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -389,6 +389,8 @@ class DockerBuilder(AbstractBuilder):
             There was an error when executing the specified build script.
         BuildConfigurationError:
             There was an error when validating the specified build configuration.
+        SystemExit:
+            A subprocess exited with an unexpected code.
         """
         image_uri = _build(target=target)
         _launch(target=target, image_uri=image_uri)
@@ -486,11 +488,15 @@ def _make_docker_client(
 
     If no configuration is passed, uses the system Docker Client configuration.
     """
-    if docker_config is None:
-        return docker.from_env()  # type: ignore
+    try:
+        if docker_config is None:
+            return docker.from_env()  # type: ignore
 
-    kwargs = {k: v for k, v in asdict(docker_config).items() if v is not None}
-    return docker.DockerClient(**kwargs)  # type: ignore
+        kwargs = {k: v for k, v in asdict(docker_config).items() if v is not None}
+        return docker.DockerClient(**kwargs)  # type: ignore
+
+    except docker.errors.DockerException as e:  # type: ignore
+        raise BuildError(f"Unable to instantiate Docker client: {e}") from e
 
 
 def _build_image(

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -3,6 +3,7 @@ The native Docker Builder plugin implementation.
 """
 # Standard Library
 import glob
+import json
 import logging
 import os
 import re
@@ -11,7 +12,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 # isort: off
@@ -176,9 +177,92 @@ class ImagePushConfig:
 
 
 @dataclass
+class DockerClientConfig:
+    """
+    The Docker Client connection details to use to connect to the Docker Server.
+
+    See https://docker-py.readthedocs.io/en/stable/client.html#client-reference for more
+    details.
+    """
+
+    base_url: str = "unix://var/run/docker.sock"
+    version: str = "auto"
+    timeout: Optional[int] = None
+    tls: bool = False
+    user_agent: Optional[str] = None
+    credstore_env: Optional[Dict[str, str]] = None
+    use_ssh_client: bool = False
+    max_pool_size: Optional[int] = None
+
+    def __post_init__(self):
+        """
+        Validates the contents of this object.
+        """
+        if self.timeout is not None and isinstance(self.timeout, str):
+            self.timeout = int(self.timeout)
+        if self.tls is not None and isinstance(self.tls, str):
+            # TODO: extract settings.as_bool to utilities, and use that instead
+            self.tls = self.tls == "True"
+        if self.credstore_env is not None and isinstance(self.credstore_env, str):
+            self.credstore_env = json.loads(self.credstore_env)
+        if self.use_ssh_client is not None and isinstance(self.use_ssh_client, str):
+            # TODO: extract settings.as_bool to utilities, and use that instead
+            self.use_ssh_client = self.use_ssh_client == "True"
+        if self.max_pool_size is not None and isinstance(self.max_pool_size, str):
+            self.max_pool_size = int(self.max_pool_size)
+
+
+@dataclass
 class BuildConfig:
     """
-    A packaged build configuration.
+    A packaged build configuration object that describes how to construct a container
+    image that is meant to execute a Runner and Standalone Functions for a specific
+    Pipeline.
+
+    Attributes
+    ----------
+    version: int
+        The version of the configuration semantics to which this object adheres.
+    image_script: Optional[str]
+        An optional path to a script which must write only a container image URI in the
+        `<repository>:<tag>@<digest>` format to standard output. This image will be used
+        as the base from which the Runner and Standalone Function image will be created.
+        Exactly one of `image_script` and `base_uri` must be specified. Defaults to
+        `None`.
+
+        This script is meant to be a hook that the user can leverage to build a base
+        image. It is the user's responsibility to ensure the resulting base image is
+        usable by Sematic in order to construct a Standalone container image:
+        - Must contain a `python3` executable in the env `PATH`.
+        - Must contain all the source code, data files, and installed Python requirements,
+        unless otherwise handled in the `build` field of this configuration.
+        - Does not need to specify a workdir, Any specified workdir will be overwritten.
+        - Does not need to specify an entry point. Any specified entry point will be
+        overwritten.
+
+        The script may write anything to standard error. The script may be written in any
+        language supported by the system, as long as it has the executable bit set, and
+        the system can determine how to execute it (i.e. specifies a shebang, or is an ELF
+        executable).
+    base_uri: Optional[ImageURI]
+        An optional container image URI in the `<repository>:<tag>@<digest>` format. This
+        image will be used as the base from which the Runner and Standalone Function image
+        will be created. Exactly one of `image_script` and `base_uri` must be specified.
+        Defaults to `None`.
+    build: Optional[SourceBuildConfig]
+        An object that configures how to package source code, data files, and Python
+        requirements inside the container image. Defaults to `None`, meaning nothing with
+        be copied to the image, except for the target launch script when using the
+        `base_uri` option. When using the `image_script` option, it is the user's
+        responsibility to ensure the launch script is present.
+    push: Optional[ImagePushConfig]
+        An object that configures how to push the resulting container image to registry
+        that is accessible from the Sematic Server that will execute the Pipeline.
+        Defaults to `None`, meaning that the resulting image will not be pushed to a
+        remote registry, and will only be kept on the Docker server user to construct it.
+    docker: Optional[DockerClientConfig]
+        The Docker Client connection configuration to use to connect to the Docker Server.
+        Defaults to `None`, meaning the system Client configuration will be used.
     """
 
     version: int
@@ -186,6 +270,7 @@ class BuildConfig:
     base_uri: Optional[ImageURI] = None
     build: Optional[SourceBuildConfig] = None
     push: Optional[ImagePushConfig] = None
+    docker: Optional[DockerClientConfig] = None
 
     def __post_init__(self):
         """
@@ -222,6 +307,9 @@ class BuildConfig:
         if self.push is not None and isinstance(self.push, dict):
             self.push = ImagePushConfig(**self.push)
 
+        if self.docker is not None and isinstance(self.docker, dict):
+            self.docker = DockerClientConfig(**self.docker)
+
         # TODO: switch from project-relative paths to build file-relative paths,
         #  and mangle these path fields
         # TODO: validate absolute paths are not used
@@ -253,7 +341,7 @@ class DockerBuilder(AbstractBuilder):
     """
     Docker-based Build System plugin implementation.
 
-    Packages the target pipeline code and required dependencies in a Docker image,
+    Packages the target Pipeline code and required dependencies in a Docker image,
     according to a proprietary build configuration specified via a configuration file of
     the form:
 
@@ -271,7 +359,7 @@ class DockerBuilder(AbstractBuilder):
         tag_suffix: <optional image push tag suffix>
     ```
 
-    It then launches the target pipeline by submitting its execution to Sematic Server,
+    It then launches the target Pipeline by submitting its execution to Sematic Server,
     using the build image to execute `@func`s in the cloud.
     """
 
@@ -291,7 +379,7 @@ class DockerBuilder(AbstractBuilder):
         Parameters
         ----------
         target: str
-            The path to the pipeline target to launch; the built image must support this
+            The path to the Pipeline target to launch; the built image must support this
             target's execution.
 
         Raises
@@ -313,8 +401,7 @@ def _build(target: str) -> ImageURI:
     build_config = _get_build_config(script_path=target)
     logger.info("Loaded build configuration: %s", build_config)
 
-    # TODO: configure the docker service connection string in the build file
-    docker_client = docker.from_env()  # type: ignore
+    docker_client = _get_docker_client(build_config.docker)
     logger.info("Instantiated docker client for server: %s", docker_client.api.base_url)
 
     image, image_uri = _build_image(
@@ -390,6 +477,21 @@ def _find_build_config_files(script_path: str) -> List[str]:
     return [file_candidate] if os.path.isfile(file_candidate) else []
 
 
+def _get_docker_client(
+    docker_config: Optional[DockerClientConfig],
+) -> docker.DockerClient:  # type: ignore
+    """
+    Instantiates a `DockerClient` based on the specified configuration.
+
+    If no configuration is passed, uses the system Docker Client configuration.
+    """
+    if docker_config is None:
+        return docker.from_env()  # type: ignore
+
+    kwargs = {k: v for k, v in asdict(docker_config).items() if v is not None}
+    return docker.DockerClient(**kwargs)  # type: ignore
+
+
 def _build_image(
     target: str,
     build_config: BuildConfig,
@@ -402,7 +504,7 @@ def _build_image(
     Parameters
     ----------
     target: str
-        The path to the pipeline target to launch; the built image must support this
+        The path to the Pipeline target to launch; the built image must support this
         target's execution.
     build_config: BuildConfig
         The configuration that controls the image build.

--- a/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
@@ -9,3 +9,7 @@ push:
   registry: "my_registry.com"
   repository: "my_repository"
   tag_suffix: "my_tag_suffix"
+docker:
+  base_url: "unix://var/run/docker.sock"
+  credstore_env:
+    DOCKER_TLS_VERIFY: "/home/trudy/legit.cer"

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -68,15 +68,15 @@ def mock_docker_client(mock_image: mock.Mock) -> mock.Mock:
 
 
 @mock.patch("sematic.plugins.building.docker_builder._push_image")
-@mock.patch("docker.from_env")
+@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
 def test_build_base_uri_happy(
-    mock_from_env: mock.MagicMock,
+    mock_get_docker_client: mock.MagicMock,
     mock_push_image: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
 ):
     expected_local_uri = docker_builder.ImageURI.from_uri(_LOCAL_IMAGE_URI)
-    mock_from_env.return_value = mock_docker_client
+    mock_get_docker_client.return_value = mock_docker_client
     mock_push_image.return_value = docker_builder.ImageURI.from_uri(_REMOTE_IMAGE_URI)
 
     actual_image_uri = docker_builder._build(target=_LAUNCH_SCRIPT)
@@ -91,9 +91,9 @@ def test_build_base_uri_happy(
 
 
 @mock.patch("sematic.plugins.building.docker_builder._push_image")
-@mock.patch("docker.from_env")
+@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
 def test_build_image_script_happy(
-    mock_from_env: mock.MagicMock,
+    mock_get_docker_client: mock.MagicMock,
     mock_push_image: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
@@ -101,7 +101,7 @@ def test_build_image_script_happy(
     # determine loading the image_script build config
     target = os.path.join(_RESOURCE_PATH, "good_minimal.py")
     expected_local_uri = docker_builder.ImageURI.from_uri(_LOCAL_IMAGE_URI)
-    mock_from_env.return_value = mock_docker_client
+    mock_get_docker_client.return_value = mock_docker_client
     mock_push_image.return_value = docker_builder.ImageURI.from_uri(_REMOTE_IMAGE_URI)
 
     actual_image_uri = docker_builder._build(target=target)
@@ -115,14 +115,14 @@ def test_build_image_script_happy(
     )
 
 
-@mock.patch("docker.from_env")
+@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
 def test_build_error(
-    mock_from_env: mock.MagicMock,
+    mock_get_docker_client: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
     caplog: Any,
 ):
-    mock_from_env.return_value = mock_docker_client
+    mock_get_docker_client.return_value = mock_docker_client
     mock_docker_client.api.build.return_value = [
         {"stream": "Step 1/14 : FROM sematicai/sematic-worker-base:latest"},
         {"stream": ""},
@@ -257,6 +257,10 @@ def test_get_build_config_full_base_uri_happy():
     assert actual_config.push.registry == "my_registry.com"
     assert actual_config.push.repository == "my_repository"
     assert actual_config.push.tag_suffix == "my_tag_suffix"
+    assert actual_config.docker.base_url == "unix://var/run/docker.sock"
+    assert actual_config.docker.credstore_env == {
+        "DOCKER_TLS_VERIFY": "/home/trudy/legit.cer"
+    }
 
 
 def test_get_build_config_minimal_image_script_happy():
@@ -290,6 +294,32 @@ def test_get_build_config_errors(config_file: str, match: str):
     config_file = os.path.join(_RESOURCE_PATH, config_file)
     with pytest.raises(docker_builder.BuildConfigurationError, match=match):
         docker_builder._get_build_config(config_file)
+
+
+def test_get_docker_client_no_config():
+    docker_client = docker_builder._get_docker_client(docker_config=None)
+
+    # the rest of the values depend on the specific version of the docker library,
+    # or are pushed down to implementation-specific components,
+    # so it doesn't make sense to assert on them
+    assert docker_client.api.base_url == "http+docker://localhost"
+    assert docker_client.api.credstore_env is None
+
+
+def test_get_docker_client_config():
+    expected_base_url = "unix://var/run/docker.sock"
+    expected_credstore_env = {"DOCKER_TLS_VERIFY": "/home/trudy/legit.cer"}
+    docker_config = docker_builder.DockerClientConfig(
+        base_url=expected_base_url, credstore_env=expected_credstore_env
+    )
+
+    docker_client = docker_builder._get_docker_client(docker_config=docker_config)
+
+    # the rest of the values depend on the specific version of the docker library,
+    # or are pushed down to implementation-specific components,
+    # so it doesn't make sense to assert on them
+    assert docker_client.api.base_url == "http+docker://localhost"
+    assert docker_client.api.credstore_env == expected_credstore_env
 
 
 @pytest.mark.parametrize(

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -328,6 +328,23 @@ def test_make_docker_client_config(mock_retrieve_server_version: mock.MagicMock)
     assert docker_client.api.credstore_env == expected_credstore_env
 
 
+@mock.patch("docker.api.client.APIClient._retrieve_server_version")
+def test_make_docker_client_error(mock_retrieve_server_version: mock.MagicMock):
+    test_error = docker.errors.DockerException("test")  # type: ignore
+    mock_retrieve_server_version.side_effect = test_error
+
+    expected_base_url = "unix://var/run/docker.sock"
+    expected_credstore_env = {"DOCKER_TLS_VERIFY": "/home/trudy/legit.cer"}
+    docker_config = docker_builder.DockerClientConfig(
+        base_url=expected_base_url, credstore_env=expected_credstore_env
+    )
+
+    with pytest.raises(
+        docker_builder.BuildError, match="Unable to instantiate Docker client: test"
+    ):
+        docker_builder._make_docker_client(docker_config=docker_config)
+
+
 @pytest.mark.parametrize(
     "source_build_config,target,expected_dockerfile",
     [

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -68,15 +68,15 @@ def mock_docker_client(mock_image: mock.Mock) -> mock.Mock:
 
 
 @mock.patch("sematic.plugins.building.docker_builder._push_image")
-@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
+@mock.patch("sematic.plugins.building.docker_builder._make_docker_client")
 def test_build_base_uri_happy(
-    mock_get_docker_client: mock.MagicMock,
+    mock_make_docker_client: mock.MagicMock,
     mock_push_image: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
 ):
     expected_local_uri = docker_builder.ImageURI.from_uri(_LOCAL_IMAGE_URI)
-    mock_get_docker_client.return_value = mock_docker_client
+    mock_make_docker_client.return_value = mock_docker_client
     mock_push_image.return_value = docker_builder.ImageURI.from_uri(_REMOTE_IMAGE_URI)
 
     actual_image_uri = docker_builder._build(target=_LAUNCH_SCRIPT)
@@ -91,9 +91,9 @@ def test_build_base_uri_happy(
 
 
 @mock.patch("sematic.plugins.building.docker_builder._push_image")
-@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
+@mock.patch("sematic.plugins.building.docker_builder._make_docker_client")
 def test_build_image_script_happy(
-    mock_get_docker_client: mock.MagicMock,
+    mock_make_docker_client: mock.MagicMock,
     mock_push_image: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
@@ -101,7 +101,7 @@ def test_build_image_script_happy(
     # determine loading the image_script build config
     target = os.path.join(_RESOURCE_PATH, "good_minimal.py")
     expected_local_uri = docker_builder.ImageURI.from_uri(_LOCAL_IMAGE_URI)
-    mock_get_docker_client.return_value = mock_docker_client
+    mock_make_docker_client.return_value = mock_docker_client
     mock_push_image.return_value = docker_builder.ImageURI.from_uri(_REMOTE_IMAGE_URI)
 
     actual_image_uri = docker_builder._build(target=target)
@@ -115,14 +115,14 @@ def test_build_image_script_happy(
     )
 
 
-@mock.patch("sematic.plugins.building.docker_builder._get_docker_client")
+@mock.patch("sematic.plugins.building.docker_builder._make_docker_client")
 def test_build_error(
-    mock_get_docker_client: mock.MagicMock,
+    mock_make_docker_client: mock.MagicMock,
     mock_docker_client: mock.Mock,
     mock_image: mock.Mock,
     caplog: Any,
 ):
-    mock_get_docker_client.return_value = mock_docker_client
+    mock_make_docker_client.return_value = mock_docker_client
     mock_docker_client.api.build.return_value = [
         {"stream": "Step 1/14 : FROM sematicai/sematic-worker-base:latest"},
         {"stream": ""},
@@ -296,8 +296,8 @@ def test_get_build_config_errors(config_file: str, match: str):
         docker_builder._get_build_config(config_file)
 
 
-def test_get_docker_client_no_config():
-    docker_client = docker_builder._get_docker_client(docker_config=None)
+def test_make_docker_client_no_config():
+    docker_client = docker_builder._make_docker_client(docker_config=None)
 
     # the rest of the values depend on the specific version of the docker library,
     # or are pushed down to implementation-specific components,
@@ -306,14 +306,14 @@ def test_get_docker_client_no_config():
     assert docker_client.api.credstore_env is None
 
 
-def test_get_docker_client_config():
+def test_make_docker_client_config():
     expected_base_url = "unix://var/run/docker.sock"
     expected_credstore_env = {"DOCKER_TLS_VERIFY": "/home/trudy/legit.cer"}
     docker_config = docker_builder.DockerClientConfig(
         base_url=expected_base_url, credstore_env=expected_credstore_env
     )
 
-    docker_client = docker_builder._get_docker_client(docker_config=docker_config)
+    docker_client = docker_builder._make_docker_client(docker_config=docker_config)
 
     # the rest of the values depend on the specific version of the docker library,
     # or are pushed down to implementation-specific components,

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -296,7 +296,10 @@ def test_get_build_config_errors(config_file: str, match: str):
         docker_builder._get_build_config(config_file)
 
 
-def test_make_docker_client_no_config():
+@mock.patch("docker.api.client.APIClient._retrieve_server_version")
+def test_make_docker_client_no_config(mock_retrieve_server_version: mock.MagicMock):
+    mock_retrieve_server_version.return_value = "1.30"
+
     docker_client = docker_builder._make_docker_client(docker_config=None)
 
     # the rest of the values depend on the specific version of the docker library,
@@ -306,7 +309,10 @@ def test_make_docker_client_no_config():
     assert docker_client.api.credstore_env is None
 
 
-def test_make_docker_client_config():
+@mock.patch("docker.api.client.APIClient._retrieve_server_version")
+def test_make_docker_client_config(mock_retrieve_server_version: mock.MagicMock):
+    mock_retrieve_server_version.return_value = "1.30"
+
     expected_base_url = "unix://var/run/docker.sock"
     expected_credstore_env = {"DOCKER_TLS_VERIFY": "/home/trudy/legit.cer"}
     docker_config = docker_builder.DockerClientConfig(


### PR DESCRIPTION
This is the third PR in a chain that introduces a Build System plugin with an implementation that uses native Python+Docker capabilities to build a container image and launch a pipeline, without requiring Bazel. The previous PR in the chain is #807.

This PR makes the Docker Client connection configurable, and fills in docstrings.

## Testing

Validated that the intermediate and advanced cases from the [`example_docker` repo](https://github.com/sematic-ai/example_docker) still work, and added unit tests and checks for the new funcitonality:

```bash
$ bazel test --test_output=all sematic/plugins/building/tests:test_docker_builder
```
