### PR TITLE
Remove redundant pod argument

### DIFF
--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -128,6 +128,8 @@ class LocalResolver(SilentResolver):
         Instead of simply queuing the root future, this method seeds the future graph
         from a clone of another execution of same pipeline.
         """
+        rerun_mode = rerun_mode or RerunMode.SPECIFIC_RUN
+
         try:
             run = api_client.get_run(from_run_id)
         except api_client.ResourceNotFoundError as e:

--- a/sematic/resolvers/local_resolver.py
+++ b/sematic/resolvers/local_resolver.py
@@ -79,7 +79,7 @@ class LocalResolver(SilentResolver):
         self,
         cache_namespace: Optional[CacheNamespace] = None,
         rerun_from: Optional[str] = None,
-        rerun_mode: RerunMode = RerunMode.SPECIFIC_RUN,
+        rerun_mode: Optional[RerunMode] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -122,7 +122,7 @@ class LocalResolver(SilentResolver):
             self._seed_from_clone(future, self._rerun_from_run_id, self._rerun_mode)
 
     def _seed_from_clone(
-        self, future: AbstractFuture, from_run_id: str, rerun_mode: RerunMode
+        self, future: AbstractFuture, from_run_id: str, rerun_mode: Optional[RerunMode]
     ):
         """
         Instead of simply queuing the root future, this method seeds the future graph

--- a/sematic/resolvers/tests/test_cloud_resolver.py
+++ b/sematic/resolvers/tests/test_cloud_resolver.py
@@ -132,7 +132,7 @@ def test_simulate_cloud_exec(
         resolution_id=future.id,
         max_parallelism=None,
         rerun_from=None,
-        rerun_mode=RerunMode.SPECIFIC_RUN,
+        rerun_mode=None,
     )
     assert api_client.get_resolution(future.id).status == ResolutionStatus.CREATED.value
 

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -291,6 +291,7 @@ def wrap_main_with_logging():
     if _EMULATE_INTERPRETER_ARG in sys.argv:
         exit_code = _emulate_interpreter(_sanitize_interpreter_args(sys.argv))
         os._exit(exit_code)
+
     print("Starting Sematic Worker")
     args = parse_args()
     prefix = log_prefix(args.run_id, JobKind.resolver if args.resolve else JobKind.run)
@@ -317,6 +318,7 @@ def wrap_main_with_logging():
         logger.info("Worker CLI args: resolve=%s", args.resolve)
         logger.info("Worker CLI args: max-parallelism=%s", args.max_parallelism)
         logger.info("Worker CLI args: rerun_from=%s", args.rerun_from)
+        logger.info("Worker CLI args: rerun_mode=%s", args.rerun_mode)
 
         main(
             run_id=args.run_id,


### PR DESCRIPTION
Currently the `--rerun-mode` argument is always injected into the pod, even if the run is not a rerun:
```
[...]
                "args": [
                    "--run_id",
                    "98b7a2cbb2fb454e822a9bfbae732733",
                    "--resolve",
                    "--rerun-mode",
                    "SPECIFIC_RUN"
                ],
[...]
```

This updated the default value of the argument to be `None` instead, so the argument is not passed:
```
[...]
                "args": [
                    "--run_id",
                    "5938a5221b4f448db06f5ff1c67a94f1",
                    "--resolve"
                ],
[...]
```

Also adds a missing log.
