### PR TITLE
Use real run data in search table

### DIFF
--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -1,0 +1,23 @@
+import { Run } from "src/Models";
+
+export type RunListPayload = {
+    current_page_url: string;
+    next_page_url?: string;
+    limit: number;
+    next_cursor?: string;
+    after_cursor_count: number;
+    content: Run[];
+};
+
+type Operator = "eq";
+
+type FilterCondition = {
+    [key: string]: {[eq in Operator]? : string | null} | undefined
+}
+
+export type Filter = FilterCondition | {
+    AND : Array<FilterCondition>
+} | {
+  OR : Array<FilterCondition>
+}
+

--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -12,12 +12,12 @@ export type RunListPayload = {
 type Operator = "eq";
 
 type FilterCondition = {
-    [key: string]: {[eq in Operator]? : string | null} | undefined
+    [key: string]: { [eq in Operator]?: string | null } | undefined
 }
 
 export type Filter = FilterCondition | {
-    AND : Array<FilterCondition>
+    AND: Array<FilterCondition>
 } | {
-  OR : Array<FilterCondition>
+    OR: Array<FilterCondition>
 }
 

--- a/sematic/ui/packages/common/src/component/DateTime.tsx
+++ b/sematic/ui/packages/common/src/component/DateTime.tsx
@@ -31,14 +31,13 @@ export const Duration = (start: Date, end: Date) => {
         end
     });
 
-    const formatString = formatDuration(duration, { format: ["minutes", "seconds"], zero: true});
+    const formatString = formatDuration(duration, { format: ["minutes", "seconds"], zero: false});
 
     return formatString.replace(/\s0\sseconds$/g, "");
 }
 
 export function DurationShort(start: Date, end: Date) {
-    return Duration(start, end).replace(/minutes/g, "m").replace(/seconds/g, "s");
+    return Duration(start, end).replace(/\sminutes?/g, "m").replace(/\sseconds?/g, "s");
 }
-
 
 export default DateTime;

--- a/sematic/ui/packages/common/src/component/Loading.tsx
+++ b/sematic/ui/packages/common/src/component/Loading.tsx
@@ -1,0 +1,8 @@
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+
+const Loading = () => <Box sx={{ textAlign: "center" }}>
+    <CircularProgress sx={{ marginY: 5 }} />
+</Box>;
+
+export default Loading;

--- a/sematic/ui/packages/common/src/component/Note.tsx
+++ b/sematic/ui/packages/common/src/component/Note.tsx
@@ -7,7 +7,7 @@ import { useCallback, useMemo, useState } from "react";
 import useMeasure from "react-use/lib/useMeasure";
 import DateTime from "src/component/DateTime";
 import NameTag from "src/component/NameTag";
-import RunReferenceLink from "src/component/RunReferenceLink";
+import { RunReferenceLink } from "src/component/RunReference";
 import Section from "src/component/Section";
 import theme from "src/theme/new";
 

--- a/sematic/ui/packages/common/src/component/RunReference.tsx
+++ b/sematic/ui/packages/common/src/component/RunReference.tsx
@@ -1,7 +1,8 @@
 import Link from "@mui/material/Link";
-import { TypographyProps } from '@mui/material/Typography';
+import Typography, { TypographyProps } from '@mui/material/Typography';
 import { Link as RouterLink } from "react-router-dom";
 import { getRunUrlPattern } from "src/hooks/runHooks";
+
 
 interface RunReferenceLinkProps {
     runId: string;
@@ -9,7 +10,7 @@ interface RunReferenceLinkProps {
     variant?: TypographyProps['variant'];
 }
 
-const RunReferenceLink = (props: RunReferenceLinkProps) => {
+export const RunReferenceLink = (props: RunReferenceLinkProps) => {
     const { runId, className, variant = "small" } = props;
 
     return <Link to={getRunUrlPattern(runId)} variant={variant} type={"code"} className={className}
@@ -18,4 +19,10 @@ const RunReferenceLink = (props: RunReferenceLinkProps) => {
     </Link>
 }
 
-export default RunReferenceLink;
+export const RunReference = (props: RunReferenceLinkProps) => {
+    const { runId, className, variant = "code" } = props;
+
+    return <Typography variant={variant} className={className} >
+        {runId.substring(0, 7)}
+    </Typography>
+}

--- a/sematic/ui/packages/common/src/component/RunReferenceLink.tsx
+++ b/sematic/ui/packages/common/src/component/RunReferenceLink.tsx
@@ -1,5 +1,7 @@
 import Link from "@mui/material/Link";
 import { TypographyProps } from '@mui/material/Typography';
+import { Link as RouterLink } from "react-router-dom";
+import { getRunUrlPattern } from "src/hooks/runHooks";
 
 interface RunReferenceLinkProps {
     runId: string;
@@ -8,11 +10,12 @@ interface RunReferenceLinkProps {
 }
 
 const RunReferenceLink = (props: RunReferenceLinkProps) => {
-    const { runId, className, variant="small" } = props;
+    const { runId, className, variant = "small" } = props;
 
-    return <Link href={`/runs/${runId}`} variant={variant} type={"code"} className={className}>
-            {runId.substring(0, 7)}
-        </Link>
+    return <Link to={getRunUrlPattern(runId)} variant={variant} type={"code"} className={className}
+        component={RouterLink}>
+        {runId.substring(0, 7)}
+    </Link>
 }
 
 export default RunReferenceLink;

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -58,21 +58,24 @@ export const SubmittedStateChip = (props: StateChipBaseProps) => {
     return <ArrowUpward color={"lightGrey"} style={styles} />;
 }
 
-export function getRunStateChipByState(futureState: string, size: StateChipBaseProps['size'] ="large") {
-    if (futureState === 'SUCCESS') {
+export function getRunStateChipByState(futureState: string, size: StateChipBaseProps['size'] = "large") {
+    if (futureState === 'RESOLVED') {
         return <SuccessStateChip size={size} />;
     }
-    if (futureState === 'FAILED') {
+    if (["FAILED", "NESTED_FAILED"].includes(futureState)) {
         return <FailedStateChip size={size} />;
     }
-    if (futureState === 'RUNNING') {
+    if (["SCHEDULED", "RAN"].includes(futureState)) {
         return <RunningStateChip size={size} />;
     }
     if (futureState === 'CANCELLED') {
         return <CanceledStateChip size={size} />;
     }
-    if (futureState === 'SCHEDULED') {
+    if (futureState === 'CREATED') {
         return <SubmittedStateChip size={size} />;
+    }
+    if (futureState === "RETRYING") {
+        return <RunningStateChip size={size} />;
     }
 
     return null;

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -59,7 +59,7 @@ export const SubmittedStateChip = (props: StateChipBaseProps) => {
 }
 
 export function getRunStateChipByState(futureState: string, size: StateChipBaseProps['size'] = "large") {
-    if (futureState === 'RESOLVED') {
+    if (["RESOLVED", "SUCCEEDED"].includes(futureState)) {
         return <SuccessStateChip size={size} />;
     }
     if (["FAILED", "NESTED_FAILED"].includes(futureState)) {
@@ -68,10 +68,10 @@ export function getRunStateChipByState(futureState: string, size: StateChipBaseP
     if (["SCHEDULED", "RAN"].includes(futureState)) {
         return <RunningStateChip size={size} />;
     }
-    if (futureState === 'CANCELLED') {
+    if (futureState === "CANCELED") {
         return <CanceledStateChip size={size} />;
     }
-    if (futureState === 'CREATED') {
+    if (futureState === "CREATED") {
         return <SubmittedStateChip size={size} />;
     }
     if (futureState === "RETRYING") {

--- a/sematic/ui/packages/common/src/component/RunStateText.ts
+++ b/sematic/ui/packages/common/src/component/RunStateText.ts
@@ -2,23 +2,28 @@ import { parseJSON } from 'date-fns';
 import { DurationShort } from 'src/component/DateTime';
 
 export function getRunStateText(futureState: string,
-    timestamps: { createdAt: string, resolvedAt?: string, failedAt?: string, canceledAt?: string }) {
-    const { createdAt, resolvedAt, failedAt, canceledAt } = timestamps;
+    timestamps: {
+        createdAt: string, resolvedAt?: string, failedAt?: string, endedAt?: string
+    }) {
+    const { createdAt, resolvedAt, failedAt, endedAt } = timestamps;
 
-    if (futureState === 'SUCCESS') {
+    if (futureState === 'RESOLVED') {
         return `Completed in ${DurationShort(parseJSON(resolvedAt!), parseJSON(createdAt))}`;
     }
-    if (futureState === 'FAILED') {
+    if (["FAILED", "NESTED_FAILED"].includes(futureState)) {
         return `Failed after ${DurationShort(parseJSON(failedAt!), parseJSON(createdAt))}`;
     }
-    if (futureState === 'RUNNING') {
+    if (["SCHEDULED", "RAN"].includes(futureState)) {
         return `Running for ${DurationShort(new Date(), parseJSON(createdAt))}`;
     }
     if (futureState === 'CANCELLED') {
-        return `Canceled after ${DurationShort(parseJSON(canceledAt!), parseJSON(createdAt))}`;
+        return `Canceled after ${DurationShort(parseJSON(endedAt || failedAt!), parseJSON(createdAt))}`;
     }
-    if (futureState === 'SCHEDULED') {
+    if (futureState === 'CREATED') {
         return 'Submitted';
+    }
+    if (futureState === 'RETRYING') {
+        return `Retrying for ${DurationShort(new Date(), parseJSON(createdAt))}`;
     }
     return null;
 }

--- a/sematic/ui/packages/common/src/component/RunStateText.ts
+++ b/sematic/ui/packages/common/src/component/RunStateText.ts
@@ -7,7 +7,7 @@ export function getRunStateText(futureState: string,
     }) {
     const { createdAt, resolvedAt, failedAt, endedAt } = timestamps;
 
-    if (futureState === 'RESOLVED') {
+    if (["RESOLVED", "SUCCEEDED"].includes(futureState)) {
         return `Completed in ${DurationShort(parseJSON(resolvedAt!), parseJSON(createdAt))}`;
     }
     if (["FAILED", "NESTED_FAILED"].includes(futureState)) {
@@ -16,13 +16,13 @@ export function getRunStateText(futureState: string,
     if (["SCHEDULED", "RAN"].includes(futureState)) {
         return `Running for ${DurationShort(new Date(), parseJSON(createdAt))}`;
     }
-    if (futureState === 'CANCELLED') {
+    if (futureState === "CANCELED") {
         return `Canceled after ${DurationShort(parseJSON(endedAt || failedAt!), parseJSON(createdAt))}`;
     }
-    if (futureState === 'CREATED') {
-        return 'Submitted';
+    if (futureState === "CREATED") {
+        return `Submitted ${DurationShort(new Date(), parseJSON(createdAt))} ago`;
     }
-    if (futureState === 'RETRYING') {
+    if (futureState === "RETRYING") {
         return `Retrying for ${DurationShort(new Date(), parseJSON(createdAt))}`;
     }
     return null;

--- a/sematic/ui/packages/common/src/component/Table.tsx
+++ b/sematic/ui/packages/common/src/component/Table.tsx
@@ -65,7 +65,7 @@ const TableDataRow = styled(TableRow)`
 
     & td {
         padding-left: 0;
-        padding-right: ${theme.spacing(2.5)};
+        padding-right: ${theme.spacing(5)};
         padding-top: 0;
         padding-bottom: 0;
         border-bottom: none;
@@ -80,19 +80,20 @@ const TableDataRow = styled(TableRow)`
     }
 `;
 
-interface TableComponentProps<T> {
+export interface TableComponentProps<T> {
     table: Table<T>;
     stickyHeader?: boolean;
     getRowLink?: (row: Row<T>) => string;
+    className?: string;
 }
 
 const TableComponent = <T,>(props: TableComponentProps<T>) => {
-    const { table, stickyHeader = true, getRowLink } = props;
+    const { table, stickyHeader = true, getRowLink, className } = props;
     const { getLeafHeaders } = table;
 
     const navigate = useNavigate();
 
-    return <TableScroller>
+    return <TableScroller className={className}>
         <TableMui>
             <StyledHeader stickyHeader={stickyHeader}>
                 <TableRow>

--- a/sematic/ui/packages/common/src/component/Table.tsx
+++ b/sematic/ui/packages/common/src/component/Table.tsx
@@ -4,7 +4,8 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { Table, flexRender } from "@tanstack/react-table";
+import { Table, flexRender, Row } from "@tanstack/react-table";
+import { useNavigate } from "react-router-dom";
 import theme from "src/theme/new";
 
 const TableScroller = styled.div`
@@ -16,7 +17,6 @@ const TableScroller = styled.div`
     flex-shrink: 1;
     position: relative;
     margin-left: -${theme.spacing(5)};
-    padding-left: ${theme.spacing(5)};
 `;
 
 const StyledHeader = styled(TableHead, {
@@ -47,10 +47,21 @@ const StyledHeader = styled(TableHead, {
         margin-left: -${theme.spacing(5)};
         background: ${theme.palette.p3border.main};
     }
+
+    & th:first-of-type {
+        padding-left: ${theme.spacing(5)};
+    }
 `;
 
 const TableDataRow = styled(TableRow)`
     height: 50px;
+    cursor: pointer;
+
+    &:hover {
+        td {
+            background: ${theme.palette.p3border.main};
+        }
+    }
 
     & td {
         padding-left: 0;
@@ -62,17 +73,24 @@ const TableDataRow = styled(TableRow)`
         &:last-of-type {
             padding-right: 0
         };
+
+        &:first-of-type {
+            padding-left: ${theme.spacing(5)};
+        }
     }
 `;
 
 interface TableComponentProps<T> {
     table: Table<T>;
     stickyHeader?: boolean;
+    getRowLink?: (row: Row<T>) => string;
 }
 
 const TableComponent = <T,>(props: TableComponentProps<T>) => {
-    const { table, stickyHeader = true } = props;
+    const { table, stickyHeader = true, getRowLink } = props;
     const { getLeafHeaders } = table;
+
+    const navigate = useNavigate();
 
     return <TableScroller>
         <TableMui>
@@ -89,7 +107,7 @@ const TableComponent = <T,>(props: TableComponentProps<T>) => {
             </StyledHeader>
             <TableBody>
                 {table.getRowModel().rows.map(row => (
-                    <TableDataRow key={row.id}>
+                    <TableDataRow key={row.id} onClick={() => !!getRowLink && navigate(getRowLink(row))}>
                         {row.getVisibleCells().map(cell => (
                             <TableCell key={cell.id} style={(cell.column.columnDef.meta as any).columnStyles}>
                                 {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/sematic/ui/packages/common/src/component/TagsList.tsx
+++ b/sematic/ui/packages/common/src/component/TagsList.tsx
@@ -42,7 +42,6 @@ const StyledBox = styled(Box)`
 
 interface TagsListProps {
     tags: string[];
-    fold?: number;
     onClick?: (tag: string) => void;
 }
 

--- a/sematic/ui/packages/common/src/context/LayoutServiceContext.ts
+++ b/sematic/ui/packages/common/src/context/LayoutServiceContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+import noop from "lodash/noop";
+
+const LayoutServiceContext = createContext<{
+    setIsLoading: (isLoading: boolean) => void;
+}>({
+    setIsLoading: noop
+});
+
+export default LayoutServiceContext;
+  

--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -1,0 +1,121 @@
+import { Filter, RunListPayload } from "@sematic/common/src/ApiContracts";
+import { useHttpClient } from "@sematic/common/src/hooks/httpHooks";
+import { useMemo, useState, useCallback, useEffect, useRef } from "react";
+import useAsyncFn from "react-use/lib/useAsyncFn";
+import { Run } from "src/Models";
+
+export type QueryParams = {[key: string]: string};
+export const PAGE_SIZE = 25;
+
+const defaultQueryParams = {};
+export function useFetchRunsFn(runFilters: Filter | undefined = undefined,
+    otherQueryParams: QueryParams = defaultQueryParams) {
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    const queryParams = useMemo(() => {
+        let params = {...otherQueryParams};
+        if (!!runFilters) {
+            params.filters = JSON.stringify(runFilters)
+        }
+        return params;
+    }, [otherQueryParams, runFilters]);
+
+    const {fetch} = useHttpClient();
+
+    const [state, load] = useAsyncFn(async (overrideQueryParams: QueryParams = {}) => {
+        const finalQueryParams = {
+            ...queryParams,
+            ...overrideQueryParams
+        }
+        const qString = (new URLSearchParams(finalQueryParams)).toString();
+        const response = await fetch({
+            url: `/api/v1/runs?${qString}`
+        });
+        const payload: RunListPayload = await response.json();
+        setIsLoaded(true);
+        return payload;
+    }, [queryParams, fetch]);
+
+    const {loading: isLoading, error, value: runs} = state;
+
+    return {isLoaded, isLoading, error, runs: runs as RunListPayload, load};
+}
+
+export function useFetchRuns(runFilters: Filter | undefined = undefined,
+    otherQueryParams: {[key: string]: string} = defaultQueryParams) {
+    const {isLoaded, isLoading, error, runs, load} = useFetchRunsFn(runFilters, otherQueryParams);
+
+    const reloadRuns = useCallback(async () => {
+        const payload = await load();
+        return payload.content;
+    }, [load]);
+
+    useEffect(() => {
+        load();
+    }, [load])
+
+    return {isLoaded, isLoading, error, runs: runs?.content, reloadRuns};
+}
+
+export function useRunsPagination(runFilters: Filter | undefined = undefined,
+    otherQueryParams: {[key: string]: string} = defaultQueryParams) {
+    
+    const [page, setPage] = useState(0);
+
+    const [currentPageData, setCurrentPageData] = useState<Array<Run>>([]);
+
+    const pagesCache = useRef<Array<RunListPayload>>([]);
+
+    const queryParams = useMemo(() => {
+        return {
+            ...otherQueryParams,
+            limit: PAGE_SIZE.toString()
+        }
+    }, [otherQueryParams]);
+
+    const {isLoaded, isLoading, error, load} = useFetchRunsFn(runFilters, queryParams);
+
+    // Previous page should always be available in cache
+    const previousPage = useCallback(async () => {
+        const newPage = page - 1;
+        setCurrentPageData(pagesCache.current[newPage].content);
+        setPage(newPage);
+    }, [page]);
+
+    const nextPage = useCallback(async () => {
+        const newPage = page + 1;
+        const cacheSize = pagesCache.current.length;
+
+        if (newPage >= cacheSize) {
+            const cursor = pagesCache.current[cacheSize - 1].next_cursor!;
+            const payload = await load({cursor});
+            pagesCache.current.push(payload);
+        } 
+
+        setCurrentPageData(pagesCache.current[newPage].content);
+        setPage(newPage);
+    }, [page, load]);
+
+    const totalRuns = useMemo(() => {
+        if (isLoaded) {
+            return pagesCache.current[0].after_cursor_count;
+        }
+    }, [isLoaded]);
+
+    const totalPages = useMemo(() => Math.ceil((totalRuns || 0) / PAGE_SIZE), [totalRuns]);
+    
+    useEffect(() => {
+        (async () => {
+            const payload = await load();
+            pagesCache.current.push(payload);
+            setCurrentPageData(payload.content);
+        })();        
+    }, [load]);
+
+    return { previousPage, nextPage, page, totalPages, isLoaded, isLoading, error, 
+        runs: currentPageData, totalRuns };
+}
+
+export function getRunUrlPattern(runID: string) {
+    return `/runs/${runID}`;
+}

--- a/sematic/ui/packages/common/src/layout/Shell.tsx
+++ b/sematic/ui/packages/common/src/layout/Shell.tsx
@@ -1,18 +1,31 @@
-import theme from "src/theme/new/index";
-import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from '@mui/material/CssBaseline';
 import Grid from "@mui/material/Grid";
-import { Outlet } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import find from "lodash/find";
+import { useMemo } from "react";
+import { Outlet, useMatches } from "react-router-dom";
 import HeaderMenu from "src/component/menu";
 import SnackBarProvider from "src/context/SnackBarProvider";
+import theme from "src/theme/new/index";
+
+export const HeaderSelectionKey = 'activatedHeaderKey';
 
 const Shell = () => {
+  const matches = useMatches();
+
+  // see if the current route would want to activate a menu item.
+  const selectionKey = useMemo(() => {
+    const found = find(matches, (match) => 
+      !!match.handle && (match.handle as any)[HeaderSelectionKey] !== undefined);
+    return found ? (found.handle as any)[HeaderSelectionKey] : undefined;
+  }, [matches]);
+
   return <SnackBarProvider>
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Grid container spacing={0} direction={'column'} style={{ height: "100vh", width: "100%" }}>
         <Grid style={{ flexShrink: 0, flexGrow: 0 }}>
-          <HeaderMenu />
+          <HeaderMenu selectedKey={selectionKey} />
         </Grid>
         <Grid style={{ flexGrow: 1, height: 0 }}>
           <Outlet />

--- a/sematic/ui/packages/common/src/layout/Shell.tsx
+++ b/sematic/ui/packages/common/src/layout/Shell.tsx
@@ -7,6 +7,13 @@ import { Outlet, useMatches } from "react-router-dom";
 import HeaderMenu from "src/component/menu";
 import SnackBarProvider from "src/context/SnackBarProvider";
 import theme from "src/theme/new/index";
+import styled from "@emotion/styled";
+
+const StyledGrid = styled(Grid)`
+  height: 100vh;
+  width: 100%;
+  overflow: overlay;
+`;
 
 export const HeaderSelectionKey = 'activatedHeaderKey';
 
@@ -23,14 +30,14 @@ const Shell = () => {
   return <SnackBarProvider>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Grid container spacing={0} direction={'column'} style={{ height: "100vh", width: "100%" }}>
+      <StyledGrid container spacing={0} direction={'column'} >
         <Grid style={{ flexShrink: 0, flexGrow: 0 }}>
           <HeaderMenu selectedKey={selectionKey} />
         </Grid>
         <Grid style={{ flexGrow: 1, height: 0 }}>
           <Outlet />
         </Grid>
-      </Grid>
+      </StyledGrid>
     </ThemeProvider>
   </SnackBarProvider>;
 }

--- a/sematic/ui/packages/common/src/layout/TwoColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/TwoColumns.tsx
@@ -1,13 +1,30 @@
 import styled from "@emotion/styled";
-import { useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Container, Left, Right as RightBase } from "src/layout/ThreeColumns";
 import theme from "src/theme/new";
+import Box from "@mui/material/Box";
+import Loading from "src/component/Loading";
+import LayoutServiceContext from "src/context/LayoutServiceContext";
 
 const Right = styled(RightBase)`
     width: auto;
     flex-grow: 1;
     padding: 0 ${theme.spacing(5)};
+    position: relative;
 `
+
+const LoadingOverlay = styled(Box)`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  top: 0;
+  right: 0;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
 
 export interface TwoColumnsProps {
     onRenderLeft: () => React.ReactNode;
@@ -17,14 +34,27 @@ export interface TwoColumnsProps {
 const TwoColumns = (props: TwoColumnsProps) => {
     const { onRenderLeft, onRenderRight } = props;
 
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+
     const leftPane = useMemo(() => onRenderLeft(), [onRenderLeft]);
     const rightPane = useMemo(() => onRenderRight(), [onRenderRight]);
+
+    const layoutServiceValue = useMemo(() => ({
+        setIsLoading
+    }), [setIsLoading]);
 
     return (
         <Container>
             <Left>{leftPane}</Left>
-            <Right >{rightPane}</Right>
-        </Container>
+            <Right >
+                <LayoutServiceContext.Provider value={layoutServiceValue}>
+                    {isLoading && <LoadingOverlay>
+                        <Loading />
+                    </LoadingOverlay>}
+                    {rightPane}
+                </LayoutServiceContext.Provider>
+            </Right>
+        </Container >
     );
 };
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -7,7 +7,7 @@ import Headline from 'src/component/Headline';
 import ImportPath from 'src/component/ImportPath';
 import MoreVertButton from 'src/component/MoreVertButton';
 import PipelineTitle from 'src/component/PipelineTitle';
-import RunReferenceLink from "src/component/RunReferenceLink";
+import { RunReferenceLink } from "src/component/RunReference";
 import { SuccessStateChip } from 'src/component/RunStateChips';
 import Section from 'src/component/Section';
 import TagsList from 'src/component/TagsList';

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -1,16 +1,22 @@
 import styled from "@emotion/styled";
 import { ChevronLeft, ChevronRight } from "@mui/icons-material";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
-import { createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { createColumnHelper, getCoreRowModel, useReactTable, Row } from "@tanstack/react-table";
 import { parseJSON } from "date-fns";
+import { Run } from "src/Models";
 import { DateTimeLongConcise } from "src/component/DateTime";
 import ImportPath from "src/component/ImportPath";
+import NameTag from "src/component/NameTag";
 import PipelineTitle from "src/component/PipelineTitle";
 import RunReferenceLink from "src/component/RunReferenceLink";
 import TableComponent from "src/component/Table";
-import TagsList from "src/component/TagsList";
+import { getRunUrlPattern, useRunsPagination } from "src/hooks/runHooks";
 import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
+import TagsColumn from "src/pages/RunSearch/TagsColumn";
 import theme from "src/theme/new";
+import LayoutServiceContext from "src/context/LayoutServiceContext";
+import { useContext, useEffect, useCallback } from "react";
 
 const Container = styled.div`
     display: flex;
@@ -56,23 +62,10 @@ const StyledRunReferenceLink = styled(RunReferenceLink)`
     color: ${theme.palette.mediumGrey.main};
 `;
 
-const RunData = {
-    ID: '3es92wd',
-    created: '2021-10-01T12:00:00Z',
-    name: 'MNIST PyTorch Example',
-    importPath: 'examples.mnist.pipeline',
-    tags: ['example', 'pytorch', 'mnist', 'demo'],
-    owner: 'Demo User',
-    status: 'RUNNING',
-    failedAt: undefined as undefined | string,
-    resolvedAt: undefined as undefined | string,
-    canceledAt: undefined as undefined | string,
-}
-
-const columnHelper = createColumnHelper<typeof RunData>()
+const columnHelper = createColumnHelper<Run>()
 
 const columns = [
-    columnHelper.accessor('ID', {
+    columnHelper.accessor('id', {
         meta: {
             columnStyles: {
                 width: "5.923%",
@@ -81,7 +74,7 @@ const columns = [
         header: 'ID',
         cell: info => <StyledRunReferenceLink variant={'inherit'} runId={info.getValue()} />,
     }),
-    columnHelper.accessor('created', {
+    columnHelper.accessor('created_at', {
         meta: {
             columnStyles: {
                 width: "12.3396%",
@@ -91,11 +84,11 @@ const columns = [
         header: 'Submitted at',
         cell: info => DateTimeLongConcise(parseJSON(info.getValue())),
     }),
-    columnHelper.accessor(data => [data.name, data.importPath], {
+    columnHelper.accessor(data => [data.name, data.function_path], {
         meta: {
             columnStyles: {
                 width: "1px",
-                maxWidth: "calc(100vw - 1090px)"
+                maxWidth: "calc(100vw - 1050px)"
             }
         },
         header: 'Name',
@@ -115,9 +108,9 @@ const columns = [
             }
         },
         header: 'Tags',
-        cell: info => <TagsList tags={info.getValue()} fold={2} />,
+        cell: info => <TagsColumn tags={info.getValue()} />,
     }),
-    columnHelper.accessor('owner', {
+    columnHelper.accessor(data => `${data.user?.first_name} ${data.user?.last_name}`, {
         meta: {
             columnStyles: {
                 width: "8.39092%",
@@ -125,14 +118,13 @@ const columns = [
             }
         },
         header: 'Owner',
-        cell: info => info.getValue(),
+        cell: info => <NameTag>{info.getValue()}</NameTag>,
     }),
     columnHelper.accessor(data => ({
-        futureState: data.status,
-        createdAt: data.created,
-        failedAt: data.failedAt,
-        canceledAt: data.canceledAt,
-        resolvedAt: data.resolvedAt
+        futureState: data.future_state,
+        createdAt: data.created_at,
+        failedAt: data.failed_at,
+        resolvedAt: data.resolved_at
     }), {
         meta: {
             columnStyles: {
@@ -141,55 +133,45 @@ const columns = [
             }
         },
         header: 'Status',
-        cell: info => <RunStatusColumn {...info.getValue()} />,
-    }),
-    columnHelper.display({
-        meta: {
-            columnStyles: {
-                width: "2.46792%",
-                minWidth: "40px"
-            }
-        },
-        header: '',
-        id: 'goto',
-        cell: _ => <ChevronRight style={{cursor: 'pointer'}}/>,
-    }),
+        cell: info => <RunStatusColumn {...info.getValue() as any} />,
+    })
 ]
 
-const data: Array<typeof RunData> = [
-    RunData,
-    RunData,
-    { ...RunData, resolvedAt: '2021-10-01T12:10:00Z', status: 'SUCCESS' },
-    { ...RunData, failedAt: '2021-10-01T12:10:00Z', status: 'FAILED' },
-    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
-    { ...RunData, status: 'SCHEDULED' },
-    RunData,
-    RunData,
-    RunData,
-    RunData,
-    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
-    { ...RunData, status: 'SCHEDULED' },
-    RunData,
-    RunData,
-    { ...RunData, canceledAt: '2021-10-01T12:10:00Z', status: 'CANCELLED' },
-]
+interface RunListProps {
+}
 
-const RunList = () => {
+const RunList = (props: RunListProps) => {
+    const { runs, page, isLoading, totalPages, totalRuns, nextPage, previousPage } = useRunsPagination();
+
+    const { setIsLoading } = useContext(LayoutServiceContext);
+
     const tableInstance = useReactTable({
-        data,
+        data: runs,
         columns,
         getCoreRowModel: getCoreRowModel()
     });
 
+    const getRowLink = useCallback((row: Row<Run>): string => {
+        return getRunUrlPattern(row.original.id);
+    }, [])
+
+    useEffect(() => {
+        setIsLoading(isLoading)
+    }, [setIsLoading, isLoading]);
+
     return <Container>
         <Stats>
-            <Typography variant={'bold'}>142 Runs</Typography>
+            <Typography variant={'bold'}>{`${totalRuns || '?'} ${totalRuns === 1 ? 'Run' : 'Runs'}`}</Typography>
         </Stats>
-        <TableComponent table={tableInstance} />
+        <TableComponent table={tableInstance} getRowLink={getRowLink} />
         <Pagination>
-            <ChevronLeft /> 
-                {'1 / 4'} 
-            <ChevronRight />
+            <IconButton aria-label="previous" disabled={page === 0} onClick={previousPage}>
+                <ChevronLeft />
+            </IconButton>
+            {`${page + 1} / ${totalPages}`}
+            <IconButton aria-label="next" disabled={page + 1 === totalPages} onClick={nextPage}>
+                <ChevronRight />
+            </IconButton>
         </Pagination>
     </Container>
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -9,8 +9,8 @@ import { DateTimeLongConcise } from "src/component/DateTime";
 import ImportPath from "src/component/ImportPath";
 import NameTag from "src/component/NameTag";
 import PipelineTitle from "src/component/PipelineTitle";
-import RunReferenceLink from "src/component/RunReferenceLink";
-import TableComponent from "src/component/Table";
+import { RunReference } from "src/component/RunReference";
+import TableComponent, { TableComponentProps } from "src/component/Table";
 import { getRunUrlPattern, useRunsPagination } from "src/hooks/runHooks";
 import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
 import TagsColumn from "src/pages/RunSearch/TagsColumn";
@@ -58,9 +58,13 @@ const NameSection = styled.div`
     position: relative;
 `;
 
-const StyledRunReferenceLink = styled(RunReferenceLink)`
+const StyledRunReferenceLink = styled(RunReference)`
     color: ${theme.palette.mediumGrey.main};
 `;
+
+const StyledTableComponent = styled(TableComponent)<TableComponentProps<Run>>`
+    min-width: 850px;
+` as typeof TableComponent;
 
 const columnHelper = createColumnHelper<Run>()
 
@@ -72,23 +76,23 @@ const columns = [
             }
         },
         header: 'ID',
-        cell: info => <StyledRunReferenceLink variant={'inherit'} runId={info.getValue()} />,
+        cell: info => <StyledRunReferenceLink runId={info.getValue()} />,
     }),
     columnHelper.accessor('created_at', {
         meta: {
             columnStyles: {
                 width: "12.3396%",
-                minWidth: "140px"
+                minWidth: "150px"
             }
         },
         header: 'Submitted at',
         cell: info => DateTimeLongConcise(parseJSON(info.getValue())),
     }),
-    columnHelper.accessor(data => [data.name, data.function_path], {
+    columnHelper.accessor(run => [run.name, run.function_path], {
         meta: {
             columnStyles: {
                 width: "1px",
-                maxWidth: "calc(100vw - 1050px)"
+                maxWidth: "calc(100vw - 1060px)"
             }
         },
         header: 'Name',
@@ -163,7 +167,7 @@ const RunList = (props: RunListProps) => {
         <Stats>
             <Typography variant={'bold'}>{`${totalRuns || '?'} ${totalRuns === 1 ? 'Run' : 'Runs'}`}</Typography>
         </Stats>
-        <TableComponent table={tableInstance} getRowLink={getRowLink} />
+        <StyledTableComponent table={tableInstance} getRowLink={getRowLink} />
         <Pagination>
             <IconButton aria-label="previous" disabled={page === 0} onClick={previousPage}>
                 <ChevronLeft />

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
@@ -19,18 +19,18 @@ interface RunStatusColumnProps {
     createdAt: string;
     failedAt?: string;
     resolvedAt?: string;
-    canceledAt?: string;
+    endedAt?: string;
 }
 
 const RunStatusColumn = (props: RunStatusColumnProps) => {
-    const { futureState, createdAt, failedAt, resolvedAt, canceledAt } = props;
+    const { futureState, createdAt, failedAt, resolvedAt, endedAt } = props;
 
     const runStateChip = useMemo(() => getRunStateChipByState(futureState), [futureState]);
 
     const runStateText = useMemo(() => getRunStateText(
         futureState,
-        {createdAt, failedAt, resolvedAt, canceledAt}
-    ), [futureState, createdAt, failedAt, resolvedAt, canceledAt]);
+        {createdAt, failedAt, resolvedAt, endedAt}
+    ), [futureState, createdAt, failedAt, resolvedAt, endedAt]);
 
     return <StyledContainer>{runStateChip} {runStateText}</StyledContainer>;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/TagsColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/TagsColumn.tsx
@@ -1,0 +1,17 @@
+import TagsList from "src/component/TagsList";
+
+interface TagsColumnProps {
+    tags: string[];
+}
+
+export const TagsColumn = (props: TagsColumnProps) => {
+    const { tags } = props;
+
+    if (tags.length === 0) {
+        return null;
+    }
+
+    return <TagsList tags={tags} />
+}
+
+export default TagsColumn;

--- a/sematic/ui/packages/common/src/reactHooks.ts
+++ b/sematic/ui/packages/common/src/reactHooks.ts
@@ -1,3 +1,3 @@
 // These exports are meant to be used by the `storybook` packages, so that they
 // can use the same version of React as this package.
-export { useState, useCallback, useEffect, useRef } from "react";
+export { useState, useCallback, useEffect, useRef, useMemo } from "react";

--- a/sematic/ui/packages/main/src/Home.tsx
+++ b/sematic/ui/packages/main/src/Home.tsx
@@ -9,13 +9,13 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { useCallback, useContext, useMemo, useState } from "react";
-import { SiDiscord, SiReadthedocs, SiGithub } from "react-icons/si";
 import UserContext from "@sematic/common/src/context/UserContext";
+import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
+import { useCallback, useContext, useMemo, useState } from "react";
+import { SiDiscord, SiGithub, SiReadthedocs } from "react-icons/si";
 import MuiRouterLink from "./components/MuiRouterLink";
 import RunStateChip from "./components/RunStateChip";
 import TrackingNotice from "./components/TrackingNotice";
-import { useFetchRuns } from "./hooks/pipelineHooks";
 
 function ShellCommand(props: { command: string }) {
   const { command } = props;

--- a/sematic/ui/packages/main/src/Payloads.tsx
+++ b/sematic/ui/packages/main/src/Payloads.tsx
@@ -1,14 +1,5 @@
 import { Artifact, Edge, Job, Note, Resolution, Run, User } from "@sematic/common/src/Models";
 
-export type RunListPayload = {
-  current_page_url: string;
-  next_page_url?: string;
-  limit: number;
-  next_cursor?: string;
-  after_cursor_count: number;
-  content: Run[];
-};
-
 export type RunViewPayload = {
   content: Run;
 };
@@ -84,18 +75,6 @@ export interface VersionPayload {
   min_client_supported: SemanticVersion;
   server: SemanticVersion;
 } 
-
-type Operator = "eq";
-
-type FilterCondition = {
-    [key: string]: {[eq in Operator]? : string | null} | undefined
-}
-
-export type Filter = FilterCondition | {
-    AND : Array<FilterCondition>
-} | {
-  OR : Array<FilterCondition>
-}
 
 export type BasicMetricsPayload = {
   content: {

--- a/sematic/ui/packages/main/src/components/BidirectionalLogView.tsx
+++ b/sematic/ui/packages/main/src/components/BidirectionalLogView.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@mui/material/styles";
 import Alert from "@mui/material/Alert";
 import { useRunPanelContext, useRunPanelLoadingIndicator } from "src/hooks/runDetailsHooks";
 import { Button } from "@mui/material";
-import { theme } from "@sematic/common/lib/src/theme/mira";
+import { theme } from "@sematic/common/src/theme/mira";
 import { useScrollTracker } from "src/hooks/scrollingHooks";
 
 const Container = styled(Box)`

--- a/sematic/ui/packages/main/src/components/RunId.tsx
+++ b/sematic/ui/packages/main/src/components/RunId.tsx
@@ -1,4 +1,4 @@
-import { getRunUrlPattern } from "../hooks/pipelineHooks";
+import { getRunUrlPattern } from "@sematic/common/src/hooks/runHooks";
 import CopyButton from "@sematic/common/src/component/CopyButton";
 import MuiRouterLink from "./MuiRouterLink";
 

--- a/sematic/ui/packages/main/src/components/RunList.tsx
+++ b/sematic/ui/packages/main/src/components/RunList.tsx
@@ -8,13 +8,13 @@ import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import { styled } from "@mui/system";
+import { Filter, RunListPayload } from "@sematic/common/src/ApiContract";
 import { Run } from "@sematic/common/src/Models";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import useLatest from "react-use/lib/useLatest";
 import usePreviousDistinct from "react-use/lib/usePreviousDistinct";
 import Loading from "src/components/Loading";
-import { useFetchRunsFn } from "src/hooks/pipelineHooks";
-import { Filter, RunListPayload } from "src/Payloads";
+import { useFetchRunsFn } from "@sematic/common/src/hooks/runHooks";
 
 const defaultPageSize = 10;
 

--- a/sematic/ui/packages/main/src/components/RunList.tsx
+++ b/sematic/ui/packages/main/src/components/RunList.tsx
@@ -8,7 +8,7 @@ import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import { styled } from "@mui/system";
-import { Filter, RunListPayload } from "@sematic/common/src/ApiContract";
+import { Filter, RunListPayload } from "@sematic/common/src/ApiContracts";
 import { Run } from "@sematic/common/src/Models";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import useLatest from "react-use/lib/useLatest";

--- a/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
+++ b/sematic/ui/packages/main/src/hooks/podHistoryHooks.ts
@@ -1,4 +1,4 @@
-import { useRefFn } from "@sematic/common/lib/src/utils/hooks";
+import { useRefFn } from "@sematic/common/src/utils/hooks";
 import { Job } from "@sematic/common/src/Models";
 import { useHttpClient } from "@sematic/common/src/hooks/httpHooks";
 import { useCallback, useEffect } from "react";

--- a/sematic/ui/packages/main/src/index.tsx
+++ b/sematic/ui/packages/main/src/index.tsx
@@ -3,7 +3,7 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import UserContext from "@sematic/common/src/context/UserContext";
-import NewShell from '@sematic/common/src/layout/Shell';
+import NewShell, { HeaderSelectionKey } from '@sematic/common/src/layout/Shell';
 import { useAtom } from "jotai";
 import { RESET } from "jotai/utils";
 import posthog, { Properties } from 'posthog-js';
@@ -31,6 +31,7 @@ import { setupPostHogOptout } from "./postHogManager";
 import { RunIndex } from "./runs/RunIndex";
 import { sha1 } from "./utils";
 import NewRunDetails from "@sematic/common/src/pages/RunDetails";
+import NewRunSearch from "@sematic/common/src/pages/RunSearch";
 import { getFeatureFlagValue } from "@sematic/common/src/utils/FeatureFlagManager";
 import Helper from "src/components/tests/tеst_normal";
 
@@ -81,6 +82,9 @@ function App() {
 const isNewUIEnabled = getFeatureFlagValue('newui');
 
 const NewRoutesOverrides = isNewUIEnabled ? (<>
+  <Route path="runs" element={<NewShell />} >
+    <Route index element={<NewRunSearch />} handle={{[HeaderSelectionKey]: 'runs'}} />
+  </Route>
   <Route path="runs/:rootId" element={<NewShell />} >
     <Route index element={<NewRunDetails />} />
   </Route>

--- a/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
@@ -12,6 +12,7 @@ import {
 import { Resolution, Run } from "@sematic/common/src/Models";
 import SnackBarContext from "@sematic/common/src/context/SnackBarContext";
 import UserContext from "@sematic/common/src/context/UserContext";
+import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
 import { useCallback, useContext, useEffect, useMemo } from "react";
 import { ActionMenu, ActionMenuItem } from "src/components/ActionMenu";
 import CalculatorPath from "src/components/CalculatorPath";
@@ -22,7 +23,6 @@ import RunStateChip from "src/components/RunStateChip";
 import TimeAgo from "src/components/TimeAgo";
 import { ExtractContextType } from "src/components/utils/typings";
 import {
-  useFetchRuns,
   usePipelineRunContext,
   useRunNavigation,
 } from "src/hooks/pipelineHooks";

--- a/sematic/ui/packages/main/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineIndex.tsx
@@ -9,6 +9,7 @@ import {
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { styled } from "@mui/system";
+import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
 import { Run } from "@sematic/common/src/Models";
 import { useCallback, useMemo } from "react";
 import CalculatorPath from "src/components/CalculatorPath";
@@ -21,9 +22,8 @@ import { RunTime } from "src/components/RunTime";
 import Tags from "src/components/Tags";
 import TimeAgo from "src/components/TimeAgo";
 import useBasicMetrics from "src/hooks/metricsHooks";
-import { useFetchRuns } from "src/hooks/pipelineHooks";
-import { pipelineSocket } from "src/sockets";
 import { runAvgRunTime, runSuccessRate } from "src/pipelines/BasicMetricsPanel";
+import { pipelineSocket } from "src/sockets";
 
 const RecentStatusesWithStyles = styled("span")`
   flex-direction: row;

--- a/sematic/ui/packages/main/src/pipelines/PipelineView.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import Loading from "../components/Loading";
-import { useFetchRuns, useRunNavigation } from "../hooks/pipelineHooks";
+import { useRunNavigation } from "../hooks/pipelineHooks";
+import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
 import { Alert } from "@mui/material";
 
 /**

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodEventHistory.tsx
@@ -2,7 +2,7 @@ import Timeline from '@mui/lab/Timeline';
 import timelineItemClasses from '@mui/lab/TimelineItem/timelineItemClasses';
 import { styled } from '@mui/system';
 import PodLifecycleEvent from 'src/pipelines/pod_lifecycle/PodLifecycleEvent';
-import { Job } from '@sematic/common/lib/src/Models';
+import { Job } from '@sematic/common/src/Models';
 import { useMemo } from 'react';
 
 const ThinTimeline = styled(Timeline)`

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycle.tsx
@@ -5,7 +5,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import CopyButton from '@sematic/common/lib/src/component/CopyButton';
+import CopyButton from '@sematic/common/src/component/CopyButton';
 import { usePipelinePanelsContext } from "src/hooks/pipelineHooks";
 import { useRunJobHistory } from 'src/hooks/podHistoryHooks';
 import { useRunPanelLoadingIndicator } from 'src/hooks/runDetailsHooks';

--- a/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
+++ b/sematic/ui/packages/main/src/pipelines/pod_lifecycle/PodLifecycleEvent.tsx
@@ -6,7 +6,7 @@ import TimelineSeparator from "@mui/lab/TimelineSeparator/TimelineSeparator";
 import Chip from "@mui/material/Chip/Chip";
 import Typography from "@mui/material/Typography/Typography";
 import styled from "@emotion/styled";
-import { Job } from "@sematic/common/lib/src/Models";
+import { Job } from "@sematic/common/src/Models";
 import { format } from 'date-fns';
 import { useMemo } from "react";
 

--- a/sematic/ui/packages/main/src/runs/RunIndex.tsx
+++ b/sematic/ui/packages/main/src/runs/RunIndex.tsx
@@ -20,7 +20,7 @@ import { RunTime } from "src/components/RunTime";
 import Tags from "src/components/Tags";
 import TimeAgo from "src/components/TimeAgo";
 import UserAvatar from "src/components/UserAvatar";
-import { getRunUrlPattern } from "src/hooks/pipelineHooks";
+import { getRunUrlPattern } from "@sematic/common/src/hooks/runHooks";
 import { spacing } from "src/utils";
 
 const StyledScroller = styled(Container)`

--- a/sematic/ui/packages/storybook/src/stories/Notes.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Notes.stories.tsx
@@ -1,9 +1,12 @@
+import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from "@mui/material/styles";
 import NoteComponent from '@sematic/common/src/component/Note';
+import SubmitNoteSection from '@sematic/common/src/pages/RunDetails/SubmitNoteSection';
 import theme from '@sematic/common/src/theme/new';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import CssBaseline from '@mui/material/CssBaseline';
-import SubmitNoteSection from '@sematic/common/src/pages/RunDetails/SubmitNoteSection';
+import { ReactElement } from 'react';
+import { Route, createBrowserRouter, createRoutesFromElements, RouterProvider } from "react-router-dom";
+import { useMemo } from '@sematic/common/src/reactHooks';
 
 export default {
   title: 'Sematic/Notes',
@@ -23,6 +26,11 @@ interface StoryProps extends React.ComponentProps<typeof NoteComponent> {
   width?: keyof (typeof sizeOptions);
   onSubmit?: (content: string) => void;
 }
+
+const dummyRouter = (node: ReactElement) => createBrowserRouter(
+  createRoutesFromElements(
+    <Route path="*" index element={node} />
+  ));
 
 const Examples: Record<string, React.ComponentProps<typeof NoteComponent>> = {
   "Clean": {
@@ -54,7 +62,14 @@ const Examples: Record<string, React.ComponentProps<typeof NoteComponent>> = {
 const Template: StoryFn<StoryProps> = (props: StoryProps) => {
   const { example = "Clean" } = props;
   const mockData = Examples[example] || Examples["clean"];
-  return <div style={{ width: '300px' }}><NoteComponent {...mockData} /></div>;
+
+  const router = useMemo(() => {
+    return dummyRouter(
+      <div style={{ width: '300px' }}><NoteComponent {...mockData} /></div>
+    );
+  }, [mockData]);
+
+  return <RouterProvider router={router} />;
 };
 
 const commonArgTypes = {
@@ -81,19 +96,19 @@ const sizeOptions = {
 
 export const NoteSubmission: StoryObj<StoryProps> = {
   render: (props) => {
-    const { width, onSubmit} = props;
+    const { width, onSubmit } = props;
 
     const keys = Object.keys(sizeOptions) as (keyof typeof sizeOptions)[];
 
     const widthValue = sizeOptions[width || keys[1]];
 
-    return <div style={{width: widthValue}}>
+    return <div style={{ width: widthValue }}>
       <SubmitNoteSection onSubmit={onSubmit!} />
     </div>
   },
   argTypes: {
     width: {
-      control: 'select', options: Object.keys(sizeOptions)      
+      control: 'select', options: Object.keys(sizeOptions)
     },
     onSubmit: { action: 'value changed' }
   }

--- a/sematic/ui/packages/storybook/src/stories/Page.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Page.stories.tsx
@@ -1,8 +1,7 @@
 import Shell from "@sematic/common/src/layout/Shell";
 import RunDetailsComponent from "@sematic/common/src/pages/RunDetails";
-import RunSearchComponent from "@sematic/common/src/pages/RunSearch";
 import { Meta, StoryObj } from '@storybook/react';
-import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from "react-router-dom";
+import { Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from "react-router-dom";
 
 const runDetailsRouter = createBrowserRouter(
   createRoutesFromElements(
@@ -25,26 +24,6 @@ export default {
 
 export const RunDetails: StoryObj<typeof RunDetailsRouter> = {
   render: () => <RunDetailsRouter />,
-
-  parameters : {
-    layout: 'fullscreen' 
-  }
-};
-
-const runSearchRouter = createBrowserRouter(
-  createRoutesFromElements(
-    <Route path="/" element={<Shell />}>
-      <Route path="*" element={<RunSearchComponent />} />
-    </Route>
-  ));
-
-function RunSearchRouter() {
-  return <RouterProvider router={runSearchRouter} />;
-}
-
-
-export const RunSearch: StoryObj<typeof RunSearchRouter> = {
-  render: () => <RunSearchRouter />,
 
   parameters : {
     layout: 'fullscreen' 


### PR DESCRIPTION
1. Use real data in the run search table
2. Any functionalities related to filtering have not yet been implemented at all. (The PR is already large). Will complete in future PRs. 
3. Pagination is implemented in this PR.
4. Header menus will have `Runs` activated for this page.
5. Unfortunately, the storybook page for run search is removed. (It is difficult to have it link to real data). From this point on, viewing the page from a real dashboard app is advised.

Preview:

![capture1](https://github.com/sematic-ai/sematic/assets/1046489/14709c82-b557-4883-8ce6-dbe617059df5)


The change can also be previewed in *my* namespace.