### PR TITLE
Optimize Native Docker builds temporally and spatially

### DIFF
--- a/sematic/examples/mnist/pytorch/__main__.yaml
+++ b/sematic/examples/mnist/pytorch/__main__.yaml
@@ -3,8 +3,6 @@ base_uri: "sematicai/sematic-worker-base:cuda@sha256:6cbedeffdbf8ef0e5182819b4ae
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: []
-  src: []
 push:
   registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
   repository: "sematic-dev"

--- a/sematic/examples/mnist/pytorch/mnist_learning_rates.yaml
+++ b/sematic/examples/mnist/pytorch/mnist_learning_rates.yaml
@@ -3,8 +3,6 @@ base_uri: "sematicai/sematic-worker-base:cuda@sha256:6cbedeffdbf8ef0e5182819b4ae
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: []
-  src: []
 push:
   registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
   repository: "sematic-dev"

--- a/sematic/examples/mnist/pytorch/mnist_train.yaml
+++ b/sematic/examples/mnist/pytorch/mnist_train.yaml
@@ -3,8 +3,6 @@ base_uri: "sematicai/sematic-worker-base:cuda@sha256:6cbedeffdbf8ef0e5182819b4ae
 build:
   platform: "linux/amd64"
   requirements: "requirements.txt"
-  data: []
-  src: []
 push:
   registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
   repository: "sematic-dev"

--- a/sematic/examples/mnist/pytorch/requirements.txt
+++ b/sematic/examples/mnist/pytorch/requirements.txt
@@ -4,4 +4,3 @@ torchmetrics
 plotly>=5.5.0
 pandas
 scikit-learn
-sematic

--- a/sematic/examples/template/requirements.txt
+++ b/sematic/examples/template/requirements.txt
@@ -3,5 +3,4 @@
 # Examples:
 # pandas
 # seaborn
-# sematic
 # torch

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
@@ -1,12 +1,13 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
+
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
@@ -1,15 +1,12 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
+
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
 
 COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic sematic/plugins/building/tests/fixtures/docker/Dockerfile.basic
 COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.data sematic/plugins/building/tests/fixtures/docker/Dockerfile.data
@@ -17,5 +14,9 @@ COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.full sematic/plug
 COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
 COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.src sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
 COPY sematic/plugins/building/tests/fixtures/docker/Dockerfile.target sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"
 
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.full
@@ -1,18 +1,12 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
 
-COPY sematic/plugins/building/tests/fixtures/requirements.txt requirements.txt
-RUN pip3 install --no-cache --ignore-installed -r requirements.txt
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
 
 COPY sematic/plugins/building/tests/fixtures/docker sematic/plugins/building/tests/fixtures/docker
 COPY sematic/plugins/building/tests/fixtures/bad_image_script.sh sematic/plugins/building/tests/fixtures/bad_image_script.sh
@@ -20,6 +14,13 @@ COPY sematic/plugins/building/tests/fixtures/good_image_script.sh sematic/plugin
 COPY sematic/plugins/building/tests/fixtures/no_image.yaml sematic/plugins/building/tests/fixtures/no_image.yaml
 COPY sematic/plugins/building/tests/fixtures/two_images.yaml sematic/plugins/building/tests/fixtures/two_images.yaml
 COPY sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt sematic/plugins/building/tests/fixtures/nested/third_level/third_level.txt
+
+COPY sematic/plugins/building/tests/fixtures/requirements.txt requirements.txt
+RUN pip install --no-cache-dir --ignore-installed --root-user-action=ignore -r requirements.txt
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"
 
 COPY sematic/plugins/building/tests/fixtures/bad_launch_script.py sematic/plugins/building/tests/fixtures/bad_launch_script.py
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.requirements
@@ -1,17 +1,18 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
 
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
+
 COPY sematic/plugins/building/tests/fixtures/requirements.txt requirements.txt
-RUN pip3 install --no-cache --ignore-installed -r requirements.txt
+RUN pip install --no-cache-dir --ignore-installed --root-user-action=ignore -r requirements.txt
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"
 
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.src
@@ -1,14 +1,15 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
+
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"
 
 COPY sematic/plugins/building/tests/fixtures/bad_launch_script.py sematic/plugins/building/tests/fixtures/bad_launch_script.py

--- a/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
+++ b/sematic/plugins/building/tests/fixtures/docker/Dockerfile.target
@@ -1,14 +1,15 @@
 FROM sematicai/sematic-worker-base:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-
-RUN python3 -c "import distutils" || apt-get update -y && apt-get install --reinstall -y python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils
-RUN which pip3 || apt-get update -y && apt-get install -y python3-pip && python3 -m pip install --upgrade pip==23.1.2
-
-ENV PATH="/sematic/bin/:${PATH}"
-RUN echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN ( echo '#!/bin/sh' > entrypoint.sh && echo '/usr/bin/python3 -m sematic.resolvers.worker "$@"' >> entrypoint.sh && chmod +x /entrypoint.sh )
 ENTRYPOINT ["/entrypoint.sh"]
+
+RUN python3 -c "from distutils import cmd, util" || ( apt-get update -y && apt-get install -y --reinstall --no-install-recommends python$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-distutils )
+
+RUN which pip || ( export PYTHONDONTWRITEBYTECODE=1 && apt-get update -y && apt-get install -y --no-install-recommends wget && wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py && unset PYTHONDONTWRITEBYTECODE )
+
+RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
+
+ENV PATH="/sematic/bin/:$PATH"
 
 COPY sematic/plugins/building/tests/fixtures/good_launch_script.py sematic/plugins/building/tests/fixtures/good_launch_script.py

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -171,6 +171,7 @@ def test_build_image_base_uri(
         target=LAUNCH_SCRIPT,
         effective_base_uri=base_uri,
         build_config=mock_build_config,
+        platform=mock_build_config.build.platform,
         docker_client=mock_docker_client,
     )
 
@@ -188,6 +189,7 @@ def test_build_image_build_script(
     mock_build_config = mock.Mock(docker_builder.BuildConfig)
     mock_build_config.base_uri = None
     mock_build_config.image_script = image_script
+    mock_build_config.build = None
     mock_build_image_from_base.return_value = mock_image, local_uri
 
     actual_image, actual_uri = docker_builder._build_image(
@@ -202,6 +204,7 @@ def test_build_image_build_script(
         target=LAUNCH_SCRIPT,
         effective_base_uri=base_uri,
         build_config=mock_build_config,
+        platform=None,
         docker_client=mock_docker_client,
     )
 

--- a/sematic/utils/spinner.py
+++ b/sematic/utils/spinner.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 @contextmanager
-def with_stdout_spinner():
+def stdout_spinner():
     """
     Prints a spinning character to stdout while execution is inside this context.
     """


### PR DESCRIPTION
This slightly optimizes the size and build time of the Docker images constructed by the Native Docker Build System.

Changes:
- Switches from installing `pip` via `apt` to installing it from source.
- Always ensures `Sematic` is installed, even if it is not specified in the pipeline's requirements.
- Moved data file copying before requirements installation, to permit users including required wheels in the build.
- Fixes bug in `pip` command which did not deactivate cache dir, as was the intention.
- Fixes corner case where sometimes the existing incomplete `distutils` distribution was not overwritten with a full one required by some requirements.
- Manages to avoid installing `apt-utils`.
- Reduces number of layers.
- Reduces log spam during requirements installation.
- Renames silly-named context manager.

Unit and integration tests are updated to reflect the changes.

**Before:**

```
$ docker image list | grep 558717131297
REPOSITORY                                                 TAG                                   IMAGE ID       CREATED         SIZE
558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev   default_example_docker_intermediate   d6b3cdf9dd17   3 days ago      1.02GB
558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev   default_mnist_train_example           5d9b6acb2514   4 days ago      5.77GB
```

**After:**

```
$ docker image list | grep 558717131297
REPOSITORY                                                 TAG                                   IMAGE ID       CREATED         SIZE
558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev   default_example_docker_intermediate   072513533c12   9 minutes ago    717MB
558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev   default_mnist_train_example           7bfc0f3ada26   10 minutes ago      5.5GB
```
