### PR TITLE
Switch to apt-get

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,12 +1,11 @@
 FROM cimg/python:3.10.10
 
-RUN sudo apt install curl gnupg
+RUN sudo apt-get update && sudo apt-get install curl gnupg
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
 RUN sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
 RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-RUN sudo apt update
-RUN sudo apt install -y bazel default-jre default-jdk xvfb libgtk-3-0 libgtk-3-0 libgbm-dev
+RUN sudo apt-get update && sudo apt-get install -y bazel default-jre default-jdk xvfb libgtk-3-0 libgtk-3-0 libgbm-dev
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 RUN curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
-    sudo apt-get install -y nodejs
-RUN sudo apt install sqlite3
+    sudo apt-get update && sudo apt-get install -y nodejs
+RUN sudo apt-get update && sudo apt-get install sqlite3

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -5,10 +5,10 @@ FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH="/sematic/bin/:${PATH}"
 
-RUN apt update -y
-RUN apt install -y software-properties-common
+RUN apt-get update -y
+RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN apt install -y python3.9
+RUN apt-get install -y python3.9
 
 RUN rm /usr/bin/python3
 RUN ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -49,8 +49,10 @@ _DOCKERFILE_BASE_TEMPLATE = """
 FROM {base_uri}
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{{sys.version_info.major}}.{{sys.version_info.minor}}')")-distutils
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{{sys.version_info.major}}.{{sys.version_info.minor}}')")-distutils
 
 ENV PATH="/sematic/bin/:${{PATH}}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
@@ -1,8 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN which pip3 || apt update -y && apt install -y python3-pip
-RUN python3 -c "import distutils" || apt update -y && apt install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
+RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
@@ -1,6 +1,8 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
 


### PR DESCRIPTION
Using `apt` results in "interactive" warning messages:

![image](https://github.com/sematic-ai/sematic/assets/1894533/eedabe7b-6fab-4c37-bee5-9fde6694a944)

This PR switches to `apt-get`, which is supposed to be the "script-safe" version.
