### PR TITLE
[New dashboard] Render and submit notes in the right pane of run details page

### DIFF
--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -1,4 +1,4 @@
-import { Artifact, Edge, Resolution, Run, User } from "src/Models";
+import { Artifact, Edge, Note, Resolution, Run, User } from "src/Models";
 
 export type RunViewPayload = {
     content: Run;
@@ -23,6 +23,25 @@ export type RunGraphPayload = {
     edges: Edge[];
     artifacts: Artifact[];
 };
+
+export type NoteListPayload = {
+    content: Note[];
+    authors: User[];
+};
+
+export type NoteCreateRequestPayload = {
+    note: {
+        author_id: string,
+        note: string,
+        root_id: string,
+        run_id: string,
+    }
+};
+
+export type NoteCreateResponsePayload = {
+    content: Note;
+};
+
 
 export type UserListPayload = {
     content: User[];

--- a/sematic/ui/packages/common/src/component/GitInfo.tsx
+++ b/sematic/ui/packages/common/src/component/GitInfo.tsx
@@ -76,7 +76,7 @@ const GitInfoBox = () => {
         if (isResolutionLoading) {
             return <Skeleton />
         }
-        if (resolution!.git_info_json === undefined) {
+        if (!resolution!.git_info_json) {
             return <GitInfoBoxPresentation hasGitInfo={false} />
         }
         const branchName = resolution!.git_info_json!.branch;

--- a/sematic/ui/packages/common/src/component/Note.tsx
+++ b/sematic/ui/packages/common/src/component/Note.tsx
@@ -30,6 +30,7 @@ const Container = styled(Section, {
 }) <ExtendedStyleProps>`
     min-height: 100px;
     height: ${props => props.isExpanded ? "max-content" : "100px"};
+    padding-left: ${theme.spacing(2.4)};
     padding-bottom: calc(${footerHeight}px);
     box-sizing: border-box;
     position: relative;
@@ -77,6 +78,7 @@ const Footer = styled(Box,  {
     background-image: linear-gradient(rgba(255,255,255,0), ${theme.palette.background.paper} 60%);
 
     & svg {
+        margin-right: ${theme.spacing(2)};
         cursor: pointer;
         transform: ${props => props.isExpanded ? "rotate(180deg)" : "rotate(0deg)"};
         transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;

--- a/sematic/ui/packages/common/src/hooks/noteHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/noteHooks.ts
@@ -1,0 +1,33 @@
+
+import useAsyncRetry from "react-use/lib/useAsyncRetry";
+import useAsyncFn from "react-use/lib/useAsyncFn";
+import { useHttpClient } from "@sematic/common/src/hooks/httpHooks";
+import { NoteCreateRequestPayload, NoteListPayload } from "src/ApiContracts";
+import parseJSON from "date-fns/parseJSON";
+
+export function usePipelineNotes(functionPath: string) {
+    const {fetch} = useHttpClient();
+
+    const {value, retry, ...others} = useAsyncRetry(async () => {
+        const response = await fetch({
+            url: `/api/v1/notes?function_path=${functionPath}`
+        });
+        const notes = (await response.json() as NoteListPayload).content
+        notes.sort((a, b) => parseJSON(b.created_at).getTime() - parseJSON(a.created_at).getTime());
+        return notes;
+    }, [functionPath]);
+
+    return {notes: value, reload: retry, ...others};
+}
+
+export function useNoteSubmission() {
+    const {fetch} = useHttpClient();
+
+    return useAsyncFn(async (note: NoteCreateRequestPayload) => {
+        await fetch({
+            url: "/api/v1/notes",
+            method: "POST",
+            body: note
+        });
+    }, []);
+}

--- a/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
@@ -1,6 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import styled from "@emotion/styled";
 import theme from "src/theme/new";
+import ChevronLeft from "@mui/icons-material/ChevronLeft";
+import ChevronRight from "@mui/icons-material/ChevronRight";
+import IconButton from "@mui/material/IconButton";
+
 
 export const Left = styled.div`
     min-width: 300px;
@@ -25,6 +29,7 @@ const Center = styled.div`
     flex-grow: 1;
     padding: 0 25px;
     border-right: 1px solid ${theme.palette.p3border.main};
+    position: relative;
 `;
 
 export const Right = styled.div`
@@ -43,6 +48,45 @@ export const Container = styled.div`
     display: flex;
 `;
 
+interface UIState {
+    folded: boolean;
+}
+
+export const RightWithState = styled(Right, {
+    shouldForwardProp: (prop) => prop !== "folded",
+}) <UIState>`
+    ${({ folded }) => folded ? "display: none;" : ""}
+`;
+
+const StyledIconButton = styled(IconButton)`
+    border-radius: 0;
+    padding: ${theme.spacing(1)} 0;
+`;
+
+const FoldingControlContainer = styled("div", {
+    shouldForwardProp: (prop) => prop !== "folded",
+}) <UIState>`
+    position: absolute;
+    right: 0;
+    top: 50%;
+    translate: ${({ folded }) => folded ? "0" : "50%"} -50%;
+    opacity: 0.5;
+
+    &:hover {
+        opacity: 1;
+    }
+
+    &:before {
+        background: ${theme.palette.white.main};
+        position: absolute;
+        content: '';
+        top: 5px;
+        left: 5px;
+        right: 5px;
+        bottom: 5px;
+    }
+`;
+
 export interface ThreeColumnsProps {
     onRenderLeft: () => React.ReactNode;
     onRenderCenter: () => React.ReactNode;
@@ -52,6 +96,8 @@ export interface ThreeColumnsProps {
 const ThreeColumns = (props: ThreeColumnsProps) => {
     const { onRenderLeft, onRenderCenter, onRenderRight } = props;
 
+    const [rightPaneFolded, setRightPaneFolded] = useState(false);
+
     const leftPane = useMemo(() => onRenderLeft(), [onRenderLeft]);
     const centerPane = useMemo(() => onRenderCenter(), [onRenderCenter]);
     const rightPane = useMemo(() => onRenderRight(), [onRenderRight]);
@@ -59,8 +105,16 @@ const ThreeColumns = (props: ThreeColumnsProps) => {
     return (
         <Container>
             <Left>{leftPane}</Left>
-            <Center>{centerPane}</Center>
-            <Right >{rightPane}</Right>
+            <Center>{centerPane}
+                <FoldingControlContainer folded={rightPaneFolded} onClick={() => setRightPaneFolded(!rightPaneFolded)}>
+                    <StyledIconButton size="small">
+                        {rightPaneFolded ? <ChevronLeft /> : <ChevronRight />}
+                    </StyledIconButton>
+                </FoldingControlContainer>
+            </Center>
+            <RightWithState folded={rightPaneFolded}>
+                {rightPane}
+            </RightWithState>
         </Container>
     );
 };

--- a/sematic/ui/packages/main/src/Payloads.tsx
+++ b/sematic/ui/packages/main/src/Payloads.tsx
@@ -1,4 +1,4 @@
-import { Artifact, Edge, Job, Note, Resolution, Run, User } from "@sematic/common/src/Models";
+import { Artifact, Edge, Job, Resolution, Run, User } from "@sematic/common/src/Models";
 
 export type RunViewPayload = {
     content: Run;
@@ -42,15 +42,6 @@ export type LogLineResult = {
 
 export type LogLineRequestResponse = {
     content: LogLineResult;
-};
-
-export type NoteListPayload = {
-    content: Note[];
-    authors: User[];
-};
-
-export type NoteCreatePayload = {
-    content: Note;
 };
 
 export type GoogleLoginPayload = {


### PR DESCRIPTION
This PR also uses real data of notes on the run details page. 

![image](https://github.com/sematic-ai/sematic/assets/133257643/4d7472ff-0124-430a-b640-ee56801c2fe2)

Now the note pane can also be folded.