### PR TITLE
Adjust the Name column width distribution

### DIFF
--- a/sematic/ui/packages/common/src/component/ErrorBoundary.tsx
+++ b/sematic/ui/packages/common/src/component/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+    fallback: React.ReactNode;
+    children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error: any) {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true };
+    }
+
+    render() {
+        if (this.state.hasError) {
+            // You can render any custom fallback UI
+            return this.props.fallback;
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/sematic/ui/packages/common/src/component/RunStateText.ts
+++ b/sematic/ui/packages/common/src/component/RunStateText.ts
@@ -8,26 +8,32 @@ export function getRunStateText(futureState: string,
     const { createdAt, resolvedAt, failedAt, endedAt } = timestamps;
 
     if (["RESOLVED", "SUCCEEDED"].includes(futureState)) {
-        return `Completed in ${DurationShort(parseJSON(resolvedAt!), parseJSON(createdAt))}`;
+        if (!resolvedAt) {
+            return "Completed in unknown duration";
+        }
+        return `Completed in ${DurationShort(parseJSON(resolvedAt!), parseJSON(createdAt)) || "< 1s"}`;
     }
     if (["FAILED", "NESTED_FAILED"].includes(futureState)) {
-        return `Failed after ${DurationShort(parseJSON(failedAt!), parseJSON(createdAt))}`;
+        if (!failedAt) {
+            return "Failed after unknown duration";
+        }
+        return `Failed after ${DurationShort(parseJSON(failedAt!), parseJSON(createdAt)) || "< 1s"}`;
     }
     if (["SCHEDULED", "RAN"].includes(futureState)) {
-        return `Running for ${DurationShort(new Date(), parseJSON(createdAt))}`;
+        return `Running for ${DurationShort(new Date(), parseJSON(createdAt)) || "< 1s"}`;
     }
     if (futureState === "CANCELED") {
         const finishAt = endedAt || failedAt!;
         if (!finishAt) {
-            return "Unknonw duration";
+            return "Canceled after unknown duration";
         }
-        return `Canceled after ${DurationShort(parseJSON(finishAt), parseJSON(createdAt))}`;
+        return `Canceled after ${DurationShort(parseJSON(finishAt), parseJSON(createdAt)) || "< 1s"}`;
     }
     if (futureState === "CREATED") {
-        return `Submitted ${DurationShort(new Date(), parseJSON(createdAt))} ago`;
+        return `Submitted ${DurationShort(new Date(), parseJSON(createdAt)) || "< 1s"} ago`;
     }
     if (futureState === "RETRYING") {
-        return `Retrying for ${DurationShort(new Date(), parseJSON(createdAt))}`;
+        return `Retrying for ${DurationShort(new Date(), parseJSON(createdAt)) || "< 1s"}`;
     }
     return null;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/NameColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/NameColumn.tsx
@@ -1,0 +1,46 @@
+import ImportPath from "src/component/ImportPath";
+import PipelineTitle from "src/component/PipelineTitle";
+import theme from "src/theme/new";
+import styled from "@emotion/styled";
+
+
+const NameSection = styled.div`
+    display: flex;
+    flex-direction: row;
+    column-gap: ${theme.spacing(2)};
+    overflow-x: hidden;
+    min-width: 100px;
+    position: relative;
+
+    & .name {
+        flex-grow: 0;
+        flex-shrink: 1;
+        overflow: hidden;
+    }
+
+    & .importPath {
+        flex-grow: 1;
+        flex-shrink: 9999;
+        overflow: hidden;
+    }
+`;
+
+interface NameColumnProps {
+    name: string;
+    importPath: string;
+}
+
+const NameColumn = (props: NameColumnProps) => {
+    const { name, importPath } = props;
+
+    return <NameSection>
+        <div className={"name"}>
+            <PipelineTitle>{name}</PipelineTitle>
+        </div>
+        <div className={"importPath"}>
+            <ImportPath>{importPath}</ImportPath>
+        </div>
+    </NameSection>
+}
+
+export default NameColumn;

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -2,22 +2,21 @@ import styled from "@emotion/styled";
 import { ChevronLeft, ChevronRight } from "@mui/icons-material";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
-import { createColumnHelper, getCoreRowModel, useReactTable, Row } from "@tanstack/react-table";
+import { Row, createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { parseJSON } from "date-fns";
+import { useCallback, useContext, useEffect, useMemo } from "react";
 import { Run } from "src/Models";
 import { DateTimeLongConcise } from "src/component/DateTime";
-import ImportPath from "src/component/ImportPath";
 import NameTag from "src/component/NameTag";
-import PipelineTitle from "src/component/PipelineTitle";
 import { RunReference } from "src/component/RunReference";
 import TableComponent, { TableComponentProps } from "src/component/Table";
+import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { getRunUrlPattern, useRunsPagination } from "src/hooks/runHooks";
+import NameColumn from "src/pages/RunSearch/NameColumn";
 import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
 import TagsColumn from "src/pages/RunSearch/TagsColumn";
+import { AllFilters, FilterType, StatusFilters, convertMiscellaneousFilterToRunFilters, convertOwnersFilterToRunFilters, convertStatusFilterToRunFilters } from "src/pages/RunSearch/filters/common";
 import theme from "src/theme/new";
-import LayoutServiceContext from "src/context/LayoutServiceContext";
-import { useContext, useEffect, useCallback, useMemo } from "react";
-import { AllFilters, convertMiscellaneousFilterToRunFilters, convertOwnersFilterToRunFilters, convertStatusFilterToRunFilters, FilterType, StatusFilters } from "src/pages/RunSearch/filters/common";
 
 const Container = styled.div`
     display: flex;
@@ -48,15 +47,6 @@ const Pagination = styled.div`
     svg {
         cursor: pointer;
     }
-`;
-
-const NameSection = styled.div`
-    display: flex;
-    flex-direction: row;
-    column-gap: ${theme.spacing(2)};
-    overflow-x: hidden;
-    min-width: 100px;
-    position: relative;
 `;
 
 const StyledRunReferenceLink = styled(RunReference)`
@@ -99,10 +89,7 @@ const columns = [
         header: "Name",
         cell: info => {
             const [name, importPath] = info.getValue();
-            return <NameSection>
-                <PipelineTitle>{name}</PipelineTitle>
-                <ImportPath>{importPath}</ImportPath>
-            </NameSection>
+            return <NameColumn name={name} importPath={importPath} />
         },
     }),
     columnHelper.accessor("tags", {

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { useMemo } from "react";
+import ErrorBoundary from "src/component/ErrorBoundary";
 import { getRunStateChipByState } from "src/component/RunStateChips";
 import getRunStateText from "src/component/RunStateText";
 import theme from "src/theme/new";
@@ -35,4 +36,10 @@ const RunStatusColumn = (props: RunStatusColumnProps) => {
     return <StyledContainer>{runStateChip} {runStateText}</StyledContainer>;
 }
 
-export default RunStatusColumn;
+const RunStatusColumnWithErrorBoundary = (props: RunStatusColumnProps) => {
+    return <ErrorBoundary fallback={"Invalid state"}>
+        <RunStatusColumn {...props} />
+    </ErrorBoundary>
+}
+
+export default RunStatusColumnWithErrorBoundary;

--- a/sematic/ui/packages/main/src/setupProxy.js
+++ b/sematic/ui/packages/main/src/setupProxy.js
@@ -7,4 +7,5 @@ module.exports = function (app) {
     });
     app.use("/api", proxy);
     app.use("/authenticate", proxy);
+    app.use("/login", proxy);
 };


### PR DESCRIPTION
The PR covers:

1. On the run search page, if the Name column width is shrunk, prioritize shrinking the width of the import path instead of squeezing the run name. So there is a better chance to see the complete run name. However, if the column width is further reduced, part of the run name remains hidden. Illustrated below:

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/414f7135-4ec7-40f8-adf3-6101b781ce73)

2. Introduced `<ErrorBoundary />` component, so errors will not bubble up and destroy the whole page.

3. Improved the rendering logic of run status logic; there are now more default/fallback values for extreme cases.

4. Fixed an issue in the local dev login process, which didn't proxy the `login` request.

The change can be previewed in `my` namespace.