### PR TITLE
[5/N] Run pipeline build through CLI

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -680,7 +680,7 @@ def _put(
     return response.json()
 
 
-def _validate_server_compatibility(use_cached: bool = True) -> None:
+def validate_server_compatibility(use_cached: bool = True) -> None:
     """Check that the client is compatible with the server.
 
     Raises an error if the server and client are incompatible, or if this can't be
@@ -766,7 +766,7 @@ def request(
     valid json.
     """
     if validate_version_compatibility:
-        _validate_server_compatibility()
+        validate_server_compatibility()
 
     kwargs = kwargs if kwargs is not None else dict()
     headers = kwargs.get("headers", {})

--- a/sematic/cli/BUILD
+++ b/sematic/cli/BUILD
@@ -117,7 +117,10 @@ sematic_py_lib(
     deps = [
         ":cli",
         ":process_utils",
+        "//sematic:api_client",
         "//sematic/config:config",
+        "//sematic/plugins:abstract_builder",
+        "//sematic/plugins/building:docker_builder",
     ],
 )
 

--- a/sematic/cli/run.py
+++ b/sematic/cli/run.py
@@ -1,17 +1,23 @@
 # Standard Library
+import math
 import os
 import runpy
 import sys
-import typing
+import time
+from logging.config import dictConfig
+from typing import List, Tuple
 
 # Third-party
 import click
 
 # Sematic
+from sematic.api_client import validate_server_compatibility
 from sematic.cli.cli import cli
 from sematic.cli.examples_utils import is_example
-from sematic.cli.process_utils import server_is_running
-from sematic.config.config import get_config
+from sematic.config.config import get_config, switch_env
+from sematic.logging import make_log_config
+from sematic.plugins.abstract_builder import get_builder_plugin
+from sematic.plugins.building.docker_builder import DockerBuilder
 
 
 def _example_path_to_import_path(script_path: str) -> str:
@@ -26,13 +32,12 @@ def _get_requirements_path(example_path: str) -> str:
     )
 
 
-def _get_requirements(example_path: str) -> typing.List[str]:
+def _get_requirements(example_path: str) -> List[str]:
     with open(_get_requirements_path(example_path), "r") as file:
         return file.read().split("\n")
 
 
 def _run_example(example_path: str):
-    click.echo("Running example {}\n".format(example_path))
     try:
         runpy.run_module(
             _example_path_to_import_path(example_path), run_name="__main__"
@@ -51,26 +56,63 @@ def _run_example(example_path: str):
         click.echo("\tpip3 install -r {}".format(_get_requirements_path(example_path)))
 
 
-@cli.command(
-    "run",
-    short_help="Run a pipeline, or a packaged example",
-    context_settings=dict(
-        ignore_unknown_options=True,
-        allow_extra_args=True,
+@cli.command("run", short_help="Run a pipeline, or a packaged example.")
+@click.option(
+    "-b",
+    "--build",
+    help=(
+        "Build a container image that will be used to execute the pipeline, "
+        "using the configured build plugin. Defaults to `False`. "
+        "If not set, the pipeline will be run locally in the current environment."
     ),
+    default=False,
+    is_flag=True,
+)
+@click.option(
+    "-l",
+    "--log-level",
+    help=(
+        "The log level to use for building and launching the pipeline. "
+        "Defaults to `INFO`."
+    ),
+    default="INFO",
 )
 @click.argument("script_path", type=click.STRING)
-@click.pass_context
-def run(ctx, script_path: str):
-    if not server_is_running():
-        click.echo("Sematic is not started, issue `sematic start` first.")
-        return
+@click.argument("script_arguments", nargs=-1, type=click.STRING)
+def run(build: bool, log_level: str, script_path: str, script_arguments: Tuple[str]):
+
+    # ensure the client is pointing to the intended server
+    switch_env("user")
+    dictConfig(make_log_config(log_to_disk=False, level=log_level))
+
+    # ensure the server is reachable before doing all the work
+    validate_server_compatibility(use_cached=False)
 
     # This is ugly, better way to do this?
-    sys.argv = [sys.argv[0]] + ctx.args
+    sys.argv = [script_path] + list(script_arguments)
+    pseudo_command = " ".join(sys.argv)
 
     if is_example(script_path):
-        _run_example(script_path)
+        click.echo(f"Running example script: {pseudo_command}")
+        _run_example(example_path=script_path)
         return
 
-    runpy.run_module(script_path, run_name="__main__")
+    if os.path.splitext(script_path)[1] != ".py":
+        click.echo(f"Can only run Python files; got: '{script_path}'", err=True)
+        sys.exit(1)
+
+    if not build:
+        click.echo(f"Running script locally: {pseudo_command}")
+        runpy.run_path(path_name=script_path, run_name="__main__")
+        return
+
+    builder_class = get_builder_plugin(default=DockerBuilder)
+    builder = builder_class()
+
+    click.echo(f"Building image and launching: {pseudo_command}")
+    start_time = time.time()
+    builder.build_and_launch(target=script_path)
+    stop_time = time.time()
+
+    duration_seconds = math.floor((stop_time - start_time) * 100) / 100.0
+    click.echo(f"Built and launched '{script_path}' in {duration_seconds}s")

--- a/sematic/logging.py
+++ b/sematic/logging.py
@@ -1,6 +1,7 @@
 # Standard Library
 import logging
 import os
+from typing import Union
 
 # Sematic
 from sematic.config.config import get_config
@@ -13,7 +14,9 @@ _LOG_FILE_ROTATION_SETTINGS = {
 }
 
 
-def make_log_config(log_to_disk: bool = False, level: int = logging.INFO):
+def make_log_config(log_to_disk: bool = False, level: Union[int, str] = logging.INFO):
+    level = logging._checkLevel(str(level).upper())  # type: ignore
+
     handlers = {
         "stdout": {
             "formatter": "standard",

--- a/sematic/logging.py
+++ b/sematic/logging.py
@@ -15,7 +15,9 @@ _LOG_FILE_ROTATION_SETTINGS = {
 
 
 def make_log_config(log_to_disk: bool = False, level: Union[int, str] = logging.INFO):
-    level = logging._checkLevel(str(level).upper())  # type: ignore
+    if isinstance(level, str):
+        level = level.upper()
+    level = logging._checkLevel(level)  # type: ignore
 
     handlers = {
         "stdout": {

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, TextIO, Tuple
 
 # isort: off
 
@@ -63,6 +63,8 @@ _DOCKERFILE_REQUIREMENTS_TEMPLATE = """
 COPY {requirements_file} requirements.txt
 RUN pip3 install --no-cache -r requirements.txt
 """
+
+_ROLLING_PRINT_WINDOW = 10
 
 
 @dataclass
@@ -601,18 +603,14 @@ def _build_image_from_base(
         image = docker_client.images.get(str(effective_base_uri))
         return image, ImageURI.from_image(image)
 
-    for status_update in status_updates:
-        if "error" in status_update.keys():
-            logger.error(
-                "Image build error details: '%s'", str(status_update.get("errorDetail"))
-            )
-            raise BuildError(
-                f"Unable to build image '{built_image_name}': {status_update['error']}"
-            )
-
-        update_str = _docker_status_update_to_str(status_update)
-        if update_str is not None:
-            logger.info("Image build update: %s", update_str)
+    error_update = _rolling_print_status_updates(status_updates)
+    if error_update is not None:
+        logger.error(
+            "Image build error details: '%s'", str(error_update.get("errorDetail"))
+        )
+        raise BuildError(
+            f"Unable to build image '{built_image_name}': {error_update['error']}"
+        )
 
     image = docker_client.images.get(built_image_name)
     return image, ImageURI.from_image(image)
@@ -769,16 +767,12 @@ def _push_image(
         )
         return _reload_image_uri(image=image)
 
-    for status_update in status_updates:
-        if "error" in status_update.keys():
-            logger.error(
-                "Image push error details: '%s'", str(status_update.get("errorDetail"))
-            )
-            raise BuildError(f"Unable to push image: {status_update['error']}")
-
-        update_str = _docker_status_update_to_str(status_update)
-        if update_str is not None:
-            logger.info("Image push update: %s", update_str)
+    error_update = _rolling_print_status_updates(status_updates)
+    if error_update is not None:
+        logger.error(
+            "Image push error details: '%s'", str(error_update.get("errorDetail"))
+        )
+        raise BuildError(f"Unable to push image: {error_update['error']}")
 
     return _reload_image_uri(image=image)
 
@@ -803,6 +797,35 @@ def _reload_image_uri(image: Image) -> ImageURI:  # type: ignore
     repository, tag = image.attrs["RepoTags"][0].split(":")
 
     return ImageURI(repository=repository, tag=tag, digest=digest)
+
+
+def _rolling_print_status_updates(
+    status_updates: Generator[Dict[str, Any], None, None],
+    output_handle: TextIO = sys.stderr,
+) -> Optional[Dict[str, Any]]:
+    """
+    Prints a rolling window of Docker server status message updates.
+    """
+    message_window = []
+
+    for status_update in status_updates:
+        if "error" in status_update.keys():
+            return status_update
+
+        update_str = _docker_status_update_to_str(status_update)
+        if update_str is None:
+            continue
+
+        message_window.append(update_str)
+        if len(message_window) <= _ROLLING_PRINT_WINDOW:
+            print(update_str, file=output_handle)
+        else:
+            message_window = message_window[1:]
+            print(f"\033[{_ROLLING_PRINT_WINDOW + 1}F\033[K[...]", file=output_handle)
+            for message in message_window:
+                print(f"\033[K{message}", file=output_handle)
+
+    return None
 
 
 def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]:

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -402,15 +402,17 @@ def _build(target: str) -> ImageURI:
     executions.
     """
     build_config = _get_build_config(script_path=target)
-    logger.info("Loaded build configuration: %s", build_config)
+    logger.debug("Loaded build configuration: %s", build_config)
 
     docker_client = _make_docker_client(build_config.docker)
-    logger.info("Instantiated docker client for server: %s", docker_client.api.base_url)
+    logger.debug(
+        "Instantiated docker client for server: %s", docker_client.api.base_url
+    )
 
     image, image_uri = _build_image(
         target=target, build_config=build_config, docker_client=docker_client
     )
-    logger.info("Built local image: %s", repr(image_uri))
+    logger.debug("Built local image: %s", repr(image_uri))
 
     build_image_uri = _push_image(
         image=image,
@@ -419,7 +421,7 @@ def _build(target: str) -> ImageURI:
         docker_client=docker_client,
     )
 
-    logger.info("Using image: %s", repr(build_image_uri))
+    logger.debug("Using image: %s", repr(build_image_uri))
 
     return build_image_uri
 
@@ -437,7 +439,7 @@ def _launch(target: str, image_uri: ImageURI) -> None:
 
     runpy.run_path(path_name=target, run_name="__main__")
 
-    logger.info("Finished launching target: '%s'", target)
+    logger.debug("Finished launching target: '%s'", target)
 
 
 def _get_build_config(script_path: str) -> BuildConfig:
@@ -451,7 +453,7 @@ def _get_build_config(script_path: str) -> BuildConfig:
         There was an error when loading or validating the specified build configuration.
     """
     build_config_files = _find_build_config_files(script_path=script_path)
-    logger.info(
+    logger.debug(
         "Script '%s' has these corresponding build files: %s",
         script_path,
         build_config_files,
@@ -674,8 +676,8 @@ def _execute_build_script(target: str, image_script: str) -> ImageURI:
             script_dir = None  # type: ignore
         script_file = f"./{script_file}"
 
-        logger.info(
-            f"Executing: executable={script_file} cwd={script_dir} args={target}"
+        logger.debug(
+            f"Executing: executable={script_file} args={target} cwd={script_dir}"
         )
 
         # the subprocess' stderr will be inherited from the current process,

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -40,11 +40,9 @@ from sematic.plugins.abstract_builder import (
 logger = logging.getLogger(__name__)
 
 # Version of the build file schema
-# TODO: bump to 1 when the build system is exposed to users
-BUILD_SCHEMA_VERSION = 0
+BUILD_SCHEMA_VERSION = 1
 
-# TODO: bump to 0.1.0 when the build system is exposed to users
-_PLUGIN_VERSION = (0, 0, 1)
+_PLUGIN_VERSION = (0, 1, 0)
 
 _DOCKERFILE_BASE_TEMPLATE = """
 FROM {base_uri}

--- a/sematic/plugins/building/tests/fixtures/bad_version.yaml
+++ b/sematic/plugins/building/tests/fixtures/bad_version.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 0
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"

--- a/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"

--- a/sematic/plugins/building/tests/fixtures/good_minimal.yaml
+++ b/sematic/plugins/building/tests/fixtures/good_minimal.yaml
@@ -1,2 +1,2 @@
-version: 0
+version: 1
 image_script: "sematic/plugins/building/tests/fixtures/good_image_script.sh"

--- a/sematic/plugins/building/tests/fixtures/malformed_push1.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_push1.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"

--- a/sematic/plugins/building/tests/fixtures/malformed_push2.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_push2.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"

--- a/sematic/plugins/building/tests/fixtures/malformed_uri.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_uri.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest"
 build:
   platform: "linux/amd64"

--- a/sematic/plugins/building/tests/fixtures/no_image.yaml
+++ b/sematic/plugins/building/tests/fixtures/no_image.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"

--- a/sematic/plugins/building/tests/fixtures/two_images.yaml
+++ b/sematic/plugins/building/tests/fixtures/two_images.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 image_script: "good_image_script.sh"
 build:

--- a/sematic/tests/test_api_client.py
+++ b/sematic/tests/test_api_client.py
@@ -15,9 +15,9 @@ from sematic.api.tests.fixtures import test_client  # noqa: F401
 from sematic.api_client import (
     IncompatibleClientError,
     _notify_event,
-    _validate_server_compatibility,
     get_artifact_value_by_id,
     save_metric_points,
+    validate_server_compatibility,
 )
 from sematic.config.config import get_config
 from sematic.db.db import DB
@@ -75,7 +75,7 @@ def test_validate_server_compatibility(mock_requests):
             min_client_supported=MIN_CLIENT_SERVER_SUPPORTS,
         ),
     )
-    _validate_server_compatibility(use_cached=False)
+    validate_server_compatibility(use_cached=False)
     mock_requests.get.assert_called_with(
         f"{get_config().api_url}/meta/versions",
         headers={"Content-Type": "application/json"},
@@ -91,7 +91,7 @@ def test_validate_server_compatibility_bad_json(mock_requests):
 
     mock_requests.get.return_value.json = bad_json
     with pytest.raises(IncompatibleClientError):
-        _validate_server_compatibility(use_cached=False)
+        validate_server_compatibility(use_cached=False)
 
 
 @mock.patch("sematic.api_client.requests")
@@ -104,7 +104,7 @@ def test_validate_server_compatibility_old_server(mock_requests):
         ),
     )
     with pytest.raises(IncompatibleClientError):
-        _validate_server_compatibility(use_cached=False)
+        validate_server_compatibility(use_cached=False)
 
 
 @mock.patch("sematic.api_client.requests")
@@ -119,7 +119,7 @@ def test_validate_server_compatibility_old_client(mock_requests):
         ),
     )
     with pytest.raises(IncompatibleClientError):
-        _validate_server_compatibility(use_cached=False)
+        validate_server_compatibility(use_cached=False)
 
 
 @mock.patch("sematic.api_client.requests")
@@ -131,8 +131,8 @@ def test_validate_server_compatibility_new_server_still_supports(mock_requests):
             min_client_supported=MIN_CLIENT_SERVER_SUPPORTS,
         ),
     )
-    _validate_server_compatibility(use_cached=False)
-    _validate_server_compatibility(use_cached=True)
+    validate_server_compatibility(use_cached=False)
+    validate_server_compatibility(use_cached=True)
 
     mock_requests.get.assert_called_once()
 


### PR DESCRIPTION
This is the fifth PR in a chain that introduces a Build System plugin with an implementation that uses native Python+Docker capabilities to build a container image and launch a pipeline, without requiring Bazel. The previous PR in the chain is #813.

This PR updates the `sematic run` CLI command to be able to run proprietary builds and launch cloud pipelines in addition to example pipelines. This effectively exposes the Docker Build System to users.

## Testing

#### Unit Tests

```
$ bazel test --test_output=all sematic/plugins/building/tests:test_docker_builder
```

#### Help String

```
$ sematic run --help
Usage: sematic run [OPTIONS] SCRIPT_PATH [SCRIPT_ARGUMENTS]...

Options:
  -b, --build           Build a container image that will be used to execute
                        the pipeline, using the configured build plugin.
                        Defaults to `False`. If not set, the pipeline will be
                        run locally in the current environment.
  -l, --log-level TEXT  The log level to use for building and launching the
                        pipeline. Defaults to `INFO`.
  --help                Show this message and exit.
```

#### Run Example

```
$ sematic run examples/add
Running example script: examples/add
2023-05-09 18:12:31,285 [INFO] sematic.resolvers.state_machine_resolver: Starting resolution 3c043766263f4521a33a6303e9a0e0f5
2023-05-09 18:12:33,538 [INFO] sematic.resolvers.state_machine_resolver: Running inline 3c043766263f4521a33a6303e9a0e0f5 sematic.examples.add.pipeline.pipeline
2023-05-09 18:12:36,020 [INFO] sematic.resolvers.state_machine_resolver: Running inline aba369ce6e934f5e844fd5f0a677af0f sematic.examples.add.pipeline.add
2023-05-09 18:12:42,093 [INFO] sematic.resolvers.state_machine_resolver: Running inline 074dc5159acf47d0b296e42b57d83ee6 sematic.examples.add.pipeline.add
2023-05-09 18:12:48,221 [INFO] sematic.resolvers.state_machine_resolver: Running inline dca122306b2948188a8678be9edccc61 sematic.examples.add.pipeline.add
2023-05-09 18:12:55,210 [INFO] sematic.resolvers.state_machine_resolver: Running inline dae6501172004dc8a2c6c7908cc9a8a3 sematic.examples.add.pipeline.add3
2023-05-09 18:12:56,907 [INFO] sematic.resolvers.state_machine_resolver: Running inline 73bda9be44b94583974783235e71a3b8 sematic.examples.add.pipeline.add
2023-05-09 18:13:03,319 [INFO] sematic.resolvers.state_machine_resolver: Running inline 16446c8929fe4d02bf904198b7f41dcb sematic.examples.add.pipeline.add
2023-05-09 18:13:10,935 [INFO] root: 12.0

You run has completed, view it at https://tudor.dev-usw2-sematic0.sematic.cloud

```

#### Run Pipeline Locally

```
example_docker$ sematic run basic/main.py
Running script locally: basic/main.py
2023-05-09 18:13:54,719 [INFO] sematic.resolvers.state_machine_resolver: Starting resolution 8d1a898ca3924a729491fb2551a054da
2023-05-09 18:13:56,112 [INFO] sematic.resolvers.state_machine_resolver: Running inline 8d1a898ca3924a729491fb2551a054da __main__.pipeline
Hello, world!
```

#### Build and Run Remote Pipeline

Building and launching a pipeline from scratch, with no cached layers ([Dashboard result](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/ce08af94d814469697ebd4c9f10cd15b)):

```
$ sematic run --build --log-level=info advanced/main.py -- /advanced/data/message.txt
Building image and launching: advanced/main.py /advanced/data/message.txt
2023-05-09 18:15:45,971 [INFO] sematic.plugins.building.docker_builder: Script 'advanced/main.py' has these corresponding build files: ['advanced/main.yaml']
2023-05-09 18:15:45,973 [INFO] sematic.plugins.building.docker_builder: Loaded build configuration: BuildConfig(version=0, image_script='advanced/scripts/build_image.sh', base_uri=None, build=None, push=ImagePushConfig(registry='558717131297.dkr.ecr.us-west-2.amazonaws.com', repository='sematic-dev', tag_suffix='example_docker_advanced'), docker=DockerClientConfig(base_url='unix://var/run/docker.sock', version='auto', timeout=None, tls=True, user_agent=None, credstore_env=None, use_ssh_client=False, max_pool_size=5))
2023-05-09 18:15:46,028 [INFO] sematic.plugins.building.docker_builder: Instantiated docker client for server: http+docker://localhost
2023-05-09 18:15:46,028 [INFO] sematic.plugins.building.docker_builder: Executing: executable=./build_image.sh cwd=advanced/scripts args=advanced/main.py
[+] Building 350.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 920B                                                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                                                               1.8s
 => [internal] load build context                                                                                                                                                                                                             0.0s
 => => transferring context: 3.99kB                                                                                                                                                                                                           0.0s
 => [ 1/14] FROM docker.io/library/ubuntu:22.04@sha256:dfd64a3b4296d8c9b62aa3309984f8620b98d87e47492599ee20739e8eb54fbf                                                                                                                       1.7s
 => => resolve docker.io/library/ubuntu:22.04@sha256:dfd64a3b4296d8c9b62aa3309984f8620b98d87e47492599ee20739e8eb54fbf                                                                                                                         0.0s
 => => sha256:dfd64a3b4296d8c9b62aa3309984f8620b98d87e47492599ee20739e8eb54fbf 1.13kB / 1.13kB                                                                                                                                                0.0s
 => => sha256:ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 424B / 424B                                                                                                                                                    0.0s
 => => sha256:3b418d7b466ac6275a6bfcb0c86fbe4422ff6ea0af444a294f82d3bf5173ce74 2.30kB / 2.30kB                                                                                                                                                0.0s
 => => sha256:dbf6a9befcdeecbb8813406afbd62ce81394e3869d84599f19f941aa5c74f3d1 29.53MB / 29.53MB                                                                                                                                              1.1s
 => => extracting sha256:dbf6a9befcdeecbb8813406afbd62ce81394e3869d84599f19f941aa5c74f3d1                                                                                                                                                     0.5s
 => [ 2/14] RUN apt update -y && apt install -y software-properties-common                                                                                                                                                                  136.3s
 => [ 3/14] RUN add-apt-repository -y ppa:deadsnakes/ppa                                                                                                                                                                                     21.3s
 => [ 4/14] RUN apt update -y && apt install -y python3.9                                                                                                                                                                                    35.1s
 => [ 5/14] RUN rm /usr/bin/python3                                                                                                                                                                                                           0.3s
 => [ 6/14] RUN ln -s /usr/bin/python3.9 /usr/bin/python3                                                                                                                                                                                     0.3s
 => [ 7/14] RUN ln -s /usr/bin/python3.9 /usr/bin/python                                                                                                                                                                                      0.4s
 => [ 8/14] RUN apt update -y && apt install -y python3-pip                                                                                                                                                                                  59.2s
 => [ 9/14] RUN apt update -y && apt install --reinstall -y python3.9-distutils                                                                                                                                                              19.6s
 => [10/14] COPY requirements.txt requirements.txt                                                                                                                                                                                            0.0s
 => [11/14] RUN pip3 install --no-cache -r requirements.txt                                                                                                                                                                                  73.3s
 => [12/14] COPY advanced/data/message.txt advanced/data/message.txt                                                                                                                                                                          0.0s
 => [13/14] COPY advanced/*.py advanced/                                                                                                                                                                                                      0.0s
 => exporting to image                                                                                                                                                                                                                        0.8s
 => => exporting layers                                                                                                                                                                                                                       0.8s
 => => writing image sha256:b7fd78d93f5aa953659577e5cbf719e9bc76159a1437db372f18fbe429035022                                                                                                                                                  0.0s
 => => naming to docker.io/library/example_docker:default_advanced                                                                                                                                                                            0.0s
2023-05-09 18:21:37,069 [INFO] sematic.plugins.building.docker_builder: Building image 'advanced:default_example_docker_advanced' starting from base: example_docker:default_advanced
[...]
stream=---> 38a1b050e064
aux={'ID': 'sha256:38a1b050e0643df0e16ea31580debaba128cac189f02c8ec53d4a2a6ca647164'}
stream=Successfully built 38a1b050e064
stream=Successfully tagged advanced:default_example_docker_advanced
2023-05-09 18:21:59,998 [INFO] sematic.plugins.building.docker_builder: Built local image: advanced:default_example_docker_advanced@sha256:38a1b050e0643df0e16ea31580debaba128cac189f02c8ec53d4a2a6ca647164
2023-05-09 18:22:00,016 [INFO] sematic.plugins.building.docker_builder: Tagged image 'advanced:default_example_docker_advanced' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_advanced'
[...]
id=ec9f1663b23d progress=[==================================================>]  267.7MB progressDetail={'current': 267698176, 'total': 263056953} status=Pushing
id=ec9f1663b23d progressDetail={} status=Pushed
id=eb78df778776 progressDetail={} status=Pushed
status=default_example_docker_advanced: digest: sha256:2596cbba0a59e99484374fabf86549faad464d72affed4e3f276f051c63810b2 size: 3871
aux={'Tag': 'default_example_docker_advanced', 'Digest': 'sha256:2596cbba0a59e99484374fabf86549faad464d72affed4e3f276f051c63810b2', 'Size': 3871} progressDetail={}
2023-05-09 18:22:14,513 [INFO] sematic.plugins.building.docker_builder: Using image: 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_advanced@sha256:2596cbba0a59e99484374fabf86549faad464d72affed4e3f276f051c63810b2
2023-05-09 18:22:14,514 [INFO] sematic.plugins.building.docker_builder: Launching target: 'advanced/main.py'
ce08af94d814469697ebd4c9f10cd15b
2023-05-09 18:22:15,792 [INFO] sematic.plugins.building.docker_builder: Finished launching target: 'advanced/main.py'
Built and launched 'advanced/main.py' in 389.82s
```

![build_advanced](https://github.com/sematic-ai/sematic/assets/1894533/4f350da3-5960-48a8-8e4f-e95dca25f0c6)

![build_intermediate](https://github.com/sematic-ai/sematic/assets/1894533/cfcad989-3887-4242-ad50-413ce5fd82f6)

