### PR TITLE
[8/N] Store run command and build config

### DIFF
--- a/sematic/cli/run.py
+++ b/sematic/cli/run.py
@@ -88,6 +88,7 @@ def run(build: bool, log_level: str, script_path: str, script_arguments: Tuple[s
     # ensure the server is reachable before doing all the work
     validate_server_compatibility(use_cached=False)
 
+    run_command = " ".join(sys.argv)
     # This is ugly, better way to do this?
     sys.argv = [script_path] + list(script_arguments)
     pseudo_command = " ".join(sys.argv)
@@ -111,7 +112,7 @@ def run(build: bool, log_level: str, script_path: str, script_arguments: Tuple[s
 
     click.echo(f"Building image and launching: {pseudo_command}")
     start_time = time.time()
-    builder.build_and_launch(target=script_path)
+    builder.build_and_launch(target=script_path, run_command=run_command)
     stop_time = time.time()
 
     duration_seconds = math.floor((stop_time - start_time) * 100) / 100.0

--- a/sematic/db/migrations/20230526141354_add_run_command_and_config_to_resolutions.sql
+++ b/sematic/db/migrations/20230526141354_add_run_command_and_config_to_resolutions.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE resolutions ADD COLUMN run_command TEXT;
+ALTER TABLE resolutions ADD COLUMN build_config TEXT;
+
+-- migrate:down
+
+-- TODO #302: implement sustainable way to upgrade sqlite3 DBs
+-- ALTER TABLE resolutions DROP COLUMN run_command;
+-- ALTER TABLE resolutions ADD COLUMN build_config;

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -145,6 +145,8 @@ def clone_resolution(resolution: Resolution, root_id: str) -> Resolution:
         cache_namespace=resolution.cache_namespace,
         # the user_id is overwritten on the API call based on the user's API key
         user_id=None,
+        run_command=resolution.run_command,
+        build_config=resolution.build_config,
     )
 
     # Set this outside the constructor because the constructor expects

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -182,6 +182,10 @@ class Resolution(HasUserMixin, Base, JSONEncodableMixin):
         be cached, as long as they also have the `cache` flag activated.
     user_id:
         User who submitted this resolution.
+    run_command:
+        The CLI command used to launch this resolution, if applicable.
+    build_config:
+        The configuration used to build the pipeline container image, if applicable.
     """
 
     __tablename__ = "resolutions"
@@ -205,12 +209,14 @@ class Resolution(HasUserMixin, Base, JSONEncodableMixin):
     # we consider this field to be immutable, so we will just re-use
     # whatever was already in the DB for it
     settings_env_vars: Dict[str, str] = Column(
-        types.JSON, nullable=False, default=lambda: {}, info={REDACTED_KEY: True}
+        types.JSON(), nullable=False, default=lambda: {}, info={REDACTED_KEY: True}
     )
     container_image_uris: Optional[Dict[str, str]] = Column(types.JSON(), nullable=True)
     container_image_uri: Optional[str] = Column(types.String(), nullable=True)
     client_version: Optional[str] = Column(types.String(), nullable=True)
     cache_namespace: Optional[str] = Column(types.String(), nullable=True)
+    run_command: Optional[str] = Column(types.String(), nullable=True)
+    build_config: Optional[str] = Column(types.String(), nullable=True)
 
     @validates("status")
     def validate_status(self, key, value) -> str:

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -206,6 +206,11 @@ def test_clone_resolution(resolution: Resolution):  # noqa: F811
     assert cloned_resolution.settings_env_vars == resolution.settings_env_vars
     assert cloned_resolution.container_image_uri == resolution.container_image_uri
     assert cloned_resolution.container_image_uris == resolution.container_image_uris
+    assert cloned_resolution.client_version == resolution.client_version
+    assert cloned_resolution.cache_namespace == resolution.cache_namespace
+    assert cloned_resolution.user_id == resolution.user_id
+    assert cloned_resolution.run_command == resolution.run_command
+    assert cloned_resolution.build_config == resolution.build_config
 
 
 def test_new():

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -43,7 +43,7 @@ CREATE TABLE resolutions (
     status TEXT NOT NULL,
     kind TEXT NOT NULL,
     container_image_uri TEXT,
-    settings_env_vars JSONB NOT NULL, external_jobs_json JSONB, git_info_json JSONB, container_image_uris JSONB, client_version TEXT, cache_namespace TEXT, user_id character(32) REFERENCES users(id),
+    settings_env_vars JSONB NOT NULL, external_jobs_json JSONB, git_info_json JSONB, container_image_uris JSONB, client_version TEXT, cache_namespace TEXT, user_id character(32) REFERENCES users(id), run_command TEXT, build_config TEXT,
 
     PRIMARY KEY (root_id),
     FOREIGN KEY (root_id) REFERENCES runs(id)
@@ -173,4 +173,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20230324182512'),
   ('20230403153220'),
   ('20230419080554'),
-  ('20230428225443');
+  ('20230428225443'),
+  ('20230526141354');

--- a/sematic/db/tests/fixtures.py
+++ b/sematic/db/tests/fixtures.py
@@ -174,6 +174,8 @@ def make_resolution(**kwargs) -> Resolution:
         container_image_uri="some.uri",
         settings_env_vars={"MY_SETTING": "MY_VALUE"},
         user_id=None,
+        run_command="sematic run my_pipeline.py",
+        build_config='version: 1\nbase_uri: "a:b@c"',
     )
 
     # Set this outside the constructor because the constructor expects

--- a/sematic/plugins/abstract_builder.py
+++ b/sematic/plugins/abstract_builder.py
@@ -4,11 +4,15 @@ code and builds container images that can be used to execute the user's funcs.
 """
 # Standard Library
 import abc
-from typing import Type, cast
+import os
+from typing import Optional, Type, cast
 
 # Sematic
 from sematic.abstract_plugin import AbstractPlugin, PluginScope
 from sematic.config.settings import get_active_plugins
+
+RUN_COMMAND_ENV_VAR = "SEMATIC_CLI_RUN_COMMAND"
+BUILD_CONFIG_ENV_VAR = "SEMATIC_IMAGE_BUILD_CONFIG"
 
 
 class BuildError(Exception):
@@ -33,7 +37,7 @@ class AbstractBuilder(AbstractPlugin):
     """
 
     @abc.abstractmethod
-    def build_and_launch(self, target: str) -> None:
+    def build_and_launch(self, target: str, run_command: Optional[str]) -> None:
         """
         Builds a container image and launches the specified target launch script.
 
@@ -42,6 +46,8 @@ class AbstractBuilder(AbstractPlugin):
         target: str
             The path to the pipeline target to launch; the built image must support this
             target's execution.
+        run_command: Optional[str]
+            The CLI command used to launch the pipeline, if applicable.
         """
 
         pass
@@ -62,3 +68,18 @@ def get_builder_plugin(default: Type[AbstractPlugin]) -> Type[AbstractBuilder]:
 
     builder_class = cast(Type[AbstractBuilder], builder_plugins[0])
     return builder_class
+
+
+def get_run_command() -> Optional[str]:
+    """
+    Returns the CLI command used to launch the currently-executing pipeline, if any.
+    """
+    return os.environ.get(RUN_COMMAND_ENV_VAR)
+
+
+def get_build_config() -> Optional[str]:
+    """
+    Returns the configuration used to build the currently-executing pipeline container
+    image, if any.
+    """
+    return os.environ.get(BUILD_CONFIG_ENV_VAR)

--- a/sematic/plugins/building/docker_builder_config.py
+++ b/sematic/plugins/building/docker_builder_config.py
@@ -429,6 +429,13 @@ class BuildConfig:
         build_configs = map(cls.load_build_config_file, build_config_files)
         return functools.reduce(lambda c1, c2: c1.merge(c2), build_configs)
 
+    def __repr__(self):
+        """
+        Returns the complete textual representation of this configuration, as it would
+        appear in a configuration file.
+        """
+        return yaml.dump(asdict(self), Dumper=yaml.Dumper)
+
 
 def load_build_config(script_path: str) -> BuildConfig:
     """

--- a/sematic/plugins/building/tests/fixtures/good_launch_script.py
+++ b/sematic/plugins/building/tests/fixtures/good_launch_script.py
@@ -8,12 +8,18 @@ if __name__ == "__main__":
     # we expect to have the SEMATIC_CONTAINER_IMAGE env var set, as that's what the
     # Runner uses to specify the K8 pod image
     image_uri = os.getenv("SEMATIC_CONTAINER_IMAGE")
+    # we expect to have the SEMATIC_CLI_RUN_COMMAND env var set
+    run_command = os.getenv("SEMATIC_CLI_RUN_COMMAND")
+    # we expect to have the SEMATIC_IMAGE_BUILD_CONFIG env var set
+    build_config = os.getenv("SEMATIC_IMAGE_BUILD_CONFIG")
     # we expect to be called with the name of a tmp file where to write the value of the
     # SEMATIC_CONTAINER_IMAGE env var
     tmp_file = sys.argv[1]
 
     # mypy picks up this file
     assert image_uri is not None
+    assert run_command is not None
+    assert build_config is not None
 
     with open(tmp_file, "wt") as f:
-        f.write(image_uri)
+        f.writelines([image_uri, "\n", run_command, "\n", build_config])

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -28,6 +28,7 @@ sematic_py_lib(
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",
         "//sematic/db/models:run",
+        "//sematic/plugins:abstract_builder",
         "//sematic/resolvers:abstract_resource_manager",
         "//sematic/resolvers/resource_managers:server_manager",
         "//sematic/utils:exceptions",

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -26,6 +26,7 @@ from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.graph import Graph, RerunMode
+from sematic.plugins.abstract_builder import get_build_config, get_run_command
 from sematic.resolvers.resource_managers.server_manager import ServerResourceManager
 from sematic.resolvers.silent_resolver import SilentResolver
 from sematic.utils.exceptions import ExceptionMetadata, format_exception_for_run
@@ -368,6 +369,8 @@ class LocalResolver(SilentResolver):
             cache_namespace=self._cache_namespace_str,
             # the user_id is overwritten on the API call based on the user's API key
             user_id=None,
+            run_command=get_run_command(),
+            build_config=get_build_config(),
         )
 
         return resolution

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -67,6 +67,8 @@ def resolution(run):
         ),
         settings_env_vars={"SOME_ENV_VAR": "some_value"},
         client_version=CURRENT_VERSION_STR,
+        run_command="sematic run my_pipeline.py",
+        build_config='version: 1\nbase_uri: "a:b@c"',
     )
 
 


### PR DESCRIPTION
This is the eight PR in a chain that introduces a Build System plugin with an implementation that uses native Python+Docker capabilities to build a container image and launch a pipeline, without requiring Bazel. The previous PR in the chain is #850.

This PR stores the CLI run command and the build configuration object text that were used to launch a pipeline in the database, in the `resolutions` table. At a later date, these will be exposed in the Dashboard.

## Testing

Existing unit and integration tests are updated to cover the new functionality. Some previously-missing checks are also filled in.

### Manual Test

**Submit a pipeline:**

```
(venv_test) tudor@ip-10-42-76-65:~/example_docker$ sematic run --build --log-level=debug intermediate/main.py -- /intermediate/data/message.txt
[...]
db1e7e69f55c42cfb4c666cabfc0fec9
2023-05-30 11:31:54,620  [DEBUG] sematic.plugins.building.docker_builder: Finished launching target: 'intermediate/main.py'
Built and launched 'intermediate/main.py' in 28.5s
```

**Result:**

```
tudor@ip-10-42-76-65:~/sematic$ curl -H "X-API-KEY: XXX" https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/resolutions/db1e7e69f55c42cfb4c666cabfc0fec9
{
  "content": {
    "build_config": "base_uri:\n  digest: sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c\n  repository: sematicai/sematic-worker-base\n  tag: latest\nbuild:\n  data:\n  - intermediate/data/message.txt\n  - sematic-0.29.0-py3-none-any.whl\n  platform: linux/amd64\n  requirements: requirements.txt\n  src:\n  - intermediate/**.py\ndocker: null\nimage_script: null\npush:\n  registry: 558717131297.dkr.ecr.us-west-2.amazonaws.com\n  repository: sematic-dev\n  tag_suffix: example_docker_intermediate\nversion: 1\n",
    "cache_namespace": null,
    "client_version": "0.29.0",
    "container_image_uri": "558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:4daf210f4b03471f5163db84d6533bac6d6a10e39840a3f486b3a8ae9908c574",
    "container_image_uris": {
      "default": "558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:4daf210f4b03471f5163db84d6533bac6d6a10e39840a3f486b3a8ae9908c574"
    },
    "git_info_json": {
      "branch": "tudor/bump-version-foruser-access",
      "commit": "3781be942ca10dfd860de11d14359c5dd63dda20",
      "dirty": true,
      "remote": "git@github.com:sematic-ai/example_docker.git"
    },
    "kind": "KUBERNETES",
    "root_id": "db1e7e69f55c42cfb4c666cabfc0fec9",
    "run_command": "/home/tudor/venv_test/bin/sematic run --build --log-level=debug intermediate/main.py -- /intermediate/data/message.txt",
    "settings_env_vars": {},
    "status": "COMPLETE",
    "user": {
      "avatar_url": "XXX",
      "created_at": "2023-03-06T23:11:33.337619+00:00",
      "first_name": "Tudor",
      "id": "XXX",
      "last_name": "Scurtu",
      "updated_at": "2023-03-06T23:11:33.337627+00:00"
    },
    "user_id": "XXX"
  }
}
```

(artificially formatted & redacted)
