### PR TITLE
Display empty state in run search table

### DIFF
--- a/sematic/ui/packages/common/src/component/NameTag.tsx
+++ b/sematic/ui/packages/common/src/component/NameTag.tsx
@@ -1,13 +1,19 @@
+import React from "react";
 import PipelineTitle from "src/component/PipelineTitle";
 
-const NameTag = (props: {
-    children: React.ReactNode;
-}) => {
-    const { children } = props;
+interface NameTagProps {
+    firstName?: string | null;
+    lastName?: string | null;
+}
+
+const NameTag = (props: NameTagProps ) => {
+    const { firstName, lastName } = props;
+
+    const name = !!firstName && !!lastName ? `${firstName} ${lastName}` : firstName || lastName || "Unknown";
 
     return <span style={{ maxWidth: "100px" }}>
         <PipelineTitle variant={"small"} >
-            {children}
+            {name}
         </PipelineTitle>
     </span>;
 }

--- a/sematic/ui/packages/common/src/component/Note.tsx
+++ b/sematic/ui/packages/common/src/component/Note.tsx
@@ -105,7 +105,7 @@ const NoteComponent = (prop: NoteProps) => {
         <div ref={contentArea}>
             <Title>
                 <Box style={{ display: "flex" }}>
-                    <NameTag>{name}</NameTag>
+                    <NameTag firstName={name} />
                     <Typography variant="small" color={theme.palette.lightGrey.main} paragraph={false}>
                         {"\xa0on run"}
                     </Typography>

--- a/sematic/ui/packages/common/src/component/ShellCommand.tsx
+++ b/sematic/ui/packages/common/src/component/ShellCommand.tsx
@@ -1,0 +1,57 @@
+import { ContentCopy } from "@mui/icons-material";
+import {
+    ButtonBase,
+    useTheme
+} from "@mui/material";
+import { useCallback, useState } from "react";
+import styled from "@emotion/styled";
+import theme from "src/theme/new";
+
+interface ShellCommandProps {
+    command: string;
+    className?: string;
+}
+
+function ShellCommand(props: ShellCommandProps) {
+    const { command, className } = props;
+
+    const [content, setContent] = useState("$ " + command);
+
+    const theme = useTheme();
+
+    const onClick = useCallback(() => {
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(command);
+        }
+        setContent("Copied!");
+        setTimeout(() => setContent("$ " + command), 1000);
+    }, [command]);
+
+    return (
+        <ButtonBase
+            sx={{
+                backgroundColor: theme.palette.grey[800],
+                color: theme.palette.grey[100],
+                py: 1,
+                px: 2,
+                borderRadius: 1,
+                display: "flex",
+                width: "100%",
+                textAlign: "left",
+                boxShadow: "rgba(0,0,0,0.5) 0px 0px 5px 0px",
+            }}
+            onClick={onClick}
+            className={className}
+        >
+            <code style={{ flexGrow: 1 }}>{content}</code>
+            <ContentCopy fontSize="small" sx={{ color: theme.palette.grey[600] }} />
+        </ButtonBase>
+    );
+}
+
+export const ShellCommandRelaxed = styled(ShellCommand)`
+    padding-top: ${theme.spacing(5)};
+    padding-bottom: ${theme.spacing(5)};
+`;
+
+export default ShellCommand;

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -181,7 +181,7 @@ const RunList = (props: RunListProps) => {
         }
         const hasFilters = filters && Object.keys(filters).length > 0;
         return <EmptyStateContainer >
-            { hasFilters ? <NoRunWithFilters /> :<NoRunNoFilters /> }
+            { hasFilters ? <NoRunWithFilters /> : <NoRunNoFilters /> }
         </EmptyStateContainer>;
     }, [runs, filters, isLoaded]);
 

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -11,11 +11,12 @@ import NameTag from "src/component/NameTag";
 import { RunReference } from "src/component/RunReference";
 import TableComponent, { TableComponentProps } from "src/component/Table";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
-import { getRunUrlPattern, useRunsPagination } from "src/hooks/runHooks";
+import { getRunUrlPattern, useFiltersConverter, useRunsPagination } from "src/hooks/runHooks";
 import NameColumn from "src/pages/RunSearch/NameColumn";
+import { NoRunNoFilters, NoRunWithFilters } from "src/pages/RunSearch/RunListEmptyState";
 import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
 import TagsColumn from "src/pages/RunSearch/TagsColumn";
-import { AllFilters, FilterType, StatusFilters, convertMiscellaneousFilterToRunFilters, convertOwnersFilterToRunFilters, convertStatusFilterToRunFilters } from "src/pages/RunSearch/filters/common";
+import { AllFilters } from "src/pages/RunSearch/filters/common";
 import theme from "src/theme/new";
 
 const Container = styled.div`
@@ -49,11 +50,23 @@ const Pagination = styled.div`
     }
 `;
 
+const EmptyStateContainer = styled.div`
+    position: absolute;
+    right: 0;
+    left: 0;
+    top: 100px;
+    bottom: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+
 const StyledRunReferenceLink = styled(RunReference)`
     color: ${theme.palette.mediumGrey.main};
 `;
 
-const StyledTableComponent = styled(TableComponent)<TableComponentProps<Run>>`
+const StyledTableComponent = styled(TableComponent) <TableComponentProps<Run>>`
     min-width: 850px;
 ` as typeof TableComponent;
 
@@ -83,7 +96,7 @@ const columns = [
         meta: {
             columnStyles: {
                 width: "1px",
-                maxWidth: "calc(100vw - 1060px)"
+                maxWidth: "calc(100vw - 1100px)"
             }
         },
         header: "Name",
@@ -102,15 +115,18 @@ const columns = [
         header: "Tags",
         cell: info => <TagsColumn tags={info.getValue()} />,
     }),
-    columnHelper.accessor(data => `${data.user?.first_name} ${data.user?.last_name}`, {
+    columnHelper.accessor(data => ({
+        firstName: data.user?.first_name,
+        lastName: data.user?.last_name
+    }), {
         meta: {
             columnStyles: {
                 width: "8.39092%",
-                minWidth: "100px"
+                maxWidth: "max(100px, 8.39092%)",
             }
         },
         header: "Owner",
-        cell: info => <NameTag>{info.getValue()}</NameTag>,
+        cell: info => <NameTag {...info.getValue()} />,
     }),
     columnHelper.accessor(data => ({
         futureState: data.future_state,
@@ -136,70 +152,38 @@ interface RunListProps {
 const RunList = (props: RunListProps) => {
     const { filters } = props;
 
-    const runFilter = useMemo(() => {
-        const conditions = [];
+    const { runFilter, queryParams } = useFiltersConverter(filters);
 
-        if (!filters) {
-            return undefined;
-        }
-
-        if (filters[FilterType.STATUS]) {
-            const statusFilters = convertStatusFilterToRunFilters(filters[FilterType.STATUS] as StatusFilters[]);
-            if (statusFilters) {
-                conditions.push(statusFilters);
-            }
-        }
-
-        if (filters[FilterType.OWNER]) {
-            const ownersFilters = convertOwnersFilterToRunFilters(filters[FilterType.OWNER]!);
-            if (ownersFilters) {
-                conditions.push(ownersFilters);
-            }
-        }
-
-        if (filters[FilterType.OTHER]) {
-            const miscellaneousFilters = convertMiscellaneousFilterToRunFilters(filters[FilterType.OTHER]!);
-            if (miscellaneousFilters) {
-                conditions.push(miscellaneousFilters);
-            }
-        }
-
-        if (conditions.length > 1 ) {
-            return {
-                "AND": conditions
-            }
-        }
-
-        if (conditions.length === 0) {
-            return undefined;
-        }
-        return conditions[0];
-    }, [filters]);
-
-    const queryParams = useMemo(() => {
-        if (!filters) {
-            return undefined;
-        }
-
-        if (filters[FilterType.SEARCH]) {
-            return {
-                "search": filters[FilterType.SEARCH]![0]
-            };
-        }
-    }, [filters]);
-
-
-    const { runs, page, isLoading, totalPages, totalRuns, nextPage, previousPage } = useRunsPagination(
+    const { runs, page, isLoaded, isLoading, totalPages, totalRuns, nextPage, previousPage } = useRunsPagination(
         runFilter as any, queryParams
     );
 
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    const totalRunsText = useMemo(() => {
+        if (!isLoading && totalRuns === 0) {
+            return "No Runs";
+        }
+        const noun = totalRuns === 1 ? "Run" : "Runs";
+
+        return `${totalRuns || "?"} ${noun}`;
+    }, [isLoading, totalRuns]);
 
     const tableInstance = useReactTable({
         data: runs,
         columns,
         getCoreRowModel: getCoreRowModel()
     });
+
+    const emtpyStateComponent = useMemo(() => {
+        if (!isLoaded || runs.length > 0) {
+            return null;
+        }
+        const hasFilters = filters && Object.keys(filters).length > 0;
+        return <EmptyStateContainer >
+            { hasFilters ? <NoRunWithFilters /> :<NoRunNoFilters /> }
+        </EmptyStateContainer>;
+    }, [runs, filters, isLoaded]);
 
     const getRowLink = useCallback((row: Row<Run>): string => {
         return getRunUrlPattern(row.original.id);
@@ -211,9 +195,10 @@ const RunList = (props: RunListProps) => {
 
     return <Container>
         <Stats>
-            <Typography variant={"bold"}>{`${totalRuns || "?"} ${totalRuns === 1 ? "Run" : "Runs"}`}</Typography>
+            <Typography variant={"bold"}>{totalRunsText}</Typography>
         </Stats>
         <StyledTableComponent table={tableInstance} getRowLink={getRowLink} />
+        {emtpyStateComponent}
         <Pagination>
             <IconButton aria-label="previous" disabled={page === 0} onClick={previousPage}>
                 <ChevronLeft />

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunListEmptyState.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunListEmptyState.tsx
@@ -1,0 +1,52 @@
+import styled from "@emotion/styled";
+import Typography from "@mui/material/Typography";
+import MuiRouterLink from "src/component/MuiRouterLink";
+import { ShellCommandRelaxed } from "src/component/ShellCommand";
+import theme from "src/theme/new";
+
+const InitialGuide = styled.div`
+    width: 806px;
+    height: 317px;
+    padding: ${theme.spacing(10)};
+
+    border: 1px solid ${theme.palette.p3border.main};
+    border-radius: 5px;
+`
+
+const StyledTypography = styled(Typography)`
+    margin-top: ${theme.spacing(5)};
+    margin-bottom: ${theme.spacing(5)};
+`
+
+const StyledLink = styled(MuiRouterLink)`
+    color: ${theme.palette.primary.main};
+    font-size: ${theme.typography.big.fontSize}px;
+`;
+
+const StyledTitle = styled.h1`
+    font-size: 24px;
+    font-weight: 500;
+    & a {
+        font-size: 24px;
+        font-weight: 500;
+    }
+`
+
+
+export const NoRunNoFilters = () => <InitialGuide >
+    <h1 style={{ marginTop: 0 }}>Get started with Sematic</h1>
+    <StyledTypography variant={"big"}>
+        Read how to <StyledLink href="/get_started">Get Started</StyledLink> or run an example pipeline.
+    </StyledTypography>
+    <ShellCommandRelaxed command={"sematic run examples/mnist/pytorch"} />
+    <StyledTypography variant={"big"}>
+        Get in touch on the <StyledLink
+            href="https://discord.gg/4KZJ6kYVax"
+            underline="none"
+            target="_blank"
+        >Sematic Discord server.</StyledLink>
+    </StyledTypography>
+</InitialGuide>
+
+export const NoRunWithFilters = () => <StyledTitle>No runs found.&nbsp; 
+    <StyledLink href="/get_started">Get Started</StyledLink>.</StyledTitle>

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -9,6 +9,7 @@ import TagsFilterSection from "src/pages/RunSearch/filters/TagsFilterSection";
 import { ResettableHandle } from "src/component/common";
 import theme from "src/theme/new";
 import { AllFilters, FilterType } from "src/pages/RunSearch/filters/common";
+import isEmpty from "lodash/isEmpty";
 
 const StyledButton = styled(Button)`
     margin: 0 -${theme.spacing(5)};
@@ -44,19 +45,35 @@ const SearchFilters = (props: SearchFiltersProps) => {
     }, []);
 
     const onSearchTextChanged = useCallback((searchText: string) => {
-        allFilters.current[FilterType.SEARCH] = [searchText];
+        if (isEmpty(searchText)) {
+            delete allFilters.current[FilterType.SEARCH];
+        } else {
+            allFilters.current[FilterType.SEARCH] = [searchText];
+        }
     }, []);
 
     const onStatusFilterChanged = useCallback((filters: string[]) => {
-        allFilters.current[FilterType.STATUS] = filters;
+        if (isEmpty(filters)) {
+            delete allFilters.current[FilterType.STATUS];
+        } else {
+            allFilters.current[FilterType.STATUS] = filters;
+        }
     }, []);
 
     const onOwnersFilterChanged = useCallback((filters: string[]) => {
-        allFilters.current[FilterType.OWNER] = filters;
+        if (isEmpty(filters)) {
+            delete allFilters.current[FilterType.OWNER];
+        } else {
+            allFilters.current[FilterType.STATUS] = filters;
+        }
     }, []);
 
     const onOtherFilterChanged = useCallback((filters: string[]) => {
-        allFilters.current[FilterType.OTHER] = filters;
+        if (isEmpty(filters)) {
+            delete allFilters.current[FilterType.OTHER];
+        } else {
+            allFilters.current[FilterType.OTHER] = filters;
+        }
     }, []);
 
     const applyFilters = useCallback(() => {

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/OwnersFilterSection.tsx
@@ -79,7 +79,7 @@ const OwnersFilterSection = forwardRef<ResettableHandle, OwnersFilterSectionProp
                     (user, index) =>
                         <StyledFormControlLabel key={index} control={<Checkbox
                             onChange={(event) => toogleFilter(user.id, event.target.checked)} />}
-                        label={<NameTag>{`${user.first_name} ${user.last_name}`}</NameTag>}
+                        label={<NameTag firstName={user.first_name} lastName={user.last_name} />}
                         checked={filters.has(user.id)} />
                 )}
             </FormGroup>

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -5,7 +5,7 @@ import SearchFilters from "src/pages/RunSearch/SearchFilters";
 import { AllFilters } from "src/pages/RunSearch/filters/common";
 
 const RunSearch = () => {
-    const [filters, setFilters] = useState<AllFilters | null>(null);
+    const [filters, setFilters] = useState<AllFilters>({});
 
     const onFiltersChanged = useCallback((filters: AllFilters) => {
         setFilters(filters);

--- a/sematic/ui/packages/main/src/Home.tsx
+++ b/sematic/ui/packages/main/src/Home.tsx
@@ -1,55 +1,20 @@
-import { ContentCopy } from "@mui/icons-material";
 import {
     Alert,
     Box,
-    ButtonBase,
     Container,
     Divider,
     Grid,
     Typography,
-    useTheme,
+    useTheme
 } from "@mui/material";
+import MuiRouterLink from "@sematic/common/src/component/MuiRouterLink";
+import ShellCommand from "@sematic/common/src/component/ShellCommand";
 import UserContext from "@sematic/common/src/context/UserContext";
 import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useContext, useMemo } from "react";
 import { SiDiscord, SiGithub, SiReadthedocs } from "react-icons/si";
-import MuiRouterLink from "@sematic/common/src/component/MuiRouterLink";
 import RunStateChip from "./components/RunStateChip";
 import TrackingNotice from "./components/TrackingNotice";
-
-function ShellCommand(props: { command: string }) {
-    const { command } = props;
-
-    const [content, setContent] = useState("$ " + command);
-
-    const theme = useTheme();
-
-    const onClick = useCallback(() => {
-        navigator.clipboard.writeText(command);
-        setContent("Copied!");
-        setTimeout(() => setContent("$ " + command), 1000);
-    }, [command]);
-
-    return (
-        <ButtonBase
-            sx={{
-                backgroundColor: theme.palette.grey[800],
-                color: theme.palette.grey[100],
-                py: 1,
-                px: 2,
-                borderRadius: 1,
-                display: "flex",
-                width: "100%",
-                textAlign: "left",
-                boxShadow: "rgba(0,0,0,0.5) 0px 0px 5px 0px",
-            }}
-            onClick={onClick}
-        >
-            <code style={{ flexGrow: 1 }}>{content}</code>
-            <ContentCopy fontSize="small" sx={{ color: theme.palette.grey[600] }} />
-        </ButtonBase>
-    );
-}
 
 export default function Home() {
     const { user } = useContext(UserContext);
@@ -194,7 +159,7 @@ export default function Home() {
                     >
                         <Grid item sx={{ textAlign: "center" }}>
                             <MuiRouterLink
-                                href="https://discord.gg/PFCpatvy"
+                                href="https://discord.gg/4KZJ6kYVax"
                                 underline="none"
                                 target="_blank"
                             >

--- a/sematic/ui/packages/main/src/components/TrackingNotice.tsx
+++ b/sematic/ui/packages/main/src/components/TrackingNotice.tsx
@@ -86,7 +86,7 @@ export default function TrackingNotice({ sx }: TrackingNoticeProps) {
                 <DialogContentText>
           If you have any questions, reach out to us on
                     <Link
-                        href="https://discord.gg/PFCpatvy"
+                        href="https://discord.gg/4KZJ6kYVax"
                         underline="none"
                         target="_blank"
                     > Discord </Link> or at&nbsp; 


### PR DESCRIPTION
Display an empty state UI when the run search returns no result. Depending on whether a filter is used, there are two styles for the empty state page.

Demo:
![capture1](https://github.com/sematic-ai/sematic/assets/133257643/0cc0d42f-c9a0-4188-bda9-ce6134311bf8)

Others:
1. Improved rendering of user's name, prevents displaying "undefined undefined".
2. Migrated `<ShellCommand />` to `common` package.
3. Relocated the logic for generating the filter conditions.
4. Updated obsolete discord link.