### PR TITLE
[New dashboard UI] Apply or reset search filters

### DIFF
--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -1,4 +1,4 @@
-import { Run } from "src/Models";
+import { Run, User } from "src/Models";
 
 export type RunListPayload = {
     current_page_url: string;
@@ -9,9 +9,13 @@ export type RunListPayload = {
     content: Run[];
 };
 
+export type UserListPayload = {
+    content: User[];
+};
+
 type Operator = "eq";
 
-type FilterCondition = {
+export type FilterCondition = {
     [key: string]: { [eq in Operator]?: string | null } | undefined
 }
 

--- a/sematic/ui/packages/common/src/component/TagsInput.tsx
+++ b/sematic/ui/packages/common/src/component/TagsInput.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import Chip from "@mui/material/Chip";
 import TextField from "@mui/material/TextField";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, forwardRef, useImperativeHandle } from "react";
+import { ResettableHandle } from "src/component/common";
 import theme from "src/theme/new";
 
 interface OverflowComponentProps {
@@ -62,7 +63,12 @@ const InputContainer = styled("div", {
   }
 `;
 
-const TagsInput = () => {
+interface TagsInputProps {
+    onTagsChange?: (tags: string[]) => void;
+}
+
+const TagsInput = forwardRef<ResettableHandle, TagsInputProps>((props, ref) => {
+    const { onTagsChange } = props;
     const [tags, setTags] = useState<string[]>([]);
     const [inputValue, setInputValue] = useState("");
     const [overflow, setOverflow] = useState(false);
@@ -75,20 +81,30 @@ const TagsInput = () => {
 
     const handleAddTag = useCallback(() => {
         if (inputValue.trim() !== "") {
-            setTags([...tags, inputValue.trim()]);
+            const newTags = [...tags, inputValue.trim()];
+            setTags(newTags);
+            onTagsChange?.(newTags);
             setInputValue("");
             syncOverflowState();
         }
-    }, [tags, inputValue, syncOverflowState]);
+    }, [tags, inputValue, onTagsChange, syncOverflowState]);
 
     const handleRemoveTag = useCallback((tag: string) => {
         const updatedTags = tags.filter((t) => t !== tag);
         setTags(updatedTags);
-    }, [tags]);
+        onTagsChange?.(updatedTags);
+    }, [tags, onTagsChange]);
 
     const handleInputChange = useCallback((e: any) => {
         setInputValue(e.target.value);
     }, []);
+
+    useImperativeHandle(ref, () => ({
+        reset: () => {
+            setTags([]);
+            setInputValue("");
+        }
+    }));
 
     return (
         <>
@@ -117,6 +133,6 @@ const TagsInput = () => {
             </InputContainer>
         </>
     );
-};
+});
 
 export default TagsInput;

--- a/sematic/ui/packages/common/src/component/common.ts
+++ b/sematic/ui/packages/common/src/component/common.ts
@@ -1,0 +1,3 @@
+export interface ResettableHandle {
+    reset: () => void;
+}

--- a/sematic/ui/packages/common/src/hooks/userHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/userHooks.ts
@@ -1,0 +1,19 @@
+import { UserListPayload } from "@sematic/common/src/ApiContracts";
+import { useHttpClient } from "@sematic/common/src/hooks/httpHooks";
+import useAsync from "react-use/lib/useAsync";
+
+export type QueryParams = { [key: string]: string };
+
+export function useUsersList() {
+    const { fetch } = useHttpClient();
+    const state = useAsync(async () => {
+        const response = await fetch({
+            url: "/api/v1/users"
+        });
+        return (await response.json() as UserListPayload)["content"];
+    }, [fetch]);
+
+    const { loading: isLoading, error, value } = state;
+
+    return { isLoading, error, users: value };
+}

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -1,11 +1,14 @@
+import styled from "@emotion/styled";
+import Button from "@mui/material/Button";
+import { useCallback, useRef } from "react";
 import OtherFiltersSection from "src/pages/RunSearch/filters/OtherFilterSection";
 import OwnersFilterSection from "src/pages/RunSearch/filters/OwnersFilterSection";
 import SearchTextSection from "src/pages/RunSearch/filters/SearchTextSection";
 import StatusFilterSection from "src/pages/RunSearch/filters/StatusFilterSection";
 import TagsFilterSection from "src/pages/RunSearch/filters/TagsFilterSection";
-import Button from "@mui/material/Button";
-import styled from "@emotion/styled";
+import { ResettableHandle } from "src/component/common";
 import theme from "src/theme/new";
+import { AllFilters, FilterType } from "src/pages/RunSearch/filters/common";
 
 const StyledButton = styled(Button)`
     margin: 0 -${theme.spacing(5)};
@@ -15,16 +18,62 @@ const StyledButton = styled(Button)`
     border-radius: 2px;
 `;
 
-const SearchFilters = () => {
+interface SearchFiltersProps {
+    onFiltersChanged: (filters: AllFilters) => void;
+}
+
+const SearchFilters = (props: SearchFiltersProps) => {
+    const { onFiltersChanged } = props;
+
+    const allFilters = useRef<AllFilters>({});
+
+    const searchTextRef = useRef<ResettableHandle>(null);
+    const tagsFiltersRef = useRef<ResettableHandle>(null);
+    const statusFiltersRef = useRef<ResettableHandle>(null);
+    const ownersFiltersRef = useRef<ResettableHandle>(null);
+    const otherFiltersRef = useRef<ResettableHandle>(null);
+
+    const resetAll = useCallback(() => {
+        searchTextRef.current?.reset();
+        tagsFiltersRef.current?.reset();
+        ownersFiltersRef.current?.reset();
+        statusFiltersRef.current?.reset();
+        otherFiltersRef.current?.reset();
+
+        allFilters.current = {}; 
+    }, []);
+
+    const onSearchTextChanged = useCallback((searchText: string) => {
+        allFilters.current[FilterType.SEARCH] = [searchText];
+    }, []);
+
+    const onStatusFilterChanged = useCallback((filters: string[]) => {
+        allFilters.current[FilterType.STATUS] = filters;
+    }, []);
+
+    const onOwnersFilterChanged = useCallback((filters: string[]) => {
+        allFilters.current[FilterType.OWNER] = filters;
+    }, []);
+
+    const onOtherFilterChanged = useCallback((filters: string[]) => {
+        allFilters.current[FilterType.OTHER] = filters;
+    }, []);
+
+    const applyFilters = useCallback(() => {
+        onFiltersChanged({...allFilters.current});
+    }, [onFiltersChanged]);
+
     return <>
-        <SearchTextSection />
-        <TagsFilterSection />
-        <StatusFilterSection />
-        <OwnersFilterSection />
-        <OtherFiltersSection />
+        <SearchTextSection ref={searchTextRef} onSearchChanged={onSearchTextChanged} />
+        <TagsFilterSection ref={tagsFiltersRef} />
+        <StatusFilterSection ref={statusFiltersRef} onFiltersChanged={onStatusFilterChanged} />
+        <OwnersFilterSection ref={ownersFiltersRef} onFiltersChanged={onOwnersFilterChanged} />
+        <OtherFiltersSection ref={otherFiltersRef} onFiltersChanged={onOtherFilterChanged} />
         {/* <OrderSection /> disabled for now */}
-        <StyledButton variant="contained" disableElevation>Filter runs</StyledButton>
-        <StyledButton variant="contained" disableElevation color={"white"}>Clear filters</StyledButton>
+        <StyledButton variant="contained" disableElevation onClick={applyFilters}>Filter runs</StyledButton>
+        <StyledButton variant="contained" disableElevation color={"white"} onClick={resetAll} >
+            Clear filters
+        </StyledButton>
     </>;
 }
 

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OtherFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OtherFilterSection.tsx
@@ -3,6 +3,8 @@ import Checkbox from "@mui/material/Checkbox";
 import { collapseClasses } from "@mui/material/Collapse";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
+import { forwardRef, useState, useImperativeHandle, useCallback } from "react";
+import { ResettableHandle } from "src/component/common";
 import CollapseableFilterSection from "src/pages/RunSearch/filters/CollapseableFilterSection";
 import theme from "src/theme/new";
 
@@ -25,18 +27,35 @@ const StyledFormControlLabel = styled(FormControlLabel)`
     margin-left: ${theme.spacing(2.9)};
 `;
 
-interface OwnersFilterSectionProps {
+interface OtherFilterSectionProps {
     onFiltersChanged?: (filters: string[]) => void;
 }
 
-const OtherFiltersSection = (props: OwnersFilterSectionProps) => {
+const OtherFiltersSection = forwardRef<ResettableHandle, OtherFilterSectionProps>((props, ref) => {
+    const { onFiltersChanged } = props;
+    const [rootRunsOnly, setRootRunsOnly] = useState<boolean>(false);
+
+    useImperativeHandle(ref, () => ({
+        reset: () => {
+            setRootRunsOnly(false);
+        }
+    }));
+
+    const onRootRunsOnlyChanged = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        const checked = event.target.checked;
+        setRootRunsOnly(checked);
+        onFiltersChanged?.(checked ? ["rootRunsOnly"] : []);
+    }, [setRootRunsOnly, onFiltersChanged]);
+
+
     return <StyledCollapseableFilterSection title={"Filters"} >
         <Container>
             <FormGroup>
-                <StyledFormControlLabel control={<Checkbox defaultChecked />} label="Root runs only" />
+                <StyledFormControlLabel control={
+                    <Checkbox checked={rootRunsOnly} onChange={onRootRunsOnlyChanged} />} label="Root runs only" />
             </FormGroup>
         </Container>
     </StyledCollapseableFilterSection>;
-}
+});
 
 export default OtherFiltersSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/SearchTextSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/SearchTextSection.tsx
@@ -1,15 +1,36 @@
-import { SectionWithBorder } from "src/component/Section";
 import TextField from "@mui/material/TextField";
+import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
+import { SectionWithBorder } from "src/component/Section";
+import { ResettableHandle } from "src/component/common";
 
+interface SearchTextSectionProps {
+    onSearchChanged?: (search: string) => void;
+}
 
-function SearchTextSection() {
+const SearchTextSection = forwardRef<ResettableHandle, SearchTextSectionProps>((props, ref) => {
+    const { onSearchChanged } = props;    
+    const [search, setSearch] = useState<string>("");
+
+    const _onSearchChanged = useCallback((search: string) => {
+        setSearch(search);
+        onSearchChanged?.(search);
+    }, [onSearchChanged]);
+
+    useImperativeHandle(ref, () => ({
+        reset: () => {
+            setSearch("");
+        }
+    }));
+    
     return <SectionWithBorder >
         <TextField
             variant="standard"
             fullWidth={true}
             placeholder={"Search..."}
+            value={search}
+            onChange={(e) => {_onSearchChanged(e.target.value)}}
         />
     </SectionWithBorder>
-}
+});
 
 export default SearchTextSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
@@ -5,7 +5,8 @@ import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip 
 import CollapseableFilterSection from "src/pages/RunSearch/filters/CollapseableFilterSection";
 import theme from "src/theme/new";
 import memoize from "lodash/memoize";
-import { ResettableHandle } from "src/pages/RunSearch/filters/common";
+import { ResettableHandle } from "src/component/common";
+import { StatusFilters } from "src/pages/RunSearch/filters/common";
 
 const StyledChip = styled(Chip)`
     padding-left: ${theme.spacing(1)};
@@ -37,7 +38,7 @@ interface StatusFilterSectionProps {
 }
 
 const toogleFilterGenerator = memoize((
-    filter: string,
+    filter: StatusFilters,
     setFilters: React.Dispatch<React.SetStateAction<Set<string>>>,
     onFiltersChanged: StatusFilterSectionProps["onFiltersChanged"]
 ) =>

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
-import { useState } from "react";
+import { useState, useRef, forwardRef, useImperativeHandle } from "react";
 import TagsInput from "src/component/TagsInput";
+import { ResettableHandle } from "src/component/common";
 import { ScrollableCollapseableFilterSection } from "src/pages/RunSearch/filters/CollapseableFilterSection";
 import theme from "src/theme/new";
 
@@ -23,16 +24,27 @@ const StyledScrollableSection = styled(ScrollableCollapseableFilterSection) <{
     transition: min-height 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 `;
 
+interface TagsFilterSectionProps {
+    onFiltersChanged?: (filters: string[]) => void;
+}
 
-const TagsFilterSection = () => {
+const TagsFilterSection = forwardRef<ResettableHandle, TagsFilterSectionProps>((props, ref) => {
     const [expanded, setExpanded] = useState(false);
+
+    const tagInputRef = useRef<ResettableHandle>(null);
+
+    useImperativeHandle(ref, () => ({
+        reset: () => {
+            tagInputRef.current?.reset();
+        }
+    }));
 
     return <StyledScrollableSection title={"Tags"} expanded={expanded}
         onChange={(_, expanded) => setExpanded(expanded)}>
         <Container>
-            <TagsInput />
+            <TagsInput ref={tagInputRef} />
         </Container>
     </StyledScrollableSection>;
-}
+});
 
 export default TagsFilterSection;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
@@ -1,3 +1,85 @@
-export interface ResettableHandle {
-    reset: () => void;
+import { Filter, FilterCondition } from "src/ApiContracts";
+
+export enum FilterType {
+    SEARCH = "search",
+    TAGS = "tags",
+    OWNER = "owner",
+    STATUS = "status",
+    OTHER = "other"
+}
+
+export type AllFilters = Partial<Record<FilterType, string[]>>;
+
+export type StatusFilters = "completed" | "failed" | "running" | "canceled";
+
+export function convertStatusFilterToRunFilters(filters: StatusFilters[]): Filter | null {
+    const filtersSet = new Set(filters);
+
+    const conditions: FilterCondition[] = [];
+
+    if (filtersSet.has("completed")) {
+        ["RESOLVED", "SUCCEEDED"].forEach((state) => {
+            conditions.push({
+                "future_state": {eq: state}
+            });
+        });
+    }
+    if (filtersSet.has("failed")) {
+        ["FAILED", "NESTED_FAILED"].forEach((state) => {
+            conditions.push({
+                "future_state": {eq: state}
+            });
+        });
+    }
+    if (filtersSet.has("running")) {
+        ["SCHEDULED", "RAN"].forEach((state) => {
+            conditions.push({
+                "future_state": {eq: state}
+            });
+        });
+    }
+    if (filtersSet.has("canceled")) {
+        conditions.push({
+            "future_state": {eq: "CANCELED"}
+        });
+    }
+
+    if (conditions.length > 1) {
+        return {
+            "OR": conditions
+        }
+    }
+
+    if (conditions.length === 0) {
+        return null;
+    }
+
+    return conditions[0];
+}
+
+export function convertMiscellaneousFilterToRunFilters(filters: string[]): Filter | null {
+    const filtersSet = new Set(filters);
+
+    if (filtersSet.has("rootRunsOnly")) {
+        return { parent_id: { eq: null } }
+    }
+    return null;
+}
+
+
+export function convertOwnersFilterToRunFilters(filters: string[]): Filter | null {
+
+    if (!!filters && filters.length > 0) {
+        const conditions = filters.map((owner) => ({
+            "user_id": {eq: owner}
+        }));
+        if (conditions.length > 1) {
+            return {
+                "OR": conditions
+            }
+        } 
+        return conditions[0];        
+    }
+    
+    return null;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -1,17 +1,27 @@
-import { useCallback } from "react";
+import { useCallback, useState, useMemo } from "react";
 import TwoColumns from "src/layout/TwoColumns";
 import RunList from "src/pages/RunSearch/RunList";
 import SearchFilters from "src/pages/RunSearch/SearchFilters";
+import { AllFilters } from "src/pages/RunSearch/filters/common";
 
 const RunSearch = () => {
+    const [filters, setFilters] = useState<AllFilters | null>(null);
+
+    const onFiltersChanged = useCallback((filters: AllFilters) => {
+        setFilters(filters);
+    }, []);
 
     const onRenderLeft = useCallback(() => {
-        return <SearchFilters />;
-    }, []);
+        return <SearchFilters onFiltersChanged={onFiltersChanged} />;
+    }, [onFiltersChanged]);
+
+    const filtersKey = useMemo(() => JSON.stringify(filters), [filters]);
 
     const onRenderRight = useCallback(() => {
-        return <RunList />;
-    }, []);
+        return <RunList key={filtersKey} filters={filters} />;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [filtersKey]);
+
 
     return <TwoColumns onRenderLeft={onRenderLeft} onRenderRight={onRenderRight} />;
 }

--- a/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
@@ -1,12 +1,12 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
-import StatusFilterSection from "@sematic/common/src/pages/RunSearch/filters/StatusFilterSection";
 import OwnersFilterSection from "@sematic/common/src/pages/RunSearch/filters/OwnersFilterSection";
+import StatusFilterSection from "@sematic/common/src/pages/RunSearch/filters/StatusFilterSection";
 
+import { ResettableHandle } from "@sematic/common/src/component/common";
 import { useRef } from "@sematic/common/src/reactHooks";
 import theme from "@sematic/common/src/theme/new";
 import { Meta, StoryObj } from "@storybook/react";
-import { ResettableHandle } from "src/pages/RunSearch/filters/common";
 
 export default {
     title: "Sematic/RunFilters",


### PR DESCRIPTION
Support applying search filters to filter run list table by adding filter conditions to backend call. 

1. Blank result page style is not yet implemented.
2. `tags` is not working (not included in the search conditions), but resetting filters will reset tags.
3. If there are multiple values for the same search type, eg, searching both `completed` and `failed` runs, the conditions will be concatenated with `OR`
4. Different search filter types will be linked with `AND`. eg. search `completed` and `user_id=1` will become ['AND', `completed`,`user_id=1`] (in reverse polish notation)
5. Fuzzy test search can be combined with other search filter types using `AND` relationship.

The effect can be previewed in `my` namespace.