### PR TITLE
Expose all K8 classes in base init

### DIFF
--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -46,8 +46,10 @@ from sematic.resolver import Resolver  # noqa: F401,E402
 from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
 from sematic.resolvers.local_resolver import LocalResolver, RerunMode  # noqa: F401,E402
 from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
+    KubernetesCapabilities,
     KubernetesResourceRequirements,
     KubernetesSecretMount,
+    KubernetesSecurityContext,
     KubernetesToleration,
     KubernetesTolerationEffect,
     KubernetesTolerationOperator,


### PR DESCRIPTION
A user was attempting to import newly-added Kubernetes utility classes directly from the Sematic base init module, as with other existing classes.

This PR adds these to the base init for improved usability.
