### PR TITLE
Use in operator for the run search filters

### DIFF
--- a/sematic/ui/packages/common/src/ApiContracts.ts
+++ b/sematic/ui/packages/common/src/ApiContracts.ts
@@ -55,10 +55,10 @@ export type BasicMetricsPayload = {
     }
 }
 
-type Operator = "eq" | "contains";
+type Operator = "eq" | "contains" | "in";
 
 export type FilterCondition = {
-    [key: string]: { [eq in Operator]?: string | null } | undefined
+    [key: string]: { [eq in Operator]?: string | null | Array<string> } | undefined
 }
 
 export type Filter = FilterCondition | {

--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -75,7 +75,7 @@ export function useFiltersConverter(filters: AllFilters | null) {
         if (filters[FilterType.TAGS]) {
             const statusFilters = convertTagsFilterToRunFilters(filters[FilterType.TAGS] as StatusFilters[]);
             if (statusFilters) {
-                conditions.push(statusFilters);
+                statusFilters.forEach(filter => conditions.push(filter));
             }
         }
 


### PR DESCRIPTION
Use `in` operator instead of `or` operator to avoid the deficiency of supporting nested boolean operations.

For tags search, each tag value will be `and`ed. This avoids the need to support `{'OR': [{tag: {contains: v1}}, {tag: {contains: v2}}]}`