### PR TITLE
Make early resolution failure more robust

### DIFF
--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -113,6 +113,8 @@ class CloudResolver(LocalResolver):
         #           machine
         self._detach = detach
 
+        self._resolution_was_created = _is_running_remotely
+
         # _is_running_remotely:
         #   True: we are running in a remote driver job
         #   False: default we are running on a local user machine

--- a/sematic/resolvers/tests/test_local_resolver.py
+++ b/sematic/resolvers/tests/test_local_resolver.py
@@ -207,6 +207,33 @@ def test_failure(
         assert future.state == expected_states[future.function.__name__]
 
 
+def test_pre_resolution_creation_failure(
+    mock_socketio,  # noqa: F811
+    mock_auth,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_requests,  # noqa: F811
+    valid_client_version,  # noqa: F811
+):
+    class CustomException(Exception):
+        pass
+
+    def do_fail(*args, **kwargs):
+        raise CustomException("Custom exception")
+
+    @func
+    def pipeline() -> None:
+        return None
+
+    resolver = LocalResolver()
+    resolver._make_resolution = do_fail
+    future = pipeline()
+
+    with pytest.raises(CustomException):
+        # this confirms the exception isn't swallowed by another when trying
+        # to fail the resolution.
+        future.resolve(resolver)
+
+
 def test_resolver_error(
     mock_socketio,  # noqa: F811
     mock_auth,  # noqa: F811


### PR DESCRIPTION
If we failed somewhere between root run creation and resolution creation, we could swallow the original source of the failure and replace it with a "resolution not found" error when we tried to update the status of the resolution to failed. This PR makes it so that we instead just log a warning about the fact that we won't be able to update the resolution status, and allows the original error to continue to propagate.

Testing
-------
In addition to unit tests, raised an intentional error from `_make_resolution` and confirmed that the console showed both the original error and the warning message about inability to update status:
```

INFO:__main__:Command line arguments: Namespace(cache_namespace=None, cloud=True, detach=True, exit_code=None, expand_shared_memory=False, external_resource=False, fan_out=0, fork_actions=None, images=False, inline=False, log_level='INFO', max_parallelism=None, nested=False, nested_timeout_settings=None, no_input=False, oom=False, raise_retry_probability=None, ray_resource=False, rerun_from=None, s3_uris=None, should_raise=False, silent=False, sleep_time=0, spam_logs=0, timeout_settings=None, virtual_funcs=False)
INFO:__main__:Pipeline arguments: {'s3_uris': None, 'should_raise': False, 'ray_resource': False, 'exit_code': None, 'nested': False, 'fan_out': 0, 'nested_timeout_settings': None, 'virtual_funcs': False, 'oom': False, 'images': False, 'external_resource': False, 'sleep_time': 0, 'no_input': False, 'timeout_settings': None, 'fork_actions': None, 'spam_logs': 0, 'inline': False, 'raise_retry_probability': None}
INFO:__main__:Invoking the pipeline...
INFO:sematic.resolvers.state_machine_resolver:Resolution 7008e8b57c3b40c4a879fa80dd9c0fec has failed; starting cleanup; look for details below
WARNING:sematic.resolvers.local_resolver:Can't update resolution status while handling resolution failure, because resolution was never created.
Traceback (most recent call last):
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 433, in <module>
    main()
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/examples/testing_pipeline/__main__.py", line 428, in main
    result = future.resolve(resolver)
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/future.py", line 57, in resolve
    self.value = resolver.resolve(self)
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 133, in resolve
    return self._detach_resolution(future)
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 236, in _detach_resolution
    self._create_resolution(future)
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/resolvers/cloud_resolver.py", line 202, in _create_resolution
    return super()._create_resolution(root_future)
  File "/home/josh/.cache/bazel/_bazel_josh/f4bd2ac87f293dc4b004505d0b886a06/execroot/sematic/bazel-out/k8-fastbuild/bin/sematic/examples/testing_pipeline/__main___binary.runfiles/sematic/sematic/resolvers/local_resolver.py", line 330, in _create_resolution
    raise ValueError("Intentional error")
ValueError: Intentional error
```