### PR TITLE
Dagview selection

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
@@ -2,18 +2,22 @@ import styled from "@emotion/styled";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import IconButton from "@mui/material/IconButton";
-import { useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { NodeProps, Position } from "reactflow";
 import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming, useNodeExpandStateToggle } from "src/hooks/dagHooks";
-import { StyledHandle } from "src/pages/RunDetails/dag/common";
+import { DagViewServiceContext, StyledHandle } from "src/pages/RunDetails/dag/common";
 import theme from "src/theme/new";
 
-const CompoundNodeContainer = styled.div`
+const CompoundNodeContainer = styled("div", {
+    shouldForwardProp: (prop) => prop !== "selected"
+}) <{
+    selected?: boolean;
+}>`
     width: min-content;
     display: flex;
     align-items: center;
-    border-width: 1px;
+    border-width: ${({ selected }) => selected ? 2 : 1}px;
     border-style: solid;
     border-radius: 4px;
 `;
@@ -47,7 +51,7 @@ export const StyledIconButton = styled(IconButton)`
 
 function CompoundNode(props: NodeProps) {
     const { data } = props;
-    const { run } = data;
+    const { run, selected } = data;
 
     const { toggleExpanded, expanded } = useNodeExpandStateToggle(data);
 
@@ -55,7 +59,15 @@ function CompoundNode(props: NodeProps) {
 
     const stateChip = useMemo(() => getRunStateChipByState(run.future_state), [run.future_state]);
     const color = useMemo(() => getRunStateColorByState(run.future_state), [run.future_state]);
-    return <CompoundNodeContainer style={{ width: `${data.width}px`, height: `${data.height}px`, borderColor: color }}>
+
+    const { onNodeClick } = useContext(DagViewServiceContext)
+
+    const onClick = useCallback(() => {
+        onNodeClick(run.id);
+    }, [onNodeClick, run]);
+
+    return <CompoundNodeContainer selected={selected} onClick={onClick}
+        style={{ width: `${data.width}px`, height: `${data.height}px`, borderColor: color }}>
         {hasIncoming && <StyledHandle type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
             {stateChip}

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
@@ -1,19 +1,23 @@
 import styled from "@emotion/styled";
-import { useMemo } from "react";
+import { useMemo, useCallback, useContext } from "react";
 import { NodeProps, Position } from "reactflow";
 import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming } from "src/hooks/dagHooks";
-import { LEFT_NODE_MAX_WIDTH, StyledHandle } from "src/pages/RunDetails/dag/common";
+import { DagViewServiceContext, LEFT_NODE_MAX_WIDTH, StyledHandle } from "src/pages/RunDetails/dag/common";
 import { SPACING } from "src/pages/RunDetails/dag/dagLayout";
 import theme from "src/theme/new";
 
-const LeftNodeContainer = styled.div`
+const LeftNodeContainer = styled("div", {
+    shouldForwardProp: (prop) => prop !== "selected"
+}) <{
+    selected?: boolean;
+}>`
     width: max-content;
     max-width: ${LEFT_NODE_MAX_WIDTH}px;
     height: 50px;
     display: flex;
     align-items: center;
-    border: 1px solid #ccc;
+    border: ${({ selected }) => selected ? 2 : 1}px solid #ccc;
     border-radius: 4px;
 `;
 
@@ -32,12 +36,20 @@ export const LabelContainer = styled.div`
 
 function LeafNode(props: NodeProps) {
     const { data } = props;
-    const { run } = data;
+    const { run, selected } = data;
     const stateChip = useMemo(() => getRunStateChipByState(run.future_state), [run.future_state]);
     const color = useMemo(() => getRunStateColorByState(run.future_state), [run.future_state]);
     const hasIncoming = useHasIncoming();
 
-    return <LeftNodeContainer style={{ paddingRight: `${SPACING}px`, borderColor: color }}>
+    const { onNodeClick } = useContext(DagViewServiceContext)
+
+    const onClick = useCallback(() => {
+        onNodeClick(run.id);
+    }, [onNodeClick, run]);
+
+    return <LeftNodeContainer selected={selected} style={{ paddingRight: `${SPACING}px`, borderColor: color }}
+        onClick={onClick}
+    >
         {hasIncoming && <StyledHandle type="target" position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
             {stateChip}

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/common.ts
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { Handle } from "reactflow";
 import theme from "src/theme/new";
+import { createContext } from "react";
+import noop from "lodash/noop";
 
 export const LEFT_NODE_MAX_WIDTH = 250;
 
@@ -11,10 +13,14 @@ export enum NodeTypes {
 
 export const StyledHandle = styled(Handle, {
     shouldForwardProp: (prop) => prop !== "color",
-})<{
+}) <{
     color?: string;
 }>`
     height: 12px;
     width: 12px;
     background-color: ${(props) => props.color || theme.palette.success.main};
 `;
+
+export const DagViewServiceContext = createContext<{
+    onNodeClick: (nodeId: string) => void;
+}>({ onNodeClick: noop });

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/dagLayout.ts
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/dagLayout.ts
@@ -129,12 +129,15 @@ export function getReactFlowDag(graph: Graph | undefined, selectedRun: Run | und
         return {
             type: NodeTypes.LEAF,
             id: run.id,
-            data: { label: run.name, run, argNames: runArgNames },
+            data: {
+                label: run.name, run, argNames: runArgNames,
+                selected: run.id === selectedRun?.id,
+            },
             parentNode: run.parent_id === null ? undefined : run.parent_id,
-            selected: run.id === selectedRun?.id,
             position: { x: 0, y: 0 },
             extent: run.parent_id === null ? undefined : "parent",
             zIndex: 0,
+            selectable: false
         };
     });
     


### PR DESCRIPTION
1. Render the selected run node in the Dag view with thicker border.
2. Upon clicking a run node in the Dag view, jump to the run details for the selected node (switching away from dagview).
3. Dag view is still draggable.

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/17877874-5657-4d25-b15c-b799d41a4dd4)
