### PR TITLE
Add "EE" hint at the top of GitHub docs

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -1,5 +1,10 @@
 # GitHub[^1]
 
+{% hint style="info" %}
+This feature is only available in Sematic
+Enterprise Edition.
+{% endhint %}
+
 ## Summary
 
 At Sematic, we believe testing is crucial to enhancing your development loop, whether


### PR DESCRIPTION
We do this for Ray (see [here](https://docs.sematic.dev/integrations/ray)), and should probably do it here as well to be consistent.