### PR TITLE
Fix Server image size bloat

### DIFF
--- a/tools/sematic_wheel_rule.bzl
+++ b/tools/sematic_wheel_rule.bzl
@@ -99,13 +99,23 @@ def _sematic_py_wheel_impl(ctx):
 
     # We handle "ee" and "non-ee" deps distinctly, because we don't want "ee"
     # dependencies to add requirements to the base wheel. Extra third-party
-    # deps for ee are all handled via "extra_requires"
-    non_ee_deps = [dep for dep in ctx.attr.deps if "sematic/ee" not in dep.label.package]
+    # deps for "ee" are all handled via "extra_requires".
+    # "ee" code modules include the "sematic/ee" module itself, but also
+    # "sematic/examples" which showcase "ee" capabilities. Currently there are
+    # no other "non-ee" optional example pipelines, so we consider all
+    # "sematic/examples" dependencies to be "ee" examples.
+    non_ee_deps = [
+        dep for dep in ctx.attr.deps
+        if "sematic/ee" not in dep.label.package and "sematic/examples" not in dep.label.package
+    ]
     non_ee_inputs = depset(
         transitive = [dep[DefaultInfo].data_runfiles.files for dep in non_ee_deps] +
                      [dep[DefaultInfo].default_runfiles.files for dep in non_ee_deps],
     )
-    ee_deps = [dep for dep in ctx.attr.deps if "sematic/ee" in dep.label.package]
+    ee_deps = [
+        dep for dep in ctx.attr.deps
+        if "sematic/ee" in dep.label.package or "sematic/examples" in dep.label.package
+    ]
     ee_inputs = depset(
         transitive = [dep[DefaultInfo].data_runfiles.files for dep in ee_deps] +
                      [dep[DefaultInfo].default_runfiles.files for dep in ee_deps],
@@ -267,7 +277,7 @@ def _sematic_py_wheel_impl(ctx):
 
 
 def _extract_dependency_name(path_within_wheel):
-    """For a path within the bazel deps, see whether it correponds to a python dep.
+    """For a path within the bazel deps, see whether it corresponds to a python dep.
 
     Return that dependency's name if so, otherwise return None.
     """


### PR DESCRIPTION
#857 caused the `sematic["default"]` wheel to also install `ray` dependencies, resulting in a Server Docker image size increase.

This PR updates the logic that decides which dependencies are "ee" or not to also include example pipelines which showcase "ee" behavior.

## Testing

Before Regression:
```
DIGEST        OS/ARCH      SCANNED  LAST PULL  COMPRESSED SIZE 
6b9d41963f35  linux/amd64  ---      a day ago  416.27 MB
```

Regression:
```
DIGEST        OS/ARCH      SCANNED  LAST PULL  COMPRESSED SIZE 
0c9f38e013d1  linux/amd64  ---      a day ago  5.1 GB
```

After Fix:
```
DIGEST        OS/ARCH      SCANNED  LAST PULL      COMPRESSED SIZE 
cf0a4855948a  linux/amd64  ---      2 minutes ago  416.36 MB
```
