### PR TITLE
Fix log duplication

### DIFF
--- a/sematic/logging.py
+++ b/sematic/logging.py
@@ -5,17 +5,15 @@ import os
 # Sematic
 from sematic.config.config import get_config
 
+_LOG_FILE_ROTATION_SETTINGS = {
+    "formatter": "standard",
+    "class": "logging.handlers.RotatingFileHandler",
+    "maxBytes": 500 * 2**20,  # 500 MB
+    "backupCount": 20,
+}
+
 
 def make_log_config(log_to_disk: bool = False, level: int = logging.INFO):
-    log_to_stdout = get_config().server_log_to_stdout or not log_to_disk
-    stdout_handler_list = ["stdout"] if log_to_stdout else []
-    log_rotation_settings = {
-        "formatter": "standard",
-        "class": "logging.handlers.RotatingFileHandler",
-        "maxBytes": 500 * 2**20,  # 500 MB
-        "backupCount": 20,
-    }
-
     handlers = {
         "stdout": {
             "formatter": "standard",
@@ -23,26 +21,25 @@ def make_log_config(log_to_disk: bool = False, level: int = logging.INFO):
             "stream": "ext://sys.stdout",
         },
     }
+
     if log_to_disk:
-        full_handler_list = ["default", "error"] + stdout_handler_list
         handlers.update(
             {
                 "default": dict(
                     level=level,  # type: ignore
                     filename=os.path.join(get_config().config_dir, "access.log"),
-                    **log_rotation_settings,  # type: ignore
+                    **_LOG_FILE_ROTATION_SETTINGS,  # type: ignore
                 ),
                 "error": dict(
                     level="ERROR",
                     filename=os.path.join(get_config().config_dir, "error.log"),
-                    **log_rotation_settings,  # type: ignore
+                    **_LOG_FILE_ROTATION_SETTINGS,  # type: ignore
                 ),
             }
         )
-    else:
-        full_handler_list = stdout_handler_list
 
-    root_logger_config = {"level": level, "handlers": full_handler_list}
+    handler_names = list(handlers.keys())
+    root_logger_config = {"level": level, "handlers": handler_names, "propagate": False}
 
     config = {
         "version": 1,
@@ -56,8 +53,9 @@ def make_log_config(log_to_disk: bool = False, level: int = logging.INFO):
         "handlers": handlers,
         "loggers": {
             "sematic": root_logger_config,
-            "gunicorn.error": {"level": logging.ERROR, "handlers": full_handler_list},
-            "gunicorn.access": {"level": level, "handlers": full_handler_list},
+            "gunicorn.error": {"level": logging.ERROR, "handlers": handler_names},
+            "gunicorn.access": {"level": level, "handlers": handler_names},
         },
     }
+
     return config


### PR DESCRIPTION
Fixes application logs being duplicated.

Also refactors the touched code in order to improve readability.

Before:
```
$ sematic run examples/add
Running example script: '['examples/add']'
Running example examples/add

2023-05-09 16:50:45,842 [INFO] sematic.resolvers.state_machine_resolver: Starting resolution c2e4fbc29bc14e91afa8af6e8940d7e2
2023-05-09 16:50:45,842 [INFO] sematic.resolvers.state_machine_resolver: Starting resolution c2e4fbc29bc14e91afa8af6e8940d7e2
2023-05-09 16:50:48,152 [INFO] sematic.resolvers.state_machine_resolver: Running inline c2e4fbc29bc14e91afa8af6e8940d7e2 sematic.examples.add.pipeline.pipeline
2023-05-09 16:50:48,152 [INFO] sematic.resolvers.state_machine_resolver: Running inline c2e4fbc29bc14e91afa8af6e8940d7e2 sematic.examples.add.pipeline.pipeline
2023-05-09 16:50:50,571 [INFO] sematic.resolvers.state_machine_resolver: Running inline c8930decb1ca42fd860b231661a74f4a sematic.examples.add.pipeline.add
2023-05-09 16:50:50,571 [INFO] sematic.resolvers.state_machine_resolver: Running inline c8930decb1ca42fd860b231661a74f4a sematic.examples.add.pipeline.add
2023-05-09 16:50:56,575 [INFO] sematic.resolvers.state_machine_resolver: Running inline ae76500b1b3d4ddcbc2a6bf8d2975f44 sematic.examples.add.pipeline.add
2023-05-09 16:50:56,575 [INFO] sematic.resolvers.state_machine_resolver: Running inline ae76500b1b3d4ddcbc2a6bf8d2975f44 sematic.examples.add.pipeline.add
2023-05-09 16:51:02,601 [INFO] sematic.resolvers.state_machine_resolver: Running inline 56c80caf3d3541bbaa982723b8a5d7a4 sematic.examples.add.pipeline.add
2023-05-09 16:51:02,601 [INFO] sematic.resolvers.state_machine_resolver: Running inline 56c80caf3d3541bbaa982723b8a5d7a4 sematic.examples.add.pipeline.add
2023-05-09 16:51:09,585 [INFO] sematic.resolvers.state_machine_resolver: Running inline d7efdcdef5ec46b0b2f782aacb0c09e5 sematic.examples.add.pipeline.add3
2023-05-09 16:51:09,585 [INFO] sematic.resolvers.state_machine_resolver: Running inline d7efdcdef5ec46b0b2f782aacb0c09e5 sematic.examples.add.pipeline.add3
2023-05-09 16:51:11,228 [INFO] sematic.resolvers.state_machine_resolver: Running inline 769739e260e5480e98187138408bab68 sematic.examples.add.pipeline.add
2023-05-09 16:51:11,228 [INFO] sematic.resolvers.state_machine_resolver: Running inline 769739e260e5480e98187138408bab68 sematic.examples.add.pipeline.add
2023-05-09 16:51:17,539 [INFO] sematic.resolvers.state_machine_resolver: Running inline aa7093bdae954fa48726223bb8096fd0 sematic.examples.add.pipeline.add
2023-05-09 16:51:17,539 [INFO] sematic.resolvers.state_machine_resolver: Running inline aa7093bdae954fa48726223bb8096fd0 sematic.examples.add.pipeline.add
2023-05-09 16:51:24,921 [INFO] root: 12.0

You run has completed, view it at https://tudor.dev-usw2-sematic0.sematic.cloud

$
```

After:
```
$ sematic run examples/add
Running example script: '['examples/add']'
Running example examples/add

2023-05-09 16:52:31,902 [INFO] sematic.resolvers.state_machine_resolver: Starting resolution 37c1cce82cde479298c84d1fdd94a023
2023-05-09 16:52:34,062 [INFO] sematic.resolvers.state_machine_resolver: Running inline 37c1cce82cde479298c84d1fdd94a023 sematic.examples.add.pipeline.pipeline
2023-05-09 16:52:36,521 [INFO] sematic.resolvers.state_machine_resolver: Running inline 33944cafda6b49cd8667460398ffdea6 sematic.examples.add.pipeline.add
2023-05-09 16:52:42,428 [INFO] sematic.resolvers.state_machine_resolver: Running inline d94d1f31ce2044609e0282f7422e118c sematic.examples.add.pipeline.add
2023-05-09 16:52:48,290 [INFO] sematic.resolvers.state_machine_resolver: Running inline c700acd3d2b24a55a4e567124163eb6c sematic.examples.add.pipeline.add
2023-05-09 16:52:55,098 [INFO] sematic.resolvers.state_machine_resolver: Running inline aa86974ad5fb4da0b4ef108ca477a756 sematic.examples.add.pipeline.add3
2023-05-09 16:52:56,543 [INFO] sematic.resolvers.state_machine_resolver: Running inline 629117e51ca24453ac5b1f5477f5838c sematic.examples.add.pipeline.add
2023-05-09 16:53:02,744 [INFO] sematic.resolvers.state_machine_resolver: Running inline 27d5fcf239384caebec96bb792b73be9 sematic.examples.add.pipeline.add
2023-05-09 16:53:10,281 [INFO] root: 12.0

You run has completed, view it at https://tudor.dev-usw2-sematic0.sematic.cloud

$
```
