### PR TITLE
Add the missing proxy rule.

### DIFF
--- a/sematic/ui/packages/main/src/setupProxy.js
+++ b/sematic/ui/packages/main/src/setupProxy.js
@@ -8,4 +8,5 @@ module.exports = function (app) {
     app.use("/api", proxy);
     app.use("/authenticate", proxy);
     app.use("/login", proxy);
+    app.use("/socket.io", proxy);
 };


### PR DESCRIPTION
Missing this proxy rule disrupts using websocket in local dev scenarios.