### PR TITLE
Fix matplotlib viz

### DIFF
--- a/sematic/ui/packages/common/src/typeViz/vizMapping.ts
+++ b/sematic/ui/packages/common/src/typeViz/vizMapping.ts
@@ -47,6 +47,7 @@ const meta: Array<[string, RenderDetails]> = [
     ["enum.Enum", { value: EnumValueView }],
     ["plotly.graph_objs._figure.Figure", { value: PlotlyFigureValueView, nested: PlotlyFigureExpandedView }],
     ["torch.utils.data.dataloader.DataLoader", { value: TorchDataLoaderValueView, nested: TorchDataFieldsView }],
+    ["matplotlib.figure.Figure", {value: ImageValueView, nested: ImageExpandedView}],
     ["pandas.core.frame.DataFrame", { value: DataFrameValueView, nested: DataFrameDetailsView }],
     ["DataFrameDataPreview", { value: DataFrameSummaryView, nested: DataFrameSummaryExpandedView }],
     ["DataFrameDataDescribe", { value: DataFrameSummaryView, nested: DataFrameSummaryExpandedView }],

--- a/sematic/ui/packages/main/src/types/Types.tsx
+++ b/sematic/ui/packages/main/src/types/Types.tsx
@@ -86,6 +86,12 @@ const meta: Array<[string, ComponentRenderDetails]> = [
             value: ImageValueView,
         },
     ],
+    [
+        "matplotlib.figure.Figure",
+        {
+            value: ImageValueView,
+        },
+    ],
 ];
 
 meta.forEach(([key, value]) => {


### PR DESCRIPTION
Matplot lib viz regressed, since it got removed from the front-end type registry when we moved it to store the summary as an image. This restores it to functionality. Now works in both new and old UIs.

<img width="914" alt="Screenshot 2023-06-15 at 10 05 29 AM" src="https://github.com/sematic-ai/sematic/assets/7181589/410f429c-e93e-47aa-9ac3-f5e1f436b7c2">

<img width="938" alt="Screenshot 2023-06-15 at 10 05 49 AM" src="https://github.com/sematic-ai/sematic/assets/7181589/7a301167-de65-4321-bdb8-1919eb670e63">


