### PR TITLE
Update mypy version to avoid bug

### DIFF
--- a/requirements/ci-requirements.txt
+++ b/requirements/ci-requirements.txt
@@ -2,7 +2,7 @@
 # Linters and such. Pin them so that different devs
 # don't get different results from using them.
 flake8==5.0.4
-mypy==0.971
+mypy==0.982
 black==22.6.0
 isort==5.10.1
 


### PR DESCRIPTION
`mypy` is manifesting a bug where it incorrectly reports a syntax error in a pyenv virtual env only on CircleCI. This is caused by [a bug in `mypy` itself](https://github.com/python/mypy/issues/13627).

This started manifesting suddenly and [is blocking merges to `main`](https://app.circleci.com/pipelines/github/sematic-ai/sematic/3874/workflows/8ae1a54b-0381-4a51-ad8a-93dc3f820a70/jobs/13753).

This PR updates the version of `mypy` to avoid the bug.

<img width="1428" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/7584a21b-3fbf-48f7-94c8-c68e411771da">


