### PR TITLE
Wrap Docker update messages

### DIFF
--- a/sematic/plugins/building/BUILD
+++ b/sematic/plugins/building/BUILD
@@ -1,11 +1,19 @@
 sematic_py_lib(
+    name = "docker_client_utils",
+    srcs = ["docker_client_utils.py"],
+    pip_deps = [],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "docker_builder",
-    srcs = ["docker_builder.py", "docker_client_utils.py"],
+    srcs = ["docker_builder.py"],
     pip_deps = [
         "docker",
         "pyyaml",
     ],
     deps = [
+        ":docker_client_utils",
         "//sematic:abstract_plugin",
         "//sematic:container_images",
         "//sematic/plugins:abstract_builder",

--- a/sematic/plugins/building/BUILD
+++ b/sematic/plugins/building/BUILD
@@ -1,6 +1,6 @@
 sematic_py_lib(
     name = "docker_builder",
-    srcs = ["docker_builder.py"],
+    srcs = ["docker_builder.py", "docker_client_utils.py"],
     pip_deps = [
         "docker",
         "pyyaml",

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -13,7 +13,8 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, Generator, List, Optional, TextIO, Tuple
+from multiprocessing import Process
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 # isort: off
 
@@ -35,6 +36,7 @@ from sematic.plugins.abstract_builder import (
     BuildConfigurationError,
     BuildError,
 )
+from sematic.plugins.building.docker_client_utils import _rolling_print_status_updates
 from sematic.utils.env import environment_variables
 from sematic.utils.types import as_bool
 
@@ -64,8 +66,6 @@ _DOCKERFILE_REQUIREMENTS_TEMPLATE = """
 COPY {requirements_file} requirements.txt
 RUN pip3 install --no-cache -r requirements.txt
 """
-
-_ROLLING_PRINT_WINDOW = 10
 
 
 @dataclass
@@ -557,28 +557,14 @@ def _build_image_from_base(
     )
     logger.debug("Using Dockerfile:\n%s", dockerfile_contents)
 
-    # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
-    # of the docker_client, because it does not work with contexts, so operations like
-    # COPY do not work, as there exists no working dir context to copy the targets from
-    # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
-    # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
-    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
-        dockerfile.write(dockerfile_contents)
-        dockerfile.flush()
-
-        optional_kwargs = dict()
-        if build_config.build is not None and build_config.build.platform is not None:
-            optional_kwargs["platform"] = build_config.build.platform
-
-        status_updates = docker_client.api.build(
-            dockerfile=dockerfile.name,
-            # use the project root as the context
-            # TODO: switch from project-relative paths to build file-relative paths
-            path=os.getcwd(),
-            tag=built_image_name,
-            decode=True,
-            **optional_kwargs,
-        )
+    status_updates = _build_from_dockerfile(
+        built_image_name=built_image_name,
+        dockerfile_contents=dockerfile_contents,
+        platform=build_config.build.platform
+        if build_config.build is not None
+        else None,
+        docker_client=docker_client,
+    )
 
     if status_updates is None:
         logger.warning("Built image '%s' without any response", built_image_name)
@@ -596,6 +582,77 @@ def _build_image_from_base(
 
     image = docker_client.images.get(built_image_name)
     return image, ImageURI.from_uri(f"{built_image_name}@{image.id}")
+
+
+def _build_from_dockerfile(
+    built_image_name: str,
+    dockerfile_contents: str,
+    platform: Optional[str],
+    docker_client: docker.DockerClient,  # type: ignore
+) -> Generator[Dict[str, Any], None, None]:
+    """
+    Builds a Docker image starting from Dockerfile contents.
+    """
+    optional_kwargs = dict()
+    if platform is not None:
+        optional_kwargs["platform"] = platform
+
+    # the call to build below is blocking and takes a while
+    # print a spinner in the meantime
+    spinner_process = Process(target=_print_spinner)
+    spinner_process.start()
+
+    # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
+    # of the docker_client, because it does not work with contexts, so operations like
+    # COPY do not work, as there exists no working dir context to copy the targets from
+    # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
+    # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
+        dockerfile.write(dockerfile_contents)
+        dockerfile.flush()
+
+        status_updates = docker_client.api.build(
+            dockerfile=dockerfile.name,
+            # use the project root as the context
+            # TODO: switch from project-relative paths to build file-relative paths
+            path=os.getcwd(),
+            tag=built_image_name,
+            decode=True,
+            **optional_kwargs,
+        )
+
+    spinner_process.terminate()
+    spinner_process.join()
+
+    return status_updates
+
+
+def _print_spinner() -> None:
+    """
+    Prints a spinning character to stdout.
+
+    This is meant to be used in a different process. Execution terminates when the process
+    receives a `SIGTERM` signal.
+    """
+    # Standard Library
+    import signal
+
+    do_spin = True
+
+    def _handler(_: Any, __: Any) -> None:
+        nonlocal do_spin
+        do_spin = False
+
+    signal.signal(signal.SIGTERM, _handler)
+
+    while do_spin:
+        for char in "\\|/-":
+            print(char)
+            time.sleep(0.1)
+            sys.stdout.write("\033[F\033[K")
+            sys.stdout.flush()
+            if not do_spin:
+                break
 
 
 def _generate_dockerfile_contents(
@@ -780,55 +837,6 @@ def _reload_image_uri(image: Image) -> ImageURI:  # type: ignore
     _, tag = image.attrs["RepoTags"][0].split(":")
 
     return ImageURI(repository=repository, tag=tag, digest=digest)
-
-
-def _rolling_print_status_updates(
-    status_updates: Generator[Dict[str, Any], None, None],
-    output_handle: TextIO = sys.stderr,
-) -> Optional[Dict[str, Any]]:
-    """
-    Prints a rolling window of Docker server status message updates.
-    """
-    message_window = []
-
-    for status_update in status_updates:
-        if "error" in status_update.keys():
-            return status_update
-
-        update_str = _docker_status_update_to_str(status_update)
-        if update_str is None:
-            continue
-
-        message_window.append(update_str)
-        if len(message_window) <= _ROLLING_PRINT_WINDOW:
-            print(update_str, file=output_handle)
-        else:
-            message_window = message_window[1:]
-            print(f"\033[{_ROLLING_PRINT_WINDOW + 1}F\033[K[...]", file=output_handle)
-            for message in message_window:
-                print(f"\033[K{message}", file=output_handle)
-
-    return None
-
-
-def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]:
-    """
-    Returns a textual representation of the status update dict received from the Docker
-    server, or None if it was devoid of useful information.
-    """
-    length = len(status_update)
-
-    if length == 0:
-        return None
-
-    if length == 1:
-        k, v = next(iter(status_update.items()))
-        if v is None or len(str(v).strip()) == 0:
-            # only one key with an empty value
-            return None
-        return f"{k}={str(v).strip()}"
-
-    return " ".join(sorted([f"{k}={str(v).strip()}" for k, v in status_update.items()]))
 
 
 def _get_local_image_name(target: str, build_config: BuildConfig) -> str:

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import runpy
+import signal
 import subprocess
 import sys
 import tempfile
@@ -36,7 +37,7 @@ from sematic.plugins.abstract_builder import (
     BuildConfigurationError,
     BuildError,
 )
-from sematic.plugins.building.docker_client_utils import _rolling_print_status_updates
+from sematic.plugins.building.docker_client_utils import rolling_print_status_updates
 from sematic.utils.env import environment_variables
 from sematic.utils.types import as_bool
 
@@ -571,7 +572,7 @@ def _build_image_from_base(
         image = docker_client.images.get(str(effective_base_uri))
         return image, ImageURI.from_uri(f"{built_image_name}@{image.id}")
 
-    error_update = _rolling_print_status_updates(status_updates)
+    error_update = rolling_print_status_updates(status_updates)
     if error_update is not None:
         logger.error(
             "Image build error details: '%s'", str(error_update.get("errorDetail"))
@@ -602,27 +603,30 @@ def _build_from_dockerfile(
     spinner_process = Process(target=_print_spinner)
     spinner_process.start()
 
-    # we have to create a tmp dockerfile and pass it instead of using the `fileobj` option
-    # of the docker_client, because it does not work with contexts, so operations like
-    # COPY do not work, as there exists no working dir context to copy the targets from
-    # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
-    # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
-    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
-        dockerfile.write(dockerfile_contents)
-        dockerfile.flush()
+    try:
+        # we have to create a tmp dockerfile and pass it instead of using the `fileobj`
+        # option of the docker_client, because it does not work with contexts, so
+        # operations like COPY do not work, as there exists no working dir context to copy
+        # the targets from
+        # API: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build
+        # Reported unresolved issue: https://github.com/docker/docker-py/issues/2105
+        with tempfile.NamedTemporaryFile(mode="wt", delete=True) as dockerfile:
+            dockerfile.write(dockerfile_contents)
+            dockerfile.flush()
 
-        status_updates = docker_client.api.build(
-            dockerfile=dockerfile.name,
-            # use the project root as the context
-            # TODO: switch from project-relative paths to build file-relative paths
-            path=os.getcwd(),
-            tag=built_image_name,
-            decode=True,
-            **optional_kwargs,
-        )
+            status_updates = docker_client.api.build(
+                dockerfile=dockerfile.name,
+                # use the project root as the context
+                # TODO: switch from project-relative paths to build file-relative paths
+                path=os.getcwd(),
+                tag=built_image_name,
+                decode=True,
+                **optional_kwargs,
+            )
 
-    spinner_process.terminate()
-    spinner_process.join()
+    finally:
+        spinner_process.terminate()
+        spinner_process.join()
 
     return status_updates
 
@@ -634,9 +638,6 @@ def _print_spinner() -> None:
     This is meant to be used in a different process. Execution terminates when the process
     receives a `SIGTERM` signal.
     """
-    # Standard Library
-    import signal
-
     do_spin = True
 
     def _handler(_: Any, __: Any) -> None:
@@ -806,7 +807,7 @@ def _push_image(
         )
         return _reload_image_uri(image=image)
 
-    error_update = _rolling_print_status_updates(status_updates)
+    error_update = rolling_print_status_updates(status_updates)
     if error_update is not None:
         logger.error(
             "Image push error details: '%s'", str(error_update.get("errorDetail"))

--- a/sematic/plugins/building/docker_client_utils.py
+++ b/sematic/plugins/building/docker_client_utils.py
@@ -10,15 +10,16 @@ _ROLLING_PRINT_COLUMNS = 120
 _ROLLING_PRINT_ROWS = 10
 
 
-def _rolling_print_status_updates(
+def rolling_print_status_updates(
     status_updates: Generator[Dict[str, Any], None, None],
-    output_handle: TextIO = sys.stderr,
+    output_handle: Optional[TextIO] = None,
     columns: int = _ROLLING_PRINT_COLUMNS,
     rows: int = _ROLLING_PRINT_ROWS,
 ) -> Optional[Dict[str, Any]]:
     """
     Prints a rolling window of Docker server status message updates.
     """
+    output_handle = output_handle or sys.stderr
     message_window: List[str] = []
 
     for status_update in status_updates:
@@ -30,23 +31,29 @@ def _rolling_print_status_updates(
         if update_str is None:
             continue
 
-        line_count = len(message_window)
+        # wrap the new status messages and add them to the rolling window
+        previous_line_count = len(message_window)
         for raw_line in update_str.split("\n"):
             wrapped_lines = textwrap.wrap(
                 raw_line, replace_whitespace=False, width=columns
             )
             message_window += wrapped_lines
 
+        # if we don't need to roll the window, then we haven't ever done it; just print
         if len(message_window) <= rows:
-            for message in message_window[line_count:]:
+            for message in message_window[previous_line_count:]:
                 print(message, file=output_handle)
 
+        # we need to roll the window by discarding from the beginning of it,
+        # then printing over the previously-printed text
         else:
             message_window = message_window[-rows:]
             message_window[0] = "[...]"
 
-            print(f"\033[{line_count + 1}F", file=output_handle)
+            # 033[F -> go up
+            print(f"\033[{previous_line_count + 1}F", file=output_handle)
             for message in message_window:
+                # \033[K -> clear line
                 print(f"\033[K{message}", file=output_handle)
 
     return None
@@ -57,16 +64,21 @@ def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]
     Returns a textual representation of the status update dict received from the Docker
     server, or None if it was devoid of useful information.
     """
-    length = len(status_update)
-
-    if length == 0:
+    if len(status_update) == 0:
         return None
 
-    if length == 1:
-        k, v = next(iter(status_update.items()))
-        if v is None or len(str(v).strip()) == 0:
-            # only one key with an empty value
-            return None
-        return str(v).strip()
+    values = []
 
-    return " ".join([str(v).strip() for _, v in sorted(status_update.items())])
+    # always present the values in the same order
+    # (by their keys, even if the keys are not included in the message update)
+    for _, v in sorted(status_update.items()):
+        # skip falsy values, such as empty dicts
+        if v:
+            str_val = str(v).strip()
+            if len(str_val) > 0:
+                values.append(str_val)
+
+    if len(values) == 0:
+        return None
+
+    return " ".join(values)

--- a/sematic/plugins/building/docker_client_utils.py
+++ b/sematic/plugins/building/docker_client_utils.py
@@ -1,0 +1,72 @@
+"""
+Utility code for interacting with the `docker-py` client.
+"""
+# Standard Library
+import sys
+import textwrap
+from typing import Any, Dict, Generator, List, Optional, TextIO
+
+_ROLLING_PRINT_COLUMNS = 120
+_ROLLING_PRINT_ROWS = 10
+
+
+def _rolling_print_status_updates(
+    status_updates: Generator[Dict[str, Any], None, None],
+    output_handle: TextIO = sys.stderr,
+    columns: int = _ROLLING_PRINT_COLUMNS,
+    rows: int = _ROLLING_PRINT_ROWS,
+) -> Optional[Dict[str, Any]]:
+    """
+    Prints a rolling window of Docker server status message updates.
+    """
+    message_window: List[str] = []
+
+    for status_update in status_updates:
+
+        if "error" in status_update.keys():
+            return status_update
+
+        update_str = _docker_status_update_to_str(status_update)
+        if update_str is None:
+            continue
+
+        line_count = len(message_window)
+        for raw_line in update_str.split("\n"):
+            wrapped_lines = textwrap.wrap(
+                raw_line, replace_whitespace=False, width=columns
+            )
+            message_window += wrapped_lines
+
+        if len(message_window) <= rows:
+            for message in message_window[line_count:]:
+                print(message, file=output_handle)
+
+        else:
+            message_window = message_window[-rows:]
+            message_window[0] = "[...]"
+
+            print(f"\033[{line_count + 1}F", file=output_handle)
+            for message in message_window:
+                print(f"\033[K{message}", file=output_handle)
+
+    return None
+
+
+def _docker_status_update_to_str(status_update: Dict[str, Any]) -> Optional[str]:
+    """
+    Returns a textual representation of the status update dict received from the Docker
+    server, or None if it was devoid of useful information.
+    """
+    length = len(status_update)
+
+    if length == 0:
+        return None
+
+    if length == 1:
+        k, v = next(iter(status_update.items()))
+        if v is None or len(str(v).strip()) == 0:
+            # only one key with an empty value
+            return None
+        return str(v).strip()
+
+    return " ".join([str(v).strip() for _, v in sorted(status_update.items())])

--- a/sematic/plugins/building/tests/BUILD
+++ b/sematic/plugins/building/tests/BUILD
@@ -1,6 +1,6 @@
 pytest_test(
     name = "test_docker_builder",
-    srcs = ["test_docker_builder.py"],
+    srcs = ["test_docker_builder.py", "test_docker_client_utils.py"],
     data = glob([
         "fixtures/**",
     ]),

--- a/sematic/plugins/building/tests/BUILD
+++ b/sematic/plugins/building/tests/BUILD
@@ -1,6 +1,18 @@
 pytest_test(
+    name = "test_docker_client_utils",
+    srcs = ["test_docker_client_utils.py"],
+    data = glob([
+        "fixtures/**",
+    ]),
+    pip_deps = ["docker"],
+    deps = [
+        "//sematic/plugins/building:docker_client_utils",
+    ],
+)
+
+pytest_test(
     name = "test_docker_builder",
-    srcs = ["test_docker_builder.py", "test_docker_client_utils.py"],
+    srcs = ["test_docker_builder.py"],
     data = glob([
         "fixtures/**",
     ]),

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -548,17 +548,6 @@ def test_reload_image_uri(mock_image: mock.Mock):
     mock_image.reload.assert_called()
 
 
-def test_docker_status_update_to_str():
-    actual_str = docker_builder._docker_status_update_to_str({})
-    assert actual_str is None
-
-    actual_str = docker_builder._docker_status_update_to_str({"k1": " v1 "})
-    assert actual_str == "k1=v1"
-
-    actual_str = docker_builder._docker_status_update_to_str({"k1": " v1 ", "k2": ""})
-    assert actual_str == "k1=v1 k2="
-
-
 def test_get_local_image_name():
     mock_build_config = mock.Mock(docker_builder.BuildConfig)
 

--- a/sematic/plugins/building/tests/test_docker_client_utils.py
+++ b/sematic/plugins/building/tests/test_docker_client_utils.py
@@ -6,10 +6,18 @@ def test_docker_status_update_to_str():
     actual_str = docker_client_utils._docker_status_update_to_str({})
     assert actual_str is None
 
+    actual_str = docker_client_utils._docker_status_update_to_str({"k1": " ", "k2": ""})
+    assert actual_str is None
+
     actual_str = docker_client_utils._docker_status_update_to_str({"k1": " v1 "})
     assert actual_str == "v1"
 
     actual_str = docker_client_utils._docker_status_update_to_str(
         {"k1": " v1 ", "k2": ""}
     )
-    assert actual_str == "v1 "
+    assert actual_str == "v1"
+
+    actual_str = docker_client_utils._docker_status_update_to_str(
+        {"k3": " v3 ", "k2": "", "k1": {"a": 1}}
+    )
+    assert actual_str == "{'a': 1} v3"

--- a/sematic/plugins/building/tests/test_docker_client_utils.py
+++ b/sematic/plugins/building/tests/test_docker_client_utils.py
@@ -1,0 +1,15 @@
+# Sematic
+from sematic.plugins.building import docker_client_utils
+
+
+def test_docker_status_update_to_str():
+    actual_str = docker_client_utils._docker_status_update_to_str({})
+    assert actual_str is None
+
+    actual_str = docker_client_utils._docker_status_update_to_str({"k1": " v1 "})
+    assert actual_str == "v1"
+
+    actual_str = docker_client_utils._docker_status_update_to_str(
+        {"k1": " v1 ", "k2": ""}
+    )
+    assert actual_str == "v1 "


### PR DESCRIPTION
The Native Docker Build System prints update messages from the Docker Server in a rolling window, but sometimes this window does not correctly reset:
```
Building image and launching: yolo_v5_poc/main.py --tiny-model-test
[...]
[...]
[...]
[...]
[...]
[...]
[...]
[...]
[...]
[...]
[...]
stream=---> e210d40bab91
stream=Step 20/22 : COPY vflow_util/__init__.py vflow_util/__init__.py
stream=---> 4560ef9dbe78
stream=Step 21/22 : COPY vflow_util/argparse.py vflow_util/argparse.py
stream=---> b191bede1f1f
stream=Step 22/22 : COPY vflow_util/vflow_alluxio_fuse.py vflow_util/vflow_alluxio_fuse.py
stream=---> 2e9b7040ef2f
aux={'ID': 'sha256:2e9b7040ef2f9438458410d7fd573cebfdeda83518c49da16e2a0769e418e890'}
stream=Successfully built 2e9b7040ef2f
stream=Successfully tagged yolo_v5_poc:default_yolo_v5_poc
```

This is due to some messages wrapping over to the next line, causing the logic that goes back to overwrite the previous window's contents to miss some message lines.

This PR updates the logic to wrap and control the contents of the rolling message window. It also introduces a spinner character that indicates progress during the initial blocking phase of building an image.

```
2023-05-19 02:55:34,182  [INFO] sematic.plugins.building.docker_builder: Building image 'testing_pipeline:default' starting from base: testing_pipeline:default_main
[...]
---> 3459e536c2c0
Step 9/9 : ENTRYPOINT ["/entrypoint.sh"]
---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)
and no specific platform was requested
---> Running in 224fc4efced7
---> 573afab5ec7c
{'ID': 'sha256:573afab5ec7cc0f094a78062421944146706a659376b0130d4747a8826da113d'}
Successfully built 573afab5ec7c
Successfully tagged testing_pipeline:default
2023-05-19 02:57:58,303  [INFO] sematic.plugins.building.docker_builder: Tagged image 'testing_pipeline:default' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default'
```

![spinner](https://github.com/sematic-ai/sematic/assets/1894533/5a3e8e31-7148-4775-a811-75329362797d)
