### PR TITLE
[6/N] Extract and reuse utility functions in DockerBuiler

### DIFF
--- a/sematic/api/endpoints/tests/BUILD
+++ b/sematic/api/endpoints/tests/BUILD
@@ -30,7 +30,7 @@ pytest_test(
         "//sematic/db/tests:fixtures",
         "//sematic/plugins:abstract_publisher",
         "//sematic/scheduling:kubernetes",
-        "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )
 
@@ -94,6 +94,7 @@ pytest_test(
         "//sematic/db:queries",
         "//sematic/db/models:user",
         "//sematic/db/models/mixins:json_encodable_mixin",
+        "//sematic/utils:types",
     ],
 )
 

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -19,10 +19,10 @@ from sematic.api.tests.fixtures import (  # noqa: F401
     test_client,
 )
 from sematic.config.server_settings import ServerSettingsVar
-from sematic.config.settings import as_bool
 from sematic.db.models.user import User
 from sematic.db.queries import get_user
 from sematic.db.tests.fixtures import persisted_user, test_db  # noqa: F401
+from sematic.utils.types import as_bool
 
 
 @pytest.mark.parametrize(

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -60,7 +60,7 @@ from sematic.db.tests.fixtures import (  # noqa: F401
 )
 from sematic.plugins.abstract_publisher import AbstractPublisher
 from sematic.scheduling.job_details import JobKind
-from sematic.tests.fixtures import environment_variables
+from sematic.utils.env import environment_variables
 
 test_get_resolution_auth = make_auth_test("/api/v1/resolutions/123")
 test_put_resolution_auth = make_auth_test("/api/v1/resolutions/123", method="PUT")

--- a/sematic/config/BUILD
+++ b/sematic/config/BUILD
@@ -31,6 +31,7 @@ sematic_py_lib(
     deps = [
         ":settings",
         "//sematic:abstract_plugin",
+        "//sematic/utils:types",
     ],
 )
 
@@ -39,6 +40,7 @@ sematic_py_lib(
     srcs = ["user_settings.py"],
     deps = [
         ":settings",
+        "//sematic/utils:types",
     ],
 )
 

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -10,12 +10,12 @@ from sematic.abstract_plugin import (
 )
 from sematic.config.settings import (
     MissingSettingsError,
-    as_bool,
     delete_plugin_setting,
     get_plugin_setting,
     get_plugin_settings,
     set_plugin_setting,
 )
+from sematic.utils.types import as_bool
 
 
 class ServerSettingsVar(AbstractPluginSettingsVar):

--- a/sematic/config/settings.py
+++ b/sematic/config/settings.py
@@ -1,5 +1,4 @@
 # Standard Library
-import distutils.util
 import enum
 import logging
 import os
@@ -306,23 +305,6 @@ class EnumDumper(yaml.Dumper):
 
     def ignore_aliases(self, data: Any) -> bool:
         return True
-
-
-def as_bool(value: Optional[Any]) -> bool:
-    """
-    Returns a boolean interpretation of the contents of the specified value.
-    """
-    if isinstance(value, bool):
-        return value
-
-    if value is None:
-        return False
-
-    str_value = str(value)
-    if len(str_value) == 0:
-        return False
-
-    return bool(distutils.util.strtobool(str_value))
 
 
 def _load_settings(file_path: str) -> Settings:

--- a/sematic/config/tests/BUILD
+++ b/sematic/config/tests/BUILD
@@ -3,7 +3,7 @@ pytest_test(
     srcs = ["test_config_dir.py"],
     deps = [
         "//sematic/config:config_dir",
-        "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )
 
@@ -34,7 +34,7 @@ pytest_test(
         "//sematic:abstract_plugin",
         "//sematic/config:settings",
         "//sematic/plugins/storage:local_storage",
-        "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )
 

--- a/sematic/config/tests/test_config_dir.py
+++ b/sematic/config/tests/test_config_dir.py
@@ -6,7 +6,7 @@ import pytest
 
 # Sematic
 from sematic.config.config_dir import _CONFIG_DIR_OVERRIDE_ENV_VAR, get_config_dir
-from sematic.tests.fixtures import environment_variables
+from sematic.utils.env import environment_variables
 
 
 def test_get_config_dir_default():

--- a/sematic/config/tests/test_settings.py
+++ b/sematic/config/tests/test_settings.py
@@ -25,7 +25,7 @@ from sematic.config.tests.fixtures import (  # noqa: F401
     no_settings_file,
 )
 from sematic.config.user_settings import UserSettings, UserSettingsVar
-from sematic.tests.fixtures import environment_variables
+from sematic.utils.env import environment_variables
 
 
 class SettingsVar(AbstractPluginSettingsVar):

--- a/sematic/config/user_settings.py
+++ b/sematic/config/user_settings.py
@@ -10,12 +10,12 @@ from sematic.abstract_plugin import (
 )
 from sematic.config.settings import (
     MissingSettingsError,
-    as_bool,
     delete_plugin_setting,
     get_plugin_setting,
     get_plugin_settings,
     set_plugin_setting,
 )
+from sematic.utils.types import as_bool
 
 
 class UserSettingsVar(AbstractPluginSettingsVar):

--- a/sematic/ee/plugins/external_resource/ray/tests/BUILD
+++ b/sematic/ee/plugins/external_resource/ray/tests/BUILD
@@ -20,6 +20,6 @@ pytest_test(
         "//sematic:function",
         "//sematic/ee/plugins/external_resource/ray:cluster",
         "//sematic/plugins:abstract_external_resource",
-        "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )

--- a/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
+++ b/sematic/ee/plugins/external_resource/ray/tests/test_cluster.py
@@ -14,7 +14,7 @@ from sematic.plugins.abstract_external_resource import (
     ResourceStatus,
 )
 from sematic.plugins.abstract_kuberay_wrapper import RayNodeConfig, SimpleRayCluster
-from sematic.tests.fixtures import environment_variables
+from sematic.utils.env import environment_variables
 
 
 class RayClusterClientsMocked(RayCluster):

--- a/sematic/plugins/building/BUILD
+++ b/sematic/plugins/building/BUILD
@@ -9,5 +9,7 @@ sematic_py_lib(
         "//sematic:abstract_plugin",
         "//sematic:container_images",
         "//sematic/plugins:abstract_builder",
+        "//sematic/utils:env",
+        "//sematic/utils:types",
     ],
 )

--- a/sematic/plugins/kuberay_wrapper/tests/BUILD
+++ b/sematic/plugins/kuberay_wrapper/tests/BUILD
@@ -4,7 +4,7 @@ pytest_test(
     deps = [
         "//sematic/plugins:abstract_kuberay_wrapper",
         "//sematic/plugins/kuberay_wrapper:standard",
+        "//sematic/utils:env",
         "//sematic/utils:exceptions",
-        "//sematic/tests:fixtures",
     ],
 )

--- a/sematic/plugins/kuberay_wrapper/tests/test_standard.py
+++ b/sematic/plugins/kuberay_wrapper/tests/test_standard.py
@@ -16,7 +16,7 @@ from sematic.plugins.kuberay_wrapper.standard import (
     StandardKuberaySettingsVar,
     StandardKuberayWrapper,
 )
-from sematic.tests.fixtures import environment_variables
+from sematic.utils.env import environment_variables
 from sematic.utils.exceptions import UnsupportedUsageError, UnsupportedVersionError
 
 _TEST_IMAGE_URI = "test_image_uri"

--- a/sematic/plugins/publishing/tests/BUILD
+++ b/sematic/plugins/publishing/tests/BUILD
@@ -9,7 +9,7 @@ pytest_test(
         "//sematic/db/models:run",
         "//sematic/db/tests:fixtures",
         "//sematic/plugins/publishing:slack",
-        "//sematic/tests:fixtures",
         "//sematic/tests:utils",
+        "//sematic/utils:env",
     ],
 )

--- a/sematic/plugins/publishing/tests/test_slack.py
+++ b/sematic/plugins/publishing/tests/test_slack.py
@@ -20,8 +20,8 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     test_db,
 )
 from sematic.plugins.publishing.slack import SlackPublisher, SlackPublisherSettingsVar
-from sematic.tests.fixtures import environment_variables
 from sematic.tests.utils import assert_logs_captured
+from sematic.utils.env import environment_variables
 
 _TEST_ENV_VARS = {
     ServerSettingsVar.SEMATIC_DASHBOARD_URL.value: "https://my.sematic",

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -76,6 +76,7 @@ pytest_test(
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:resource_requirements",
         "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )
 
@@ -98,6 +99,7 @@ pytest_test(
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:worker",
         "//sematic/tests:fixtures",
+        "//sematic/utils:env",
         "//sematic/utils:stdout",
     ],
 )

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -28,10 +28,8 @@ from sematic.db.tests.fixtures import (  # noqa: F401
 )
 from sematic.function import func
 from sematic.resolvers.cloud_resolver import CloudResolver
-from sematic.tests.fixtures import (  # noqa: F401
-    environment_variables,
-    valid_client_version,
-)
+from sematic.tests.fixtures import valid_client_version  # noqa: F401
+from sematic.utils.env import environment_variables
 
 
 @func(base_image_tag="cuda", standalone=True)

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -35,11 +35,8 @@ from sematic.function import func
 from sematic.future_context import PrivateContext, SematicContext
 from sematic.resolvers.cloud_resolver import CloudResolver
 from sematic.resolvers.worker import _emulate_interpreter, main, wrap_main_with_logging
-from sematic.tests.fixtures import (  # noqa: F401
-    environment_variables,
-    test_storage,
-    valid_client_version,
-)
+from sematic.tests.fixtures import test_storage, valid_client_version  # noqa: F401
+from sematic.utils.env import environment_variables
 from sematic.utils.stdout import redirect_to_file
 
 

--- a/sematic/scheduling/tests/BUILD
+++ b/sematic/scheduling/tests/BUILD
@@ -26,6 +26,6 @@ pytest_test(
         "//sematic/db/tests:fixtures",
         "//sematic/resolvers:resource_requirements",
         "//sematic/scheduling:kubernetes",
-        "//sematic/tests:fixtures",
+        "//sematic/utils:env",
     ],
 )

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -31,7 +31,7 @@ from sematic.scheduling.kubernetes import (
     refresh_job,
     schedule_run_job,
 )
-from sematic.tests.fixtures import environment_variables  # noqa: F401
+from sematic.utils.env import environment_variables  # noqa: F401
 
 
 @mock.patch("sematic.scheduling.kubernetes.load_kube_config")

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -1,7 +1,5 @@
 # Standard Library
-import contextlib
 import enum
-import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -10,7 +8,6 @@ import pytest
 
 # Sematic
 import sematic.api_client as api_client
-import sematic.config.settings as sematic_settings
 from sematic.abstract_future import FutureState
 from sematic.plugins.storage.memory_storage import MemoryStorage
 
@@ -40,38 +37,6 @@ def allow_any_run_state_transition():
         yield
     finally:
         FutureState.is_allowed_transition = original
-
-
-@contextlib.contextmanager
-def environment_variables(to_set: Dict[str, Optional[str]]):
-    """Context manager to configure the os environ for tests.
-
-    Parameters
-    ----------
-    to_set:
-        A dict from env var name to env var value. If the env var value
-        is None, that will be treated as indicating that the env var should
-        be unset within the managed context.
-    """
-    backup_of_changed_keys = {k: os.environ.get(k, None) for k in to_set.keys()}
-
-    def update_environ_with(env_dict):
-        # in case the specified variables are settings overrides, we need to
-        # force reloading of global settings in order to apply the overrides
-        sematic_settings._ACTIVE_SETTINGS = None
-
-        for key, value in env_dict.items():
-            if value is None:
-                if key in os.environ:
-                    del os.environ[key]
-            else:
-                os.environ[key] = value
-
-    update_environ_with(to_set)
-    try:
-        yield
-    finally:
-        update_environ_with(backup_of_changed_keys)
 
 
 class MyEnum(enum.Enum):

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -5,6 +5,21 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "db",
+    srcs = ["db.py"],
+    pip_deps = [
+        "sqlalchemy",
+    ],
+    deps = [],
+)
+
+sematic_py_lib(
+    name = "env",
+    srcs = ["env.py"],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "exceptions",
     srcs = ["exceptions.py"],
     deps = [
@@ -70,10 +85,7 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
-    name = "db",
-    srcs = ["db.py"],
-    pip_deps = [
-        "sqlalchemy",
-    ],
+    name = "types",
+    srcs = ["types.py"],
     deps = [],
 )

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -16,7 +16,9 @@ sematic_py_lib(
 sematic_py_lib(
     name = "env",
     srcs = ["env.py"],
-    deps = [],
+    deps = [
+        "//sematic/config:settings",
+    ],
 )
 
 sematic_py_lib(

--- a/sematic/utils/env.py
+++ b/sematic/utils/env.py
@@ -36,6 +36,7 @@ def environment_variables(to_set: Dict[str, Optional[str]]):
                 os.environ[key] = value
 
     update_environ_with(to_set)
+
     try:
         yield
     finally:

--- a/sematic/utils/env.py
+++ b/sematic/utils/env.py
@@ -1,0 +1,42 @@
+# Standard Library
+import contextlib
+import os
+from typing import Dict, Optional
+
+# Sematic
+import sematic.config.settings as sematic_settings
+
+
+@contextlib.contextmanager
+def environment_variables(to_set: Dict[str, Optional[str]]):
+    """
+    Context manager to configure the os environ.
+
+    After exiting the context, the original env vars will be back in place.
+
+    Parameters
+    ----------
+    to_set:
+        A dict from env var name to env var value. If the env var value is None, that will
+        be treated as indicating that the env var should be unset within the managed
+        context.
+    """
+    backup_of_changed_keys = {k: os.environ.get(k, None) for k in to_set.keys()}
+
+    def update_environ_with(env_dict):
+        # in case the specified variables are settings overrides, we need to
+        # force reloading of global settings in order to apply the overrides
+        sematic_settings._ACTIVE_SETTINGS = None
+
+        for key, value in env_dict.items():
+            if value is None:
+                if key in os.environ:
+                    del os.environ[key]
+            else:
+                os.environ[key] = value
+
+    update_environ_with(to_set)
+    try:
+        yield
+    finally:
+        update_environ_with(backup_of_changed_keys)

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -1,0 +1,20 @@
+# Standard Library
+import distutils.util
+from typing import Any, Optional
+
+
+def as_bool(value: Optional[Any]) -> bool:
+    """
+    Returns a boolean interpretation of the contents of the specified value.
+    """
+    if isinstance(value, bool):
+        return value
+
+    if value is None:
+        return False
+
+    str_value = str(value)
+    if len(str_value) == 0:
+        return False
+
+    return bool(distutils.util.strtobool(str_value))


### PR DESCRIPTION
This is the sixth PR in a chain that introduces a Build System plugin with an implementation that uses native Python+Docker capabilities to build a container image and launch a pipeline, without requiring Bazel. The previous PR in the chain is #815.

This PR eliminates tech debt by extracting two local functions from other code modules to utility functions, and reusing them in the new Docker Build System, in addition to the original usages.
