### PR TITLE
Avoid pip resolution bug

### DIFF
--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -51,8 +51,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{{sys.version_info.major}}.{{sys.version_info.minor}}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${{PATH}}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
@@ -62,7 +62,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 _DOCKERFILE_REQUIREMENTS_TEMPLATE = """
 COPY {requirements_file} requirements.txt
-RUN pip3 install --no-cache -r requirements.txt
+RUN pip3 install --no-cache --ignore-installed -r requirements.txt
 """
 
 

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
@@ -12,7 +12,7 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 COPY sematic/plugins/building/tests/fixtures/requirements.txt requirements.txt
-RUN pip3 install --no-cache -r requirements.txt
+RUN pip3 install --no-cache --ignore-installed -r requirements.txt
 
 COPY sematic/plugins/building/tests/fixtures/docker sematic/plugins/building/tests/fixtures/docker
 COPY sematic/plugins/building/tests/fixtures/bad_image_script.sh sematic/plugins/building/tests/fixtures/bad_image_script.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
@@ -12,6 +12,6 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 COPY sematic/plugins/building/tests/fixtures/requirements.txt requirements.txt
-RUN pip3 install --no-cache -r requirements.txt
+RUN pip3 install --no-cache --ignore-installed -r requirements.txt
 
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
@@ -3,8 +3,8 @@ WORKDIR /
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip
 RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
+RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
 
 ENV PATH="/sematic/bin/:${PATH}"
 RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh


### PR DESCRIPTION
Avoids [a bug in `pip`'s resolution algorithm](https://github.com/pypa/pip/issues/10851) by pinning the version.

Stack trace:
```
(venv_test) tudor@ip-10-42-76-65:~/sematic$ sematic run --build sematic/examples/lightning_resnet/main.py -- --cloud
Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
WARNING:sematic.config.config:Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
Building image and launching: sematic/examples/lightning_resnet/main.py --cloud
2023-05-26 10:07:30,060  [INFO] sematic.plugins.building.docker_builder: Building image 'lightning_resnet:default_main_example' starting from base: sematicai/sematic-worker-base:cuda
[...]
    to_install = resolver.get_installation_order(requirement_set)
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/resolver.py", line 188, in
get_installation_order
    weights = get_topological_weights(
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/resolver.py", line 276, in
get_topological_weights
    assert len(weights) == expected_node_count
AssertionError

2023-05-26 10:08:50,036  [ERROR] sematic.plugins.building.docker_builder: Image build error details: '{'code': 2, 'message': "The command '/bin/sh -c pip3 install --no-cache -r requirements.txt' returned a non-zero code: 2"}'
Traceback (most recent call last):
  File "/home/tudor/venv_test/bin/sematic", line 8, in <module>
    sys.exit(cli())
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/cli/run.py", line 114, in run
    builder.build_and_launch(target=script_path)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 126, in build_and_launch
    image_uri = _build(target=target)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 143, in _build
    image, image_uri = _build_image(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 235, in _build_image
    return _build_image_from_base(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 285, in _build_image_from_base
    raise BuildError(
sematic.plugins.abstract_builder.BuildError: Unable to build image 'lightning_resnet:default_main_example': The command '/bin/sh -c pip3 install --no-cache -r requirements.txt' returned a non-zero code: 2
(venv_test) tudor@ip-10-42-76-65:~/sematic$
```

Also fixes two other `pip`-related issues discovered on pipelines which seem to have corner case dependencies that manifest them:

```
(venv_test) tudor@ip-10-42-76-65:~/sematic$ sematic run --build sematic/examples/lightning_resnet/main.py -- --cloud
Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
WARNING:sematic.config.config:Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
Building image and launching: sematic/examples/lightning_resnet/main.py --cloud
2023-05-26 10:26:18,569  [INFO] sematic.plugins.building.docker_builder: Building image 'lightning_resnet:default_main_example' starting from base: sematicai/sematic-worker-base:cuda
[...]
nvidia-cudnn-cu11, jsonschema, Jinja2, gpustat, googleapis-common-protos, gitdb, gevent, botocore, anyio, aiosignal,
starlette, s3transfer, requests-oauthlib, ray, google-auth, GitPython, gevent-websocket, Flask, docker, aiohttp,
kubernetes, google-auth-oauthlib, google-api-core, git-python, Flask-SocketIO, Flask-Cors, fastapi, boto3, aiohttp-cors,
tensorboard, opencensus, triton, torch, torchvision, torchmetrics, sematic, pytorch-lightning, ray-lightning
Attempting uninstall: blinker
Found existing installation: blinker 1.4
ERROR: Cannot uninstall 'blinker'. It is a distutils installed project and thus we cannot accurately determine
which files belong to it which would lead to only a partial uninstall.

2023-05-26 10:29:08,320  [ERROR] sematic.plugins.building.docker_builder: Image build error details: '{'code': 1, 'message': "The command '/bin/sh -c pip3 install --no-cache -r requirements.txt' returned a non-zero code: 1"}'
Traceback (most recent call last):
  File "/home/tudor/venv_test/bin/sematic", line 8, in <module>
    sys.exit(cli())
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/cli/run.py", line 114, in run
    builder.build_and_launch(target=script_path)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 126, in build_and_launch
    image_uri = _build(target=target)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 143, in _build
    image, image_uri = _build_image(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 235, in _build_image
    return _build_image_from_base(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 285, in _build_image_from_base
    raise BuildError(
sematic.plugins.abstract_builder.BuildError: Unable to build image 'lightning_resnet:default_main_example': The command '/bin/sh -c pip3 install --no-cache -r requirements.txt' returned a non-zero code: 1
(venv_test) tudor@ip-10-42-76-65:~/sematic$
```

```
(venv_test) tudor@ip-10-42-76-65:~/sematic$ sematic run --build sematic/examples/testing_pipeline/__main__.py -- --cloud
Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
WARNING:sematic.config.config:Sematic will soon require the sqlite3 version to be at least 3.38.0, but your Python is using 3.37.2. Please upgrade. You may find this useful: https://stackoverflow.com/a/55729735/2540669
Building image and launching: sematic/examples/testing_pipeline/__main__.py --cloud
2023-05-26 11:17:50,588  [INFO] sematic.plugins.building.docker_builder: Building image 'testing_pipeline:default_main_example' starting from base: sematicai/sematic-worker-base:latest
[...]
    from pip._internal.locations import get_major_minor_version
  File "/usr/lib/python3/dist-packages/pip/_internal/locations/__init__.py", line 14, in <module>

    from . import _distutils, _sysconfig
  File "/usr/lib/python3/dist-packages/pip/_internal/locations/_distutils.py", line 9, in <module>

    from distutils.cmd import Command as DistutilsCommand
ModuleNotFoundError: No module named 'distutils.cmd'

2023-05-26 11:19:28,931  [ERROR] sematic.plugins.building.docker_builder: Image build error details: '{'code': 1, 'message': "The command '/bin/sh -c which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2' returned a non-zero code: 1"}'
Traceback (most recent call last):
  File "/home/tudor/venv_test/bin/sematic", line 8, in <module>
    sys.exit(cli())
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/cli/run.py", line 114, in run
    builder.build_and_launch(target=script_path)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 126, in build_and_launch
    image_uri = _build(target=target)
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 143, in _build
    image, image_uri = _build_image(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 235, in _build_image
    return _build_image_from_base(
  File "/home/tudor/venv_test/lib/python3.10/site-packages/sematic/plugins/building/docker_builder.py", line 285, in _build_image_from_base
    raise BuildError(
sematic.plugins.abstract_builder.BuildError: Unable to build image 'testing_pipeline:default_main_example': The command '/bin/sh -c which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2' returned a non-zero code: 1
(venv_test) tudor@ip-10-42-76-65:~/sematic$
```
