### PR TITLE
Fix Native Docker Build System recursive globbing

### DIFF
--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -350,7 +350,7 @@ def _generate_dockerfile_contents(
     if source_build_config is not None and source_build_config.data is not None:
         logger.debug("Adding data files: %s", source_build_config.data)
         for data_glob in source_build_config.data:
-            data_files = glob.glob(data_glob)
+            data_files = glob.glob(data_glob, recursive=True)
             if len(data_files) > 0:
                 # sorting for determinism
                 for data_file in sorted(data_files):
@@ -363,7 +363,7 @@ def _generate_dockerfile_contents(
     if source_build_config is not None and source_build_config.src is not None:
         logger.debug("Adding source files: %s", source_build_config.src)
         for src_glob in source_build_config.src:
-            src_files = glob.glob(src_glob)
+            src_files = glob.glob(src_glob, recursive=True)
             if len(src_files) > 0:
                 # sorting for determinism
                 for src_file in sorted(src_files):

--- a/sematic/plugins/building/tests/BUILD
+++ b/sematic/plugins/building/tests/BUILD
@@ -1,9 +1,7 @@
 sematic_py_lib(
     name = "config_lib",
     srcs = ["test_docker_builder_config.py"],
-    data = glob([
-        "fixtures/**",
-    ]),
+    data = ["fixtures"],
     pip_deps = [],
     deps = [
         "//sematic/plugins/building:docker_builder_config",
@@ -13,9 +11,7 @@ sematic_py_lib(
 pytest_test(
     name = "test_docker_client_utils",
     srcs = ["test_docker_client_utils.py"],
-    data = glob([
-        "fixtures/**",
-    ]),
+    data = ["fixtures"],
     pip_deps = ["docker"],
     deps = [
         "//sematic/plugins/building:docker_client_utils",
@@ -25,9 +21,7 @@ pytest_test(
 pytest_test(
     name = "test_docker_builder_config",
     srcs = ["test_docker_builder_config.py"],
-    data = glob([
-        "fixtures/**",
-    ]),
+    data = ["fixtures"],
     pip_deps = [],
     deps = [
         ":config_lib",
@@ -37,9 +31,7 @@ pytest_test(
 pytest_test(
     name = "test_docker_builder",
     srcs = ["test_docker_builder.py"],
-    data = glob([
-        "fixtures/**",
-    ]),
+    data = ["fixtures"],
     pip_deps = ["docker"],
     deps = [
         ":config_lib",

--- a/sematic/plugins/building/tests/fixtures/absolute_data.yaml
+++ b/sematic/plugins/building/tests/fixtures/absolute_data.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["/**.txt"]
-  src: ["**.py"]
+  data: ["/**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/absolute_image_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/absolute_image_script.yaml
@@ -3,8 +3,8 @@ image_script: "/home/bob/.bashrc"
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/absolute_requirements.yaml
+++ b/sematic/plugins/building/tests/fixtures/absolute_requirements.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "/requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/absolute_src.yaml
+++ b/sematic/plugins/building/tests/fixtures/absolute_src.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["/**.py"]
+  data: ["**/*.txt"]
+  src: ["/**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/bad_version.yaml
+++ b/sematic/plugins/building/tests/fixtures/bad_version.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
@@ -19,8 +19,8 @@ COPY sematic/plugins/building/tests/fixtures/bad_image_script.sh sematic/plugins
 COPY sematic/plugins/building/tests/fixtures/good_image_script.sh sematic/plugins/building/tests/fixtures/good_image_script.sh
 COPY sematic/plugins/building/tests/fixtures/no_image.yaml sematic/plugins/building/tests/fixtures/no_image.yaml
 COPY sematic/plugins/building/tests/fixtures/two_images.yaml sematic/plugins/building/tests/fixtures/two_images.yaml
+COPY sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt
 
-COPY sematic/plugins/building/tests/fixtures/__init__.py sematic/plugins/building/tests/fixtures/__init__.py
 COPY sematic/plugins/building/tests/fixtures/bad_launch_script.py sematic/plugins/building/tests/fixtures/bad_launch_script.py
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py
 COPY sematic/plugins/building/tests/fixtures/good_minimal.py sematic/plugins/building/tests/fixtures/good_minimal.py

--- a/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/good_launch_script.yaml
@@ -7,7 +7,8 @@ build:
     "docker",
     "*.sh",
     "//sematic/plugins/building/tests/fixtures/no_image*",
-    "../**/two_images*"
+    "../**/two_images*",
+    "**/third_level.*"
   ]
   src: ["*.py"]
 push:

--- a/sematic/plugins/building/tests/fixtures/jailbreak_data.yaml
+++ b/sematic/plugins/building/tests/fixtures/jailbreak_data.yaml
@@ -4,7 +4,7 @@ build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
   data: ["./../../.././../../../home/bob"]
-  src: ["**.py"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/jailbreak_image_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/jailbreak_image_script.yaml
@@ -3,8 +3,8 @@ image_script: "phony/../../home/bob/.bashrc"
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/jailbreak_requirements.yaml
+++ b/sematic/plugins/building/tests/fixtures/jailbreak_requirements.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "../../../../../../requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/jailbreak_src.yaml
+++ b/sematic/plugins/building/tests/fixtures/jailbreak_src.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["//../home/bob/**.py"]
+  data: ["**/*.txt"]
+  src: ["//../home/bob/**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/malformed_push_empty_registry.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_push_empty_registry.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: null
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/malformed_push_missing_repository.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_push_missing_repository.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   tag_suffix: "my_tag_suffix"

--- a/sematic/plugins/building/tests/fixtures/malformed_uri.yaml
+++ b/sematic/plugins/building/tests/fixtures/malformed_uri.yaml
@@ -3,8 +3,8 @@ base_uri: "sematicai/sematic-worker-base:latest"
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/nested/ignored.yaml
+++ b/sematic/plugins/building/tests/fixtures/nested/ignored.yaml
@@ -1,4 +1,4 @@
 version: 1
 base_uri: "x:y@z"
 build:
-  data: ["**.ignored"]
+  data: ["**/*.ignored"]

--- a/sematic/plugins/building/tests/fixtures/nested/launch_script.yaml
+++ b/sematic/plugins/building/tests/fixtures/nested/launch_script.yaml
@@ -2,5 +2,5 @@ version: 1
 base_uri: "d:e@f"
 build:
   platform: null
-  data: ["**.dat"]
-  src: ["**.py"]
+  data: ["**/*.dat"]
+  src: ["**/*.py"]

--- a/sematic/plugins/building/tests/fixtures/nested/sematic_build.yaml
+++ b/sematic/plugins/building/tests/fixtures/nested/sematic_build.yaml
@@ -3,4 +3,4 @@ image_script: "../good_image_script.sh"
 build:
   platform: "linux/amd64"
   requirements: "//sematic/plugins/building/tests/fixtures/requirements.txt"
-  data: ["**.txt"]
+  data: ["**/*.txt"]

--- a/sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt
+++ b/sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt
@@ -1,0 +1,1 @@
+# This file just needs to exist

--- a/sematic/plugins/building/tests/fixtures/no_image.yaml
+++ b/sematic/plugins/building/tests/fixtures/no_image.yaml
@@ -2,8 +2,8 @@ version: 1
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/fixtures/two_images.yaml
+++ b/sematic/plugins/building/tests/fixtures/two_images.yaml
@@ -4,8 +4,8 @@ image_script: "good_image_script.sh"
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: ["**.txt"]
-  src: ["**.py"]
+  data: ["**/*.txt"]
+  src: ["**/*.py"]
 push:
   registry: "my_registry"
   repository: "my_repository"

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -340,6 +340,7 @@ def test_make_docker_client_error(mock_retrieve_server_version: mock.MagicMock):
                     "*.sh",
                     "//sematic/plugins/building/tests/fixtures/no_image*",
                     "../**/two_images*",
+                    "**/third_level.*",
                 ],
                 # check the target is not duplicated
                 # this actually results in an unexpected __init__.py file being included

--- a/sematic/plugins/building/tests/test_docker_builder_config.py
+++ b/sematic/plugins/building/tests/test_docker_builder_config.py
@@ -132,6 +132,7 @@ def test_load_build_config_full_base_uri_happy():
         "sematic/plugins/building/tests/fixtures/*.sh",
         "sematic/plugins/building/tests/fixtures/no_image*",
         "sematic/plugins/building/tests/**/two_images*",
+        "sematic/plugins/building/tests/fixtures/**/third_level.*",
     ]
     assert actual_config.build.src == ["sematic/plugins/building/tests/fixtures/*.py"]
     assert actual_config.push is not None
@@ -211,10 +212,10 @@ def test_load_build_config_merge_and_normalize_w_specific_config():
             platform="linux/amd64",
             requirements=os.path.join(RESOURCE_PATH, "requirements.txt"),
             data=[
-                os.path.join(RESOURCE_PATH, "nested", "**.txt"),
-                os.path.join(RESOURCE_PATH, "nested", "**.dat"),
+                os.path.join(RESOURCE_PATH, "nested", "**/*.txt"),
+                os.path.join(RESOURCE_PATH, "nested", "**/*.dat"),
             ],
-            src=[os.path.join(RESOURCE_PATH, "nested", "**.py")],
+            src=[os.path.join(RESOURCE_PATH, "nested", "**/*.py")],
         ),
         push=None,
         docker=None,
@@ -235,7 +236,7 @@ def test_load_build_config_merge_and_normalize_no_specific_config():
         build=docker_builder_config.SourceBuildConfig(
             platform="linux/amd64",
             requirements="sematic/plugins/building/tests/fixtures/requirements.txt",
-            data=[os.path.join(RESOURCE_PATH, "nested", "**.txt")],
+            data=[os.path.join(RESOURCE_PATH, "nested", "**/*.txt")],
             src=None,
         ),
         push=None,


### PR DESCRIPTION
The source and data file globbing resolution was not done recursively, meaning that only one level of nesting resolution was supported.

This fixes the bug and adds a new test case to validate multi-level file globbing resolution.