### PR TITLE
Context menus on the run details page

### DIFF
--- a/sematic/ui/packages/common/src/component/ContextMenu.tsx
+++ b/sematic/ui/packages/common/src/component/ContextMenu.tsx
@@ -1,0 +1,83 @@
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { useCallback, useEffect, useState, useMemo } from "react";
+
+interface ContextCommand {
+    title: string;
+    onClick: () => void;
+    disabled?: boolean;
+}
+
+interface ContextMenuProps {
+    anchorEl: HTMLElement | null;
+    commands: Array<ContextCommand>;
+    anchorOffset?: {
+        x: number;
+        y: number;
+    }
+}
+
+function ContextMenu(props: ContextMenuProps) {
+    const { anchorEl: anchorElProp, commands, anchorOffset } = props;
+
+    const [open, setOpen] = useState(false);
+    const [anchorEl, setAnchorElement] = useState<HTMLElement>();
+
+    const buttonClickEvent = useCallback(() => {
+        setOpen((open) => !open);
+    }, [setOpen]);
+
+    useEffect(() => {
+        if (anchorElProp) {
+            setAnchorElement(anchorElProp);
+            anchorElProp.addEventListener("click", buttonClickEvent);
+
+            return () => {
+                anchorElProp.removeEventListener("click", buttonClickEvent);
+            }
+        }
+    }, [anchorElProp, buttonClickEvent]);
+
+    // Use a [virtual anchor element](https://mui.com/material-ui/react-popover/#virtual-element)
+    // to offset the menu
+    const virtualAnchorElement = useMemo(() => ({
+        nodeType: 1,
+        getBoundingClientRect: () => {
+            const rect = anchorEl?.getBoundingClientRect() ?? { x: 0, y: 0 };
+            if (!anchorOffset) {
+                return rect;
+            }
+            const newReact = DOMRect.fromRect(rect);
+            newReact.x += anchorOffset.x;
+            newReact.y += anchorOffset.y;
+            return newReact;
+        }
+    }), [anchorEl, anchorOffset]);
+
+    return <Menu
+        anchorEl={virtualAnchorElement as any}
+        open={open}
+        anchorOrigin={{
+            vertical: "top",
+            horizontal: "right",
+        }}
+        transformOrigin={{
+            vertical: "top",
+            horizontal: "left",
+        }}
+        onClose={() => setOpen(false)}
+    >
+        {
+            commands.map(({ title, disabled, onClick }, index) =>
+                <MenuItem key={index} onClick={disabled ? undefined : () => {
+                    setOpen(false);
+                    onClick();
+                }} disabled={disabled}>
+                    {title}
+                </MenuItem>
+            )
+        }
+    </Menu>
+}
+
+export default ContextMenu;

--- a/sematic/ui/packages/common/src/component/MoreVertButton.tsx
+++ b/sematic/ui/packages/common/src/component/MoreVertButton.tsx
@@ -1,6 +1,7 @@
 import { MoreVert } from "@mui/icons-material";
 import styled from "@emotion/styled";
 import theme from "src/theme/new";
+import { forwardRef } from "react";
 
 interface MoreVertButtonProps {
     className?: string;
@@ -21,10 +22,11 @@ const StyledButton = styled.button`
     }
 `;
 
-const MoreVertButton = (props: MoreVertButtonProps) => {
-    const { className } = props;
+const MoreVertButton = forwardRef<HTMLButtonElement | null, MoreVertButtonProps>(
+    (props: MoreVertButtonProps, ref) => {
+        const { className } = props;
 
-    return <StyledButton className={className}><MoreVert /></StyledButton>;
-}
+        return <StyledButton ref={ref} className={className}><MoreVert /></StyledButton>;
+    });
 
 export default MoreVertButton;

--- a/sematic/ui/packages/common/src/hooks/resolutionHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/resolutionHooks.ts
@@ -1,4 +1,5 @@
 import useAsync from "react-use/lib/useAsync";
+import useAsyncFn from "react-use/lib/useAsyncFn";
 import { ResolutionPayload } from "src/ApiContracts";
 import { Resolution } from "src/Models";
 import { useHttpClient } from "src/hooks/httpHooks";
@@ -16,4 +17,30 @@ export function useFetchResolution(resolutionId: string): [
     }, [resolutionId]);
     
     return [value, loading, error];
+}
+
+
+export function useRerun(rootRunId?: string, rerunFrom?: string) {
+    const { fetch } = useHttpClient();
+
+    return useAsyncFn(async () => {
+        return await fetch({
+            url: `/api/v1/resolutions/${rootRunId}/rerun`,
+            method: "POST",
+            body: {
+                rerun_from: rerunFrom,
+            }
+        });
+    }, [fetch]);
+}
+
+export function useCancelRun(rootRunId: string) {
+    const { fetch } = useHttpClient();
+
+    return useAsyncFn(async () => {
+        return await fetch({
+            url: `/api/v1/resolutions/${rootRunId}/cancel`,
+            method: "PUT"
+        });
+    }, [fetch]);
 }

--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -191,6 +191,10 @@ export function getRunUrlPattern(runID: string) {
     return `/runs/${runID}`;
 }
 
+export function getPipelineRunsPattern(functionPath: string) {
+    return `/pipeline/${functionPath}`;
+}
+
 export function useRunNavigation() {
     const navigate = useNavigate();
     const { hash } = useLocation();

--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import parseJSON from "date-fns/parseJSON";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { DateTimeLong } from "src/component/DateTime";
 import Headline from "src/component/Headline";
 import ImportPath from "src/component/ImportPath";
@@ -15,6 +15,7 @@ import Section from "src/component/Section";
 import TagsList from "src/component/TagsList";
 import { useRootRunContext } from "src/context/RootRunContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
+import FunctionSectionActionMenu from "src/pages/RunDetails/contextMenus/FunctionSectionMenu";
 import theme from "src/theme/new";
 
 const StyledSection = styled(Section)`
@@ -125,6 +126,8 @@ const FunctionSection = () => {
         return `${runDuration} on ${completeAt}`;
     }, [selectedRun]);
 
+    const contextMenuAnchor = useRef<HTMLButtonElement>(null);
+
     return <StyledSection>
         <Headline>Function Run</Headline>
         <BoxContainer>
@@ -145,7 +148,8 @@ const FunctionSection = () => {
             {isGraphLoading ? <LongPlaceholderSkeleton />
                 : <ImportPath>{selectedRun?.function_path}</ImportPath>}
         </ImportPathContainer>
-        <StyledVertButton />
+        <StyledVertButton ref={contextMenuAnchor} />
+        <FunctionSectionActionMenu anchorEl={contextMenuAnchor.current} />
         {isGraphLoading ? <MediumPlaceholderSkeleton />
             : <TagsContainer>
                 <div className={"tags-list-wrapper"} key={selectedRun?.id}><TagsList tags={selectedRun?.tags || []} /></div>

--- a/sematic/ui/packages/common/src/pages/RunDetails/PipelineSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/PipelineSection.tsx
@@ -1,8 +1,10 @@
 import styled from "@emotion/styled";
-import Alert from "@mui/material/Alert";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
+import Tooltip from "@mui/material/Tooltip";
 import Typograph from "@mui/material/Typography";
+import { useRef } from "react";
 import Headline from "src/component/Headline";
 import ImportPath from "src/component/ImportPath";
 import MoreVertButton from "src/component/MoreVertButton";
@@ -10,6 +12,7 @@ import PipelineTitle from "src/component/PipelineTitle";
 import Section from "src/component/Section";
 import RootRunContext, { useRootRunContext } from "src/context/RootRunContext";
 import useBasicMetrics from "src/hooks/metricsHooks";
+import PipelineSectionActionMenu from "src/pages/RunDetails/contextMenus/PipelineSectionMenu";
 import theme from "src/theme/new";
 import { ExtractContextType, RemoveUndefined } from "src/utils/typings";
 
@@ -24,6 +27,7 @@ const BottomSection = styled.section`
   border-bottom: 1px solid ${theme.palette.p3border.main};
   display: flex;
   margin: 0 -25px;
+
   & .MuiBox-root {
     width: 100px;
     min-height: 100px;
@@ -61,11 +65,28 @@ const SkeletonForMetrics = styled(Skeleton)`
     }
 `;
 
+const StyledErrorOutlineIcon = styled(ErrorOutlineIcon)`
+    color: ${theme.palette.error.main};
+    width: 18px;
+    height: 18px;
+`;
+
+function ErrorComponent(props: {
+    error: Error
+}) {
+    const { error } = props;
+    return <Tooltip title={error.message}>
+        <StyledErrorOutlineIcon />
+    </Tooltip>;
+}
+
 const PipelineSection = () => {
     const { rootRun } = useRootRunContext() as RemoveUndefined<ExtractContextType<typeof RootRunContext>>;
 
     const { error, avgRuntime, successRate, totalCount, loading }
         = useBasicMetrics({ runId: rootRun.id, rootFunctionPath: rootRun.function_path });
+
+    const contextMenuAnchor = useRef<HTMLButtonElement>(null);
 
     return (
         <>
@@ -75,24 +96,30 @@ const PipelineSection = () => {
                 <ImportPath>
                     {rootRun.function_path}
                 </ImportPath>
-                <StyledVertButton />
+                <StyledVertButton ref={contextMenuAnchor} />
+                <PipelineSectionActionMenu anchorEl={contextMenuAnchor.current} />
             </TopSection>
             <BottomSection>
-                {error && <Alert severity="error">{error.message}</Alert>}
-                {!error && <>
+                <>
                     {loading ? <SkeletonForMetrics /> : <Box>
-                        <Typograph variant="bigBold">{totalCount}</Typograph>
+                        <Typograph variant="bigBold">
+                            {error ? <ErrorComponent error={error} /> : totalCount}
+                        </Typograph>
                         <Typograph variant="body1">runs</Typograph>
                     </Box>}
                     {loading ? <SkeletonForMetrics /> : <Box>
-                        <Typograph variant="bigBold">{`${avgRuntime}`}</Typograph>
+                        <Typograph variant="bigBold">
+                            {error ? <ErrorComponent error={error} /> : avgRuntime}
+                        </Typograph>
                         <Typograph variant="body1">avg. runtime</Typograph>
                     </Box>}
                     {loading ? <SkeletonForMetrics /> : <Box>
-                        <Typograph variant="bigBold">{successRate}</Typograph>
+                        <Typograph variant="bigBold">
+                            {error ? <ErrorComponent error={error} /> : successRate}
+                        </Typograph>
                         <Typograph variant="body1">success</Typograph>
                     </Box>}
-                </>}
+                </>
             </BottomSection>
         </>
     );

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import Headline from "src/component/Headline";
 import MoreVertButton from "src/component/MoreVertButton";
@@ -12,6 +12,7 @@ import Section from "src/component/Section";
 import TagsList from "src/component/TagsList";
 import RootRunContext, { useRootRunContext } from "src/context/RootRunContext";
 import { getRunUrlPattern, useFetchRuns } from "src/hooks/runHooks";
+import RunSectionActionMenu from "src/pages/RunDetails/contextMenus/RunSectionMenu";
 import theme from "src/theme/new";
 import { ExtractContextType, RemoveUndefined } from "src/utils/typings";
 
@@ -72,12 +73,15 @@ const RunSection = () => {
         navigate(getRunUrlPattern(newRootRunId as string));
     }, [navigate]);
 
+    const contextMenuAnchor = useRef<HTMLButtonElement>(null);
+
     return (
         <StyledSection>
             <Headline>Pipeline Run</Headline>
             <BoxContainer style={{ marginBottom: theme.spacing(3) }}>
                 <RunsDropdown runs={runs || []} onChange={onRootRunChange} defaultValue={rootRun.id} />
-                <StyledVertButton />
+                <StyledVertButton ref={contextMenuAnchor} />
+                <RunSectionActionMenu anchorEl={contextMenuAnchor.current} />
             </BoxContainer>
             <BoxContainer style={{ marginBottom: theme.spacing(2) }}>
                 <OwnerContainer>{owner}</OwnerContainer>

--- a/sematic/ui/packages/common/src/pages/RunDetails/artifacts/artifact.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/artifacts/artifact.tsx
@@ -1,16 +1,21 @@
-import Headline from "src/component/Headline";
-import Section from "src/component/Section";
 import styled from "@emotion/styled";
-import MoreVertButton from "src/component/MoreVertButton";
+import { useEffect, useRef } from "react";
+import useCounter from "react-use/lib/useCounter";
+import useLatest from "react-use/lib/useLatest";
 import { Artifact as ArtifactType } from "src/Models";
-import { renderArtifactRow } from "src/typeViz/common";
+import Headline from "src/component/Headline";
+import MoreVertButton from "src/component/MoreVertButton";
+import Section from "src/component/Section";
+import ArtifactMenu from "src/pages/RunDetails/contextMenus/ArtifactMenu";
 import theme from "src/theme/new";
+import { renderArtifactRow } from "src/typeViz/common";
 
 const StyledSection = styled(Section)`
     height: 50px;
     display: flex;
     align-items: center;
     position: relative;
+    margin-right: -${theme.spacing(5)};
 `;
 
 const StyledVertButton = styled(MoreVertButton)`
@@ -34,11 +39,23 @@ function Artifact(props: ArtifactProps) {
     const { name, artifact, expanded } = props;
 
     const { type_serialization, json_summary } = artifact;
+    const [renderTimes, {inc}] = useCounter();
+
+    const contextMenuAnchor = useRef<HTMLButtonElement>(null);
+    const latestAnchor = useLatest(contextMenuAnchor.current);
+
+    useEffect(() => {
+        // re-render until the context menu anchor is set
+        if (latestAnchor.current === null) {
+            inc();
+        }
+    }, [renderTimes, inc, latestAnchor]);
 
     return <>
         <StyledSection>
             <Headline>Artifact</Headline>
-            <StyledVertButton />
+            <StyledVertButton ref={contextMenuAnchor} />
+            <ArtifactMenu anchorEl={latestAnchor.current} artifactId={artifact.id} />
         </StyledSection>
         <ArtifactRepresentation>
             {renderArtifactRow(name, type_serialization, json_summary, { expanded })}

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/ArtifactMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/ArtifactMenu.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useContext, useMemo } from "react";
+import ContextMenu from "src/component/ContextMenu";
+import SnackBarContext from "src/context/SnackBarContext";
+
+const ANCHOR_OFFSET = {x: 13, y: -11};
+
+interface ArtifactMenuProps {
+    anchorEl: HTMLElement | null;
+    artifactId: string;
+}
+
+function ArtifactMenu(props: ArtifactMenuProps) {
+    const { anchorEl, artifactId } = props;
+    const { setSnackMessage } = useContext(SnackBarContext);
+
+    const onCopyArtifactID = useCallback(() => {
+        navigator.clipboard.writeText(artifactId);
+        setSnackMessage({ message: "Artifact ID copied" });
+    }, [setSnackMessage, artifactId]);
+
+    const commands = useMemo(() => {
+        return [
+            {
+                title: "Copy artifact ID",
+                onClick: onCopyArtifactID
+            }
+        ]
+    }, [onCopyArtifactID]);
+
+    return <ContextMenu anchorEl={anchorEl} commands={commands} anchorOffset={ANCHOR_OFFSET} />;
+}
+
+export default ArtifactMenu;

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/FunctionSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/FunctionSectionMenu.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useContext, useMemo } from "react";
+import ContextMenu from "src/component/ContextMenu";
+import { useRootRunContext } from "src/context/RootRunContext";
+import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
+import SnackBarContext from "src/context/SnackBarContext";
+import { useCancelRun, useRerun } from "src/hooks/resolutionHooks";
+
+const ANCHOR_OFFSET = {x: 13, y: -11};
+
+interface FunctionSectionActionMenuProps {
+    anchorEl: HTMLElement | null;
+}
+
+function FunctionSectionActionMenu(props: FunctionSectionActionMenuProps) {
+    const { anchorEl } = props;
+
+    const { rootRun, resolution, graph } = useRootRunContext();
+    const { selectedRun  } = useRunDetailsSelectionContext();
+
+    const { setSnackMessage } = useContext(SnackBarContext);
+
+    const [rerunState, rerun] = useRerun(rootRun?.id, selectedRun?.id);
+    const [cancelRunState, cancel] = useCancelRun(rootRun!.id);
+
+    const selectedRunInputEdges = useMemo(
+        () => graph?.edges.filter((edge) => edge.destination_run_id === selectedRun?.id),
+        [graph, selectedRun?.id]
+    );
+
+    const cancelEnabled = useMemo(
+        () => {
+            if (!rootRun) {
+                return false;
+            }
+            if (cancelRunState.loading) {
+                return false;
+            }
+            return !["FAILED", "NESTED_FAILED", "RESOLVED", "CANCELED"].includes(
+                rootRun!.future_state
+            );
+        }, [rootRun, cancelRunState]
+    );
+
+    const rerunEnable = useMemo(
+        () => selectedRunInputEdges?.every((edge) => !!edge.artifact_id)
+            && !!resolution?.container_image_uri && !rerunState.loading,
+        [resolution, rerunState, selectedRunInputEdges]
+    );
+
+    const onCopyShareClick = useCallback(() => {
+        navigator.clipboard.writeText(window.location.href);
+        setSnackMessage({ message: "Resolution link copied" });
+    }, [setSnackMessage]);
+
+    const onCopyRunIdClick = useCallback(() => {
+        navigator.clipboard.writeText(selectedRun?.id || "");
+        setSnackMessage({ message: "Resolution link copied" });
+    }, [setSnackMessage, selectedRun]);
+
+    const commands = useMemo(() => {
+        return [
+            {
+                title: "Rerun",
+                disabled: !rerunEnable,
+                onClick: async () => {
+                    try {
+                        rerun();
+                    } catch (error) {
+                        setSnackMessage({ message: "Failed to trigger rerun." });
+                    }
+                }
+            },
+            {
+                title: "Cancel",
+                disabled: !cancelEnabled,
+                onClick: () => {
+                    try {
+                        cancel();
+                    } catch (error) {
+                        setSnackMessage({ message: "Failed to cancel pipeline run." });
+                    }
+                }
+            },
+            {
+                title: "Share",
+                onClick: onCopyShareClick
+            },
+            {
+                title: "Copy run ID",
+                onClick: onCopyRunIdClick
+            }
+        ]
+    }, [setSnackMessage, rerun, cancel, onCopyShareClick, onCopyRunIdClick, rerunEnable, cancelEnabled]);
+
+    return <ContextMenu anchorEl={anchorEl} commands={commands} anchorOffset={ANCHOR_OFFSET} />;
+}
+
+export default FunctionSectionActionMenu;

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/PipelineSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/PipelineSectionMenu.tsx
@@ -1,0 +1,37 @@
+import ContextMenu from "src/component/ContextMenu";
+import { useMemo } from "react";
+import { useRootRunContext } from "src/context/RootRunContext";
+import { useNavigate } from "react-router-dom";
+import { getPipelineRunsPattern } from "src/hooks/runHooks";
+
+const ANCHOR_OFFSET = {x: 13, y: -11};
+interface PipelineSectionActionMenuProps {
+    anchorEl: HTMLElement | null;
+}
+
+function PipelineSectionActionMenu(props: PipelineSectionActionMenuProps) {
+    const { anchorEl } = props;
+
+    const { rootRun } = useRootRunContext();
+    const navigate = useNavigate();
+
+
+    const commands = useMemo(() => {
+        return [
+            {
+                title: "View all runs",
+                onClick: () => {
+                    navigate(getPipelineRunsPattern(rootRun!.function_path))
+                }
+            },
+            {
+                title: "Metrics",
+                onClick: () => { }
+            }
+        ]
+    }, [rootRun, navigate]);
+
+    return <ContextMenu anchorEl={anchorEl} commands={commands} anchorOffset={ANCHOR_OFFSET} />;
+}
+
+export default PipelineSectionActionMenu;

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/RunSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/RunSectionMenu.tsx
@@ -1,0 +1,81 @@
+import { useContext, useMemo, useCallback } from "react";
+import ContextMenu from "src/component/ContextMenu";
+import { useRootRunContext } from "src/context/RootRunContext";
+import SnackBarContext from "src/context/SnackBarContext";
+import { useCancelRun, useRerun } from "src/hooks/resolutionHooks";
+
+const ANCHOR_OFFSET = {x: 13, y: -38};
+
+interface RunSectionActionMenuProps {
+    anchorEl: HTMLElement | null;
+}
+
+function RunSectionActionMenu(props: RunSectionActionMenuProps) {
+    const { anchorEl } = props;
+
+    const { rootRun, resolution } = useRootRunContext();
+
+    const { setSnackMessage } = useContext(SnackBarContext);
+
+    const [rerunState, rerun] = useRerun(rootRun!.id, rootRun!.id);
+    const [cancelRunState, cancel] = useCancelRun(rootRun!.id);
+
+    const cancelEnabled = useMemo(
+        () => {
+            if (!rootRun) {
+                return false;
+            }
+            if (cancelRunState.loading) {
+                return false;
+            }
+            return !["FAILED", "NESTED_FAILED", "RESOLVED", "CANCELED"].includes(
+                rootRun!.future_state
+            );
+        }, [rootRun, cancelRunState]
+    );
+
+    const rerunEnable = useMemo(
+        () => !!resolution?.container_image_uri && !rerunState.loading,
+        [resolution, rerunState]
+    );
+
+    const onCopyShareClick = useCallback(() => {
+        navigator.clipboard.writeText(window.location.href);
+        setSnackMessage({ message: "Resolution link copied" });
+    }, [setSnackMessage]);
+
+    const commands = useMemo(() => {
+        return [
+            {
+                title: "Rerun",
+                disabled: !rerunEnable,
+                onClick: async () => {
+                    try {
+                        rerun();
+                    } catch (error) {
+                        setSnackMessage({ message: "Failed to trigger rerun." });
+                    }
+                }
+            },
+            {
+                title: "Cancel",
+                disabled: !cancelEnabled,
+                onClick: () => {
+                    try {
+                        cancel();
+                    } catch (error) {
+                        setSnackMessage({ message: "Failed to cancel pipeline run." });
+                    }
+                }
+            },
+            {
+                title: "Share",
+                onClick: onCopyShareClick
+            }
+        ]
+    }, [setSnackMessage, rerun, cancel, onCopyShareClick, rerunEnable, cancelEnabled]);
+
+    return <ContextMenu anchorEl={anchorEl} commands={commands} anchorOffset={ANCHOR_OFFSET} />;
+}
+
+export default RunSectionActionMenu;

--- a/sematic/ui/packages/common/src/theme/new/components.ts
+++ b/sematic/ui/packages/common/src/theme/new/components.ts
@@ -297,6 +297,28 @@ const components: Components = {
                 "textAlign": "left",
             })) as any
         }
+    },
+    MuiMenu: {
+        styleOverrides: {
+            "list": {
+                "padding": "0",
+            }
+        }
+    },
+    MuiMenuItem: {
+        styleOverrides: {
+            root: (({ theme }: { theme: Theme }) => ({
+                "fontSize": `${theme.typography.fontSize}px`,
+                "textAlign": "left",
+                "width": "300px",
+                "height": "50px",
+                "fontWeight": theme.typography.fontWeightBold,
+                "&:hover": {
+                    "backgroundColor": theme.palette.primary.main,
+                    "color": theme.palette.white.main,
+                }
+            })) as any
+        }
     }
 }
 


### PR DESCRIPTION
Add context menus on the run details page. 

This PR implements the context menu for 4 places on the run details page.

![image](https://github.com/sematic-ai/sematic/assets/133257643/277c693b-ed18-4342-ade4-f7b4eea16b75)

This PR also implements a error state for metrics error:

<img width="302" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/a75350bd-85f1-44b8-9257-b2b63151e806">


The change can be previewed from _my_ workspace.
