### PR TITLE
Support filter runs by tags

### DIFF
--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -55,7 +55,7 @@ export type BasicMetricsPayload = {
     }
 }
 
-type Operator = "eq";
+type Operator = "eq" | "contains";
 
 export type FilterCondition = {
     [key: string]: { [eq in Operator]?: string | null } | undefined

--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import useAsyncFn from "react-use/lib/useAsyncFn";
 import { Run } from "src/Models";
-import { AllFilters, FilterType, StatusFilters, convertMiscellaneousFilterToRunFilters, convertOwnersFilterToRunFilters, convertStatusFilterToRunFilters } from "src/pages/RunSearch/filters/common";
+import { AllFilters, FilterType, StatusFilters, convertMiscellaneousFilterToRunFilters, convertOwnersFilterToRunFilters, convertStatusFilterToRunFilters, convertTagsFilterToRunFilters } from "src/pages/RunSearch/filters/common";
 import useAsync from "react-use/lib/useAsync";
 
 export const selectedRunHashAtom = atomWithHashCustomSerialization("run", "")
@@ -70,6 +70,13 @@ export function useFiltersConverter(filters: AllFilters | null) {
 
         if (!filters) {
             return undefined;
+        }
+
+        if (filters[FilterType.TAGS]) {
+            const statusFilters = convertTagsFilterToRunFilters(filters[FilterType.TAGS] as StatusFilters[]);
+            if (statusFilters) {
+                conditions.push(statusFilters);
+            }
         }
 
         if (filters[FilterType.STATUS]) {

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunList.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { ChevronLeft, ChevronRight } from "@mui/icons-material";
+import Alert from "@mui/material/Alert";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { Row, createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -154,7 +155,7 @@ const RunList = (props: RunListProps) => {
 
     const { runFilter, queryParams } = useFiltersConverter(filters);
 
-    const { runs, page, isLoaded, isLoading, totalPages, totalRuns, nextPage, previousPage } = useRunsPagination(
+    const { runs, error, page, isLoaded, isLoading, totalPages, totalRuns, nextPage, previousPage } = useRunsPagination(
         runFilter as any, queryParams
     );
 
@@ -192,6 +193,10 @@ const RunList = (props: RunListProps) => {
     useEffect(() => {
         setIsLoading(isLoading)
     }, [setIsLoading, isLoading]);
+
+    if (error)  {
+        return <Alert severity="error">{error.message}</Alert>
+    }
 
     return <Container>
         <Stats>

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -52,6 +52,14 @@ const SearchFilters = (props: SearchFiltersProps) => {
         }
     }, []);
 
+    const onTagsFilterChanged = useCallback((filters: string[]) => {
+        if (isEmpty(filters)) {
+            delete allFilters.current[FilterType.TAGS];
+        } else {
+            allFilters.current[FilterType.TAGS] = filters;
+        }
+    }, []);
+
     const onStatusFilterChanged = useCallback((filters: string[]) => {
         if (isEmpty(filters)) {
             delete allFilters.current[FilterType.STATUS];
@@ -64,7 +72,7 @@ const SearchFilters = (props: SearchFiltersProps) => {
         if (isEmpty(filters)) {
             delete allFilters.current[FilterType.OWNER];
         } else {
-            allFilters.current[FilterType.STATUS] = filters;
+            allFilters.current[FilterType.OWNER] = filters;
         }
     }, []);
 
@@ -82,7 +90,7 @@ const SearchFilters = (props: SearchFiltersProps) => {
 
     return <>
         <SearchTextSection ref={searchTextRef} onSearchChanged={onSearchTextChanged} />
-        <TagsFilterSection ref={tagsFiltersRef} />
+        <TagsFilterSection ref={tagsFiltersRef} onFiltersChanged={onTagsFilterChanged} />
         <StatusFilterSection ref={statusFiltersRef} onFiltersChanged={onStatusFilterChanged} />
         <OwnersFilterSection ref={ownersFiltersRef} onFiltersChanged={onOwnersFilterChanged} />
         <OtherFiltersSection ref={otherFiltersRef} onFiltersChanged={onOtherFilterChanged} />

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/TagsFilterSection.tsx
@@ -29,6 +29,8 @@ interface TagsFilterSectionProps {
 }
 
 const TagsFilterSection = forwardRef<ResettableHandle, TagsFilterSectionProps>((props, ref) => {
+    const { onFiltersChanged } = props;
+
     const [expanded, setExpanded] = useState(false);
 
     const tagInputRef = useRef<ResettableHandle>(null);
@@ -42,7 +44,7 @@ const TagsFilterSection = forwardRef<ResettableHandle, TagsFilterSectionProps>((
     return <StyledScrollableSection title={"Tags"} expanded={expanded}
         onChange={(_, expanded) => setExpanded(expanded)}>
         <Container>
-            <TagsInput ref={tagInputRef} />
+            <TagsInput ref={tagInputRef} onTagsChange={onFiltersChanged} />
         </Container>
     </StyledScrollableSection>;
 });

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/common.ts
@@ -12,6 +12,23 @@ export type AllFilters = Partial<Record<FilterType, string[]>>;
 
 export type StatusFilters = "completed" | "failed" | "running" | "canceled";
 
+export function convertTagsFilterToRunFilters(filters: string[]): Filter | null {
+
+    if (!!filters && filters.length > 0) {
+        const conditions = filters.map((tag) => ({
+            "tags": { contains: tag}
+        }));        
+        if (conditions.length > 1) {
+            return {
+                "OR": conditions
+            }
+        } 
+        return conditions[0];
+    }
+    
+    return null;
+}
+
 export function convertStatusFilterToRunFilters(filters: StatusFilters[]): Filter | null {
     const filtersSet = new Set(filters);
 


### PR DESCRIPTION
Link to backend api to actually filter runs by tags.

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/c296dc40-03f9-4bab-9ce3-cd933125a350)


unfortunately using multiple filter types currently doesn't work and will be investigated separately. 