### PR TITLE
Fix local storage error message

### DIFF
--- a/sematic/plugins/storage/local_storage.py
+++ b/sematic/plugins/storage/local_storage.py
@@ -111,7 +111,7 @@ def download_endpoint(user: Optional[User], namespace: str, key: str) -> flask.R
             content = file.read()
     except FileNotFoundError:
         return jsonify_error(
-            error="No such namespace or key: {namespace} {key}",
+            error=f"No such namespace or key: {namespace} {key}",
             status=HTTPStatus.NOT_FOUND,
         )
 


### PR DESCRIPTION
Fixes an incorrect error message:

```
2023-06-01 08:42:29,936 - ERROR - sematic.api_client: Server returned 404 for GET http://sematic-server/api/v1/storage/artifacts/d0c4ca2a1a087c84c2aec3763da887836c62a2cd/local: {"error": "No such namespace or key: {namespace} {key}"}
```