### PR TITLE
Disable Docker updates rolling window on DEBUG level

### DIFF
--- a/sematic/plugins/building/BUILD
+++ b/sematic/plugins/building/BUILD
@@ -28,5 +28,6 @@ sematic_py_lib(
         "//sematic:container_images",
         "//sematic/plugins:abstract_builder",
         "//sematic/utils:env",
+        "//sematic/utils:spinner",
     ],
 )

--- a/sematic/plugins/building/docker_client_utils.py
+++ b/sematic/plugins/building/docker_client_utils.py
@@ -2,9 +2,12 @@
 Utility code for interacting with the `docker-py` client.
 """
 # Standard Library
+import logging
 import sys
 import textwrap
 from typing import Any, Dict, Generator, List, Optional, TextIO
+
+logger = logging.getLogger(__name__)
 
 _ROLLING_PRINT_COLUMNS = 120
 _ROLLING_PRINT_ROWS = 10
@@ -18,9 +21,13 @@ def rolling_print_status_updates(
 ) -> Optional[Dict[str, Any]]:
     """
     Prints a rolling window of Docker server status message updates.
+
+    This behavior is deactivated if the logging level is `DEBUG`, in which case all the
+    messages are kept.
     """
     output_handle = output_handle or sys.stderr
     message_window: List[str] = []
+    debugging = logger.isEnabledFor(logging.DEBUG)
 
     for status_update in status_updates:
 
@@ -29,6 +36,11 @@ def rolling_print_status_updates(
 
         update_str = _docker_status_update_to_str(status_update)
         if update_str is None:
+            continue
+
+        if debugging:
+            # disable the rolling window
+            print(update_str, file=output_handle)
             continue
 
         # wrap the new status messages and add them to the rolling window

--- a/sematic/utils/BUILD
+++ b/sematic/utils/BUILD
@@ -73,6 +73,12 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "spinner",
+    srcs = ["spinner.py"],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "stdout",
     srcs = ["stdout.py"],
     deps = [],

--- a/sematic/utils/spinner.py
+++ b/sematic/utils/spinner.py
@@ -1,0 +1,58 @@
+# Standard Library
+import signal
+import sys
+import time
+from contextlib import contextmanager
+from multiprocessing import Process
+from typing import Any
+
+
+@contextmanager
+def with_stdout_spinner():
+    """
+    Prints a spinning character to stdout while execution is inside this context.
+    """
+    spinner_process = None
+
+    try:
+        spinner_process = Process(target=_print_spinner)
+        spinner_process.start()
+
+        yield
+
+    finally:
+        if spinner_process is not None:
+            try:
+
+                spinner_process.terminate()
+                spinner_process.join(timeout=5)
+                if spinner_process.is_alive():
+                    spinner_process.kill()
+
+            except Exception:
+                pass
+
+
+def _print_spinner() -> None:
+    """
+    Prints a spinning character to stdout.
+
+    This is meant to be used in a different process. Execution terminates when the process
+    receives a `SIGTERM` signal.
+    """
+    do_spin = True
+
+    def _handler(_: Any, __: Any) -> None:
+        nonlocal do_spin
+        do_spin = False
+
+    signal.signal(signal.SIGTERM, _handler)
+
+    while do_spin:
+        for char in "\\|/-":
+            print(char)
+            time.sleep(0.1)
+            sys.stdout.write("\033[F\033[K")
+            sys.stdout.flush()
+            if not do_spin:
+                break


### PR DESCRIPTION
When passing the `--log-level=debug` parameter to the Native Docker Build System, this update deactivates the rolling window feature so that all update messages can be seen after during execution. This also simplifies any log files that are `tee`'d during execution, as they will not be interleaved with non-human readable deletion characters.

This also extracts printing the spinner character while waiting on a reply from the Docker server to a context manager for syntactic sugar, and also propagates it to waiting for pushing the image, not only while waiting for building it.

## Sample Usages

**No debug:**

```
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$ sematic run --build intermediate/main.py -- /intermediate/data/message.txt
Building image and launching: intermediate/main.py /intermediate/data/message.txt
2023-05-30 07:08:35,271  [INFO] sematic.plugins.building.docker_builder: Building image 'intermediate:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
[...]
Step 13/15 : COPY intermediate/__init__.py intermediate/__init__.py
---> a3d28b612823
Step 14/15 : COPY intermediate/main.py intermediate/main.py
---> ad8a740fc8e4
Step 15/15 : COPY intermediate/pipeline.py intermediate/pipeline.py
---> 0416029a6269
{'ID': 'sha256:0416029a6269f20260b1f3ef365896b8fb9539877057412e9069d30413d35df6'}
Successfully built 0416029a6269
Successfully tagged intermediate:default_example_docker_intermediate
2023-05-30 07:12:00,816  [INFO] sematic.plugins.building.docker_builder: Tagged image 'intermediate:default_example_docker_intermediate' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_intermediate'
[...]
0e4ff9e78c23 [==================================================>]  329.6MB {'current': 329643225, 'total': 324982812}
Pushing
0e4ff9e78c23 [==================================================>]    332MB {'current': 332036096, 'total': 324982812}
Pushing
0e4ff9e78c23 Pushed
default_example_docker_intermediate: digest: sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c
size: 5131
{'Tag': 'default_example_docker_intermediate', 'Digest':
'sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c', 'Size': 5131}
2023-05-30 07:12:29,783  [INFO] sematic.plugins.building.docker_builder: Launching target: 'intermediate/main.py'
a324563f7e164982b600a3dd2fcba095
Built and launched 'intermediate/main.py' in 242.28s
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$
```

**Debug:**

```
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$ sematic run --build --log-level=debug intermediate/main.py -- /intermediate/data/message.txt
2023-05-30 07:13:02,710  [DEBUG] sematic.api_client: Constructed server url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/meta/versions
2023-05-30 07:13:03,360  [DEBUG] sematic.api_client: Sematic client 0.29.0 is compatible with server 0.29.0
Building image and launching: intermediate/main.py /intermediate/data/message.txt
2023-05-30 07:13:03,361  [DEBUG] sematic.plugins.building.docker_builder_config: Script 'intermediate/main.py' has these corresponding build files: ['intermediate/main.yaml']
2023-05-30 07:13:03,366  [DEBUG] sematic.plugins.building.docker_builder: Loaded build configuration: BuildConfig(version=1, image_script=None, base_uri=sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c, build=SourceBuildConfig(platform='linux/amd64', requirements='requirements.txt', data=['intermediate/data/message.txt'], src=['intermediate/**.py']), push=ImagePushConfig(registry='558717131297.dkr.ecr.us-west-2.amazonaws.com', repository='sematic-dev', tag_suffix='example_docker_intermediate'), docker=None)
2023-05-30 07:13:03,453  [DEBUG] sematic.plugins.building.docker_builder: Instantiated docker client for server: http+docker://localhost
2023-05-30 07:13:03,454  [INFO] sematic.plugins.building.docker_builder: Building image 'intermediate:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
2023-05-30 07:13:03,454  [DEBUG] sematic.plugins.building.docker_builder: Adding requirements file: requirements.txt
2023-05-30 07:13:03,454  [DEBUG] sematic.plugins.building.docker_builder: Adding data files: ['intermediate/data/message.txt']
2023-05-30 07:13:03,454  [DEBUG] sematic.plugins.building.docker_builder: Adding source files: ['intermediate/**.py']
2023-05-30 07:13:03,455  [DEBUG] sematic.plugins.building.docker_builder: Using Dockerfile:
FROM sematicai/sematic-worker-base:latest
WORKDIR /

RUN apt-get update && apt-get install -y --no-install-recommends apt-utils

RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2

ENV PATH="/sematic/bin/:${PATH}"
RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
RUN chmod +x /entrypoint.sh
ENTRYPOINT ["/entrypoint.sh"]

COPY requirements.txt requirements.txt
RUN pip3 install --no-cache --ignore-installed -r requirements.txt

COPY intermediate/data/message.txt intermediate/data/message.txt

COPY intermediate/__init__.py intermediate/__init__.py
COPY intermediate/main.py intermediate/main.py
COPY intermediate/pipeline.py intermediate/pipeline.py
Step 1/15 : FROM sematicai/sematic-worker-base:latest
---> 99fcf4928f3b
Step 2/15 : WORKDIR /
---> Using cache
---> 8c2ecddd3fef
Step 3/15 : RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
---> Using cache
---> 02799410323f
Step 4/15 : RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
---> Using cache
---> 48e46963b635
Step 5/15 : RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
---> Using cache
---> 78cc1585e4c9
Step 6/15 : ENV PATH="/sematic/bin/:${PATH}"
---> Using cache
---> 819b88d72271
Step 7/15 : RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
---> Using cache
---> a1ea1da8873d
Step 8/15 : RUN chmod +x /entrypoint.sh
---> Using cache
---> 4fd94653cb1d
Step 9/15 : ENTRYPOINT ["/entrypoint.sh"]
---> Using cache
---> 5d0701152218
Step 10/15 : COPY requirements.txt requirements.txt
---> Using cache
---> adfe20bd8366
Step 11/15 : RUN pip3 install --no-cache --ignore-installed -r requirements.txt
---> Using cache
---> cd0963c8554f
Step 12/15 : COPY intermediate/data/message.txt intermediate/data/message.txt
---> Using cache
---> 42e8c3777f22
Step 13/15 : COPY intermediate/__init__.py intermediate/__init__.py
---> Using cache
---> a3d28b612823
Step 14/15 : COPY intermediate/main.py intermediate/main.py
---> Using cache
---> ad8a740fc8e4
Step 15/15 : COPY intermediate/pipeline.py intermediate/pipeline.py
---> Using cache
---> 0416029a6269
{'ID': 'sha256:0416029a6269f20260b1f3ef365896b8fb9539877057412e9069d30413d35df6'}
Successfully built 0416029a6269
Successfully tagged intermediate:default_example_docker_intermediate
2023-05-30 07:13:06,434  [DEBUG] sematic.plugins.building.docker_builder: Built local image: intermediate:default_example_docker_intermediate@sha256:0416029a6269f20260b1f3ef365896b8fb9539877057412e9069d30413d35df6
2023-05-30 07:13:06,439  [INFO] sematic.plugins.building.docker_builder: Tagged image 'intermediate:default_example_docker_intermediate' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_intermediate'
The push refers to repository [558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev]
9cd9fdba08d4 Preparing
93f161512a38 Preparing
9f6ca2594933 Preparing
bc6e7f0e210a Preparing
0fc2e8992ae7 Preparing
b826f9d02a82 Preparing
bd70815a0bc2 Preparing
b23b50a7a0c2 Preparing
b826f9d02a82 Waiting
bd70815a0bc2 Waiting
b23b50a7a0c2 Waiting
0e4ff9e78c23 Preparing
95c796f02ce6 Preparing
4187e5bd0e6b Preparing
88606090f580 Preparing
48c32d9bdc4d Preparing
c4cc4bb05252 Preparing
fb265646f04f Preparing
9e5b01064a07 Preparing
26aa9c02e99e Preparing
2b42b338bc03 Preparing
dd2937225788 Preparing
34200e553ba3 Preparing
69e041190553 Preparing
af4418d96ca6 Preparing
e59fc9495612 Preparing
0e4ff9e78c23 Waiting
48c32d9bdc4d Waiting
95c796f02ce6 Waiting
c4cc4bb05252 Waiting
4187e5bd0e6b Waiting
fb265646f04f Waiting
9e5b01064a07 Waiting
88606090f580 Waiting
69e041190553 Waiting
26aa9c02e99e Waiting
af4418d96ca6 Waiting
2b42b338bc03 Waiting
e59fc9495612 Waiting
dd2937225788 Waiting
34200e553ba3 Waiting
0fc2e8992ae7 Layer already exists
9f6ca2594933 Layer already exists
bc6e7f0e210a Layer already exists
93f161512a38 Layer already exists
9cd9fdba08d4 Layer already exists
b826f9d02a82 Layer already exists
bd70815a0bc2 Layer already exists
0e4ff9e78c23 Layer already exists
95c796f02ce6 Layer already exists
b23b50a7a0c2 Layer already exists
4187e5bd0e6b Layer already exists
88606090f580 Layer already exists
c4cc4bb05252 Layer already exists
fb265646f04f Layer already exists
48c32d9bdc4d Layer already exists
26aa9c02e99e Layer already exists
34200e553ba3 Layer already exists
9e5b01064a07 Layer already exists
2b42b338bc03 Layer already exists
dd2937225788 Layer already exists
af4418d96ca6 Layer already exists
69e041190553 Layer already exists
e59fc9495612 Layer already exists
default_example_docker_intermediate: digest: sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c size: 5131
{'Tag': 'default_example_docker_intermediate', 'Digest': 'sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c', 'Size': 5131}
2023-05-30 07:13:13,616  [DEBUG] sematic.plugins.building.docker_builder: Using image: 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c
2023-05-30 07:13:13,618  [INFO] sematic.plugins.building.docker_builder: Launching target: 'intermediate/main.py'
2023-05-30 07:13:13,636  [DEBUG] sematic.resolvers.local_resolver: Created run 9b25274b3721473fabab7ba2623282de for intermediate.pipeline.pipeline
2023-05-30 07:13:13,637  [DEBUG] sematic.api_client: Constructed server url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/storage/artifacts/0cee82332bd3642cc54d99a77f37c8746c21125e/location?origin=https://tudor.dev-usw2-sematic0.sematic.cloud
2023-05-30 07:13:14,794  [DEBUG] sematic.api_client: [_get] Got response with raw content: b'{XXX}\n'
2023-05-30 07:13:15,661  [DEBUG] sematic.resolvers.local_resolver: Created artifact 'data_file_path' with id 0cee82332bd3642cc54d99a77f37c8746c21125e for run 9b25274b3721473fabab7ba2623282de
2023-05-30 07:13:15,662  [DEBUG] sematic.api_client: Constructed server url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/graph
2023-05-30 07:13:16,351  [DEBUG] sematic.api_client: [_put] Got response with raw content: b'{}\n'
2023-05-30 07:13:16,351  [DEBUG] sematic.api_client: Notifying update: namespace=graph; event=update; payload={'run_id': '9b25274b3721473fabab7ba2623282de'}
2023-05-30 07:13:16,351  [DEBUG] sematic.api_client: Constructed socketio url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/events/graph/update
2023-05-30 07:13:16,992  [DEBUG] sematic.api_client: [_post] Got response with raw content: b'{}\n'
2023-05-30 07:13:16,992  [DEBUG] sematic.resolvers.local_resolver: The Resolution is not configured to use cached values
2023-05-30 07:13:17,094  [DEBUG] git.cmd: Popen(['git', 'version'], cwd=/Users/tudorscurtu/work/example_docker, universal_newlines=False, shell=None, istream=None)
2023-05-30 07:13:17,129  [DEBUG] git.cmd: Popen(['git', 'version'], cwd=/Users/tudorscurtu/work/example_docker, universal_newlines=False, shell=None, istream=None)
2023-05-30 07:13:17,148  [DEBUG] sematic.utils.git: Found source path for <function pipeline at 0x16bb98700>: '/Users/tudorscurtu/work/example_docker/intermediate/pipeline.py'
2023-05-30 07:13:17,148  [DEBUG] sematic.utils.git: Trying source path of specified object: /Users/tudorscurtu/work/example_docker/intermediate/pipeline.py
2023-05-30 07:13:17,157  [DEBUG] sematic.utils.git: Found git repo in '/Users/tudorscurtu/work/example_docker/.git'
2023-05-30 07:13:17,158  [DEBUG] git.cmd: Popen(['git', 'cat-file', '--batch-check'], cwd=/Users/tudorscurtu/work/example_docker, universal_newlines=False, shell=None, istream=<valid stream>)
2023-05-30 07:13:17,177  [DEBUG] git.cmd: Popen(['git', 'diff', '--cached', '--abbrev=40', '--full-index', '--raw'], cwd=/Users/tudorscurtu/work/example_docker, universal_newlines=False, shell=None, istream=None)
2023-05-30 07:13:17,197  [DEBUG] git.cmd: Popen(['git', 'diff', '--abbrev=40', '--full-index', '--raw'], cwd=/Users/tudorscurtu/work/example_docker, universal_newlines=False, shell=None, istream=None)
2023-05-30 07:13:17,212  [DEBUG] sematic.api_client: Constructed server url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/resolutions/9b25274b3721473fabab7ba2623282de
2023-05-30 07:13:17,869  [DEBUG] sematic.api_client: [_put] Got response with raw content: b'{}\n'
2023-05-30 07:13:17,870  [DEBUG] sematic.api_client: Notifying update: namespace=pipeline; event=update; payload={'function_path': 'intermediate.pipeline.pipeline'}
2023-05-30 07:13:17,870  [DEBUG] sematic.api_client: Constructed socketio url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/events/pipeline/update
2023-05-30 07:13:18,489  [DEBUG] sematic.api_client: [_post] Got response with raw content: b'{}\n'
2023-05-30 07:13:18,490  [DEBUG] sematic.api_client: Notifying update: namespace=pipeline; event=update; payload={'function_path': 'intermediate.pipeline.pipeline'}
2023-05-30 07:13:18,490  [DEBUG] sematic.api_client: Constructed socketio url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/events/pipeline/update
2023-05-30 07:13:19,122  [DEBUG] sematic.api_client: [_post] Got response with raw content: b'{}\n'
2023-05-30 07:13:19,123  [DEBUG] sematic.api_client: Constructed server url: https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/resolutions/9b25274b3721473fabab7ba2623282de/schedule
2023-05-30 07:13:20,150  [DEBUG] sematic.api_client: [_post] Got response with raw content: b'{"content":{"cache_namespace":null,"client_version":"0.29.0","container_image_uri":"558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c","container_image_uris":{"default":"558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev:default_example_docker_intermediate@sha256:bcdf0b935878222304698ae7846d0c40b04d505f57011265630d1d1a788ece3c"},"git_info_json":{"branch":"tudor/bump-version-foruser-access","commit":"3781be942ca10dfd860de11d14359c5dd63dda20","dirty":true,"remote":"git@github.com:sematic-ai/example_docker.git"},"kind":"KUBERNETES","root_id":"9b25274b3721473fabab7ba2623282de","settings_env_vars":{},"status":"SCHEDULED","user":{XXX}}\n'
9b25274b3721473fabab7ba2623282de
2023-05-30 07:13:20,152  [DEBUG] sematic.plugins.building.docker_builder: Finished launching target: 'intermediate/main.py'
Built and launched 'intermediate/main.py' in 16.79s
(3.9.14/envs/3.9.14-testing) ~/work/example_docker$
```