### PR TITLE
[2/N] Add Organizations associations

### DIFF
--- a/sematic/db/BUILD
+++ b/sematic/db/BUILD
@@ -43,7 +43,7 @@ exports_files(
 
 sematic_py_lib(
     name = "migrate_lib",
-    srcs = ["migrate.py"],
+    srcs = ["migrate.py", "migration_utils.py"],
     data = glob(
         [
             "migrations/*.sql",

--- a/sematic/db/migration_utils.py
+++ b/sematic/db/migration_utils.py
@@ -1,0 +1,65 @@
+# Standard Library
+import logging
+import os
+import shutil
+
+# Sematic
+from sematic.config.config import get_config
+
+logger = logging.getLogger(__name__)
+
+SQLITE_SCHEMA = "sqlite://"
+
+
+def back_up_db_file(suffix: str) -> None:
+    try:
+        url = get_config().db_url
+        if not url.startswith(SQLITE_SCHEMA):
+            raise ValueError(
+                f"Unable to locate Sqlite database file based on configuration: {url}"
+            )
+
+        schema_length = len(SQLITE_SCHEMA)
+        db_file_path = url[schema_length:]
+        if not os.path.exists(db_file_path):
+            raise ValueError(f"Sqlite database file {db_file_path} does not exist")
+
+        backup_file_path = f"{db_file_path}_{suffix}.bck"
+
+        if os.path.exists(backup_file_path):
+            os.remove(backup_file_path)
+
+        shutil.copyfile(db_file_path, backup_file_path)
+
+    except BaseException as e:
+        logger.exception("Unable to back up Sqlite database file: %s", str(e))
+
+
+def reinstate_db_file_from_backup(suffix: str) -> None:
+    try:
+        url = get_config().db_url
+        if not url.startswith(SQLITE_SCHEMA):
+            raise ValueError(
+                f"Unable to locate Sqlite database file based on configuration: {url}"
+            )
+
+        schema_length = len(SQLITE_SCHEMA)
+        db_file_path = url[schema_length:]
+        backup_file_path = f"{db_file_path}_{suffix}.bck"
+
+        if not os.path.exists(backup_file_path):
+            raise ValueError(
+                f"Sqlite database backup file {backup_file_path} does not exist"
+            )
+        if os.path.getsize(backup_file_path) == 0:
+            raise ValueError(f"Sqlite database backup file {backup_file_path} is empty")
+
+        if os.path.exists(db_file_path):
+            down_backup_file_path = f"{db_file_path}.down.bck"
+            shutil.copyfile(db_file_path, down_backup_file_path)
+            os.remove(db_file_path)
+
+        shutil.copyfile(backup_file_path, db_file_path)
+
+    except BaseException as e:
+        logger.exception("Unable to reinstate Sqlite database backup file: %s", str(e))

--- a/sematic/db/migrations/20230706150252_pre_alembic_parity.py
+++ b/sematic/db/migrations/20230706150252_pre_alembic_parity.py
@@ -1,72 +1,16 @@
 # flake8: noqa E501
 # Standard Library
 import logging
-import os
-import shutil
 
 # Sematic
-from sematic.config.config import get_config
 from sematic.db.db import db
-
-SQLITE_SCHEMA = "sqlite://"
+from sematic.db.migration_utils import back_up_db_file, reinstate_db_file_from_backup
 
 logger = logging.getLogger(__name__)
 
 
-def _back_up_db_file(suffix: str) -> None:
-    try:
-        url = get_config().db_url
-        if not url.startswith(SQLITE_SCHEMA):
-            raise ValueError(
-                f"Unable to locate Sqlite database file based on configuration: {url}"
-            )
-
-        db_file_path = url[len(SQLITE_SCHEMA) :]
-        if not os.path.exists(db_file_path):
-            raise ValueError(f"Sqlite database file {db_file_path} does not exist")
-
-        backup_file_path = f"{db_file_path}_{suffix}.bck"
-
-        if os.path.exists(backup_file_path):
-            os.remove(backup_file_path)
-
-        shutil.copyfile(db_file_path, backup_file_path)
-
-    except BaseException as e:
-        logger.exception("Unable to back up Sqlite database file: %s", str(e))
-
-
-def _reinstate_db_file_from_backup(suffix: str) -> None:
-    try:
-        url = get_config().db_url
-        if not url.startswith(SQLITE_SCHEMA):
-            raise ValueError(
-                f"Unable to locate Sqlite database file based on configuration: {url}"
-            )
-
-        db_file_path = url[len(SQLITE_SCHEMA) :]
-        backup_file_path = f"{db_file_path}_{suffix}.bck"
-
-        if not os.path.exists(backup_file_path):
-            raise ValueError(
-                f"Sqlite database backup file {backup_file_path} does not exist"
-            )
-        if os.path.getsize(backup_file_path) == 0:
-            raise ValueError(f"Sqlite database backup file {backup_file_path} is empty")
-
-        if os.path.exists(db_file_path):
-            down_backup_file_path = f"{db_file_path}.down.bck"
-            shutil.copyfile(db_file_path, down_backup_file_path)
-            os.remove(db_file_path)
-
-        shutil.copyfile(backup_file_path, db_file_path)
-
-    except BaseException as e:
-        logger.exception("Unable to reinstate Sqlite database backup file: %s", str(e))
-
-
 def sqlite_up():
-    _back_up_db_file("0.31.2")
+    back_up_db_file("0.31.2")
 
     with db().get_engine().begin() as conn:
         conn.execute(
@@ -392,7 +336,7 @@ def sqlite_up():
 
 
 def sqlite_down():
-    _reinstate_db_file_from_backup("0.31.2")
+    reinstate_db_file_from_backup("0.31.2")
 
 
 def postgres_up():

--- a/sematic/db/migrations/20230712121255_add_organizations_associations.py
+++ b/sematic/db/migrations/20230712121255_add_organizations_associations.py
@@ -1,0 +1,296 @@
+# flake8: noqa E501
+# Standard Library
+import logging
+import os
+import shutil
+
+# Sematic
+from sematic.config.config import get_config
+from sematic.db.db import db
+
+SQLITE_SCHEMA = "sqlite://"
+
+logger = logging.getLogger(__name__)
+
+
+def _back_up_db_file(suffix: str) -> None:
+    try:
+        url = get_config().db_url
+        if not url.startswith(SQLITE_SCHEMA):
+            raise ValueError(
+                f"Unable to locate Sqlite database file based on configuration: {url}"
+            )
+
+        db_file_path = url[len(SQLITE_SCHEMA) :]
+        if not os.path.exists(db_file_path):
+            raise ValueError(f"Sqlite database file {db_file_path} does not exist")
+
+        backup_file_path = f"{db_file_path}_{suffix}.bck"
+
+        if os.path.exists(backup_file_path):
+            os.remove(backup_file_path)
+
+        shutil.copyfile(db_file_path, backup_file_path)
+
+    except BaseException as e:
+        logger.exception("Unable to back up Sqlite database file: %s", str(e))
+
+
+def _reinstate_db_file_from_backup(suffix: str) -> None:
+    try:
+        url = get_config().db_url
+        if not url.startswith(SQLITE_SCHEMA):
+            raise ValueError(
+                f"Unable to locate Sqlite database file based on configuration: {url}"
+            )
+
+        db_file_path = url[len(SQLITE_SCHEMA) :]
+        backup_file_path = f"{db_file_path}_{suffix}.bck"
+
+        if not os.path.exists(backup_file_path):
+            raise ValueError(
+                f"Sqlite database backup file {backup_file_path} does not exist"
+            )
+        if os.path.getsize(backup_file_path) == 0:
+            raise ValueError(f"Sqlite database backup file {backup_file_path} is empty")
+
+        if os.path.exists(db_file_path):
+            down_backup_file_path = f"{db_file_path}.down.bck"
+            shutil.copyfile(db_file_path, down_backup_file_path)
+            os.remove(db_file_path)
+
+        shutil.copyfile(backup_file_path, db_file_path)
+
+    except BaseException as e:
+        logger.exception("Unable to reinstate Sqlite database backup file: %s", str(e))
+
+
+def up_sqlite():
+    _back_up_db_file(suffix="0.31.2")
+
+    with db().get_engine().begin() as conn:
+        conn.execute(
+            """
+            CREATE TABLE resolutions_new (
+                    root_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    container_image_uri TEXT,
+                    settings_env_vars JSONB NOT NULL,
+                    git_info_json JSONB,
+                    container_image_uris JSONB,
+                    client_version TEXT,
+                    cache_namespace TEXT,
+                    user_id character(32),
+                    run_command TEXT,
+                    build_config TEXT,
+                    organization_id character(32),
+
+                    PRIMARY KEY (root_id),
+                    FOREIGN KEY (root_id) REFERENCES runs(id),
+                    FOREIGN KEY (user_id) REFERENCES users(id),
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO resolutions_new
+                SELECT
+                    root_id,
+                    status,
+                    kind,
+                    container_image_uri,
+                    settings_env_vars,
+                    git_info_json,
+                    container_image_uris,
+                    client_version,
+                    cache_namespace,
+                    user_id,
+                    run_command,
+                    build_config,
+                    NULL
+                FROM resolutions;
+            """
+        )
+        conn.execute("DROP TABLE resolutions;")
+        conn.execute("ALTER TABLE resolutions_new RENAME TO resolutions;")
+
+        conn.execute(
+            """
+            CREATE TABLE runs_new (
+                    id character(32) NOT NULL,
+                    future_state TEXT NOT NULL,
+                    name TEXT,
+                    function_path TEXT NOT NULL,
+                    created_at timestamp WITH time zone NOT NULL,
+                    updated_at timestamp WITH time zone NOT NULL,
+                    started_at timestamp,
+                    ended_at timestamp,
+                    resolved_at timestamp,
+                    failed_at timestamp,
+                    parent_id character(32),
+                    description TEXT,
+                    tags TEXT NOT NULL,
+                    source_code TEXT NOT NULL,
+                    root_id character(32) NOT NULL,
+                    nested_future_id character(32),
+                    resource_requirements_json JSONB,
+                    exception_metadata_json JSONB,
+                    container_image_uri TEXT,
+                    external_exception_metadata_json JSONB,
+                    original_run_id character(32),
+                    cache_key TEXT,
+                    user_id character(32),
+                    organization_id character(32),
+
+                    PRIMARY KEY (id),
+
+                    FOREIGN KEY(root_id) REFERENCES runs (id),
+                    FOREIGN KEY (user_id) REFERENCES users(id),
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO runs_new
+                SELECT
+                    id,
+                    future_state,
+                    name,
+                    function_path,
+                    created_at,
+                    updated_at,
+                    started_at,
+                    ended_at,
+                    resolved_at,
+                    failed_at,
+                    parent_id,
+                    description,
+                    tags,
+                    source_code,
+                    root_id,
+                    nested_future_id,
+                    resource_requirements_json,
+                    exception_metadata_json,
+                    container_image_uri,
+                    external_exception_metadata_json,
+                    original_run_id,
+                    cache_key,
+                    user_id,
+                    NULL
+                FROM runs;
+            """
+        )
+        conn.execute("DROP TABLE runs;")
+        conn.execute("ALTER TABLE runs_new RENAME TO runs;")
+        conn.execute("CREATE INDEX ix_runs_cache_key ON runs (cache_key);")
+        conn.execute("CREATE INDEX ix_runs_function_path ON runs (function_path);")
+
+        conn.execute(
+            """
+            CREATE TABLE metric_labels_new (
+                    metric_id TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    metric_labels JSONB NOT NULL DEFAULT '{}',
+                    metric_type SMALLINT NOT NULL,
+                    organization_id character(32),
+
+                    PRIMARY KEY (metric_id),
+
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO metric_labels_new
+                SELECT
+                    metric_id,
+                    metric_name,
+                    metric_labels,
+                    metric_type,
+                    NULL
+                FROM metric_labels;
+            """
+        )
+        conn.execute("DROP TABLE metric_labels;")
+        conn.execute("ALTER TABLE metric_labels_new RENAME TO metric_labels;")
+        conn.execute(
+            "CREATE UNIQUE INDEX metric_labels_name_labels_idx ON metric_labels(metric_name, metric_labels);"
+        )
+
+        conn.execute(
+            """
+            CREATE TABLE artifacts_new (
+                id character(40) NOT NULL,
+                json_summary JSONB NOT NULL,
+                created_at timestamp NOT NULL,
+                updated_at timestamp NOT NULL,
+                type_serialization JSONB NOT NULL,
+                organization_id character(32),
+
+                PRIMARY KEY (id),
+
+                FOREIGN KEY (organization_id) REFERENCES organizations(id)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO artifacts_new
+                SELECT
+                    id,
+                    json_summary,
+                    created_at,
+                    updated_at,
+                    type_serialization,
+                    NULL
+                FROM artifacts;
+            """
+        )
+        conn.execute("DROP TABLE artifacts;")
+        conn.execute("ALTER TABLE artifacts_new RENAME TO artifacts;")
+
+
+def down_sqlite():
+    _reinstate_db_file_from_backup(suffix="0.31.2")
+
+
+def up_postgres():
+    with db().get_engine().begin() as conn:
+        conn.execute(
+            """
+            ALTER TABLE resolutions ADD COLUMN organization_id REFERENCES organizations(id);
+            ALTER TABLE runs ADD COLUMN organization_id REFERENCES organizations(id);
+            ALTER TABLE metric_labels ADD COLUMN organization_id REFERENCES organizations(id);
+            ALTER TABLE artifacts ADD COLUMN organization_id REFERENCES organizations(id);
+            """
+        )
+
+
+def down_postgres():
+    with db().get_engine().begin() as conn:
+        conn.execute(
+            """
+            ALTER TABLE resolutions DROP COLUMN organization_id;
+            ALTER TABLE runs DROP COLUMN organization_id;
+            ALTER TABLE metric_labels DROP COLUMN organization_id;
+            ALTER TABLE artifacts DROP COLUMN organization_id;
+            """
+        )
+
+
+def up():
+    if db().get_engine().url.drivername == "sqlite":
+        up_sqlite()
+    else:
+        up_postgres()
+
+
+def down():
+    if db().get_engine().url.drivername == "sqlite":
+        down_sqlite()
+    else:
+        down_postgres()

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -6,6 +6,7 @@ sematic_py_lib(
     ],
     deps = [
         ":base",
+        "//sematic/db/models/mixins:has_organization_mixin",
         "//sematic/db/models/mixins:json_encodable_mixin",
     ],
 )
@@ -100,6 +101,7 @@ sematic_py_lib(
         ":base",
         "//sematic:abstract_function",
         "//sematic:abstract_future",
+        "//sematic/db/models/mixins:has_organization_mixin",
         "//sematic/db/models/mixins:has_user_mixin",
         "//sematic/db/models/mixins:json_encodable_mixin",
         "//sematic/types:serialization",
@@ -128,6 +130,7 @@ sematic_py_lib(
     deps = [
         ":base",
         ":git_info",
+        "//sematic/db/models/mixins:has_organization_mixin",
         "//sematic/db/models/mixins:has_user_mixin",
         "//sematic/db/models/mixins:json_encodable_mixin",
     ],

--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -10,7 +10,7 @@ from sematic.db.models.mixins.has_organization_mixin import HasOrganizationMixin
 from sematic.db.models.mixins.json_encodable_mixin import JSON_KEY, JSONEncodableMixin
 
 
-class Artifact(HasOrganizationMixin, Base, JSONEncodableMixin):
+class Artifact(Base, HasOrganizationMixin, JSONEncodableMixin):
     # we use content-addressed values for artifacts, with the id being
     # generated from the type and value themselves
     # when a resolution generates an artifact which has been seen before and which is

--- a/sematic/db/models/artifact.py
+++ b/sematic/db/models/artifact.py
@@ -6,10 +6,11 @@ from sqlalchemy import Column, types
 
 # Sematic
 from sematic.db.models.base import Base
+from sematic.db.models.mixins.has_organization_mixin import HasOrganizationMixin
 from sematic.db.models.mixins.json_encodable_mixin import JSON_KEY, JSONEncodableMixin
 
 
-class Artifact(Base, JSONEncodableMixin):
+class Artifact(HasOrganizationMixin, Base, JSONEncodableMixin):
     # we use content-addressed values for artifacts, with the id being
     # generated from the type and value themselves
     # when a resolution generates an artifact which has been seen before and which is

--- a/sematic/db/models/mixins/BUILD
+++ b/sematic/db/models/mixins/BUILD
@@ -10,6 +10,15 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "has_organization_mixin",
+    srcs = ["has_organization_mixin.py"],
+    pip_deps = [
+        "sqlalchemy",
+    ],
+    deps = [],
+)
+
+sematic_py_lib(
     name = "has_user_mixin",
     srcs = ["has_user_mixin.py"],
     pip_deps = [

--- a/sematic/db/models/mixins/has_organization_mixin.py
+++ b/sematic/db/models/mixins/has_organization_mixin.py
@@ -1,0 +1,23 @@
+# Standard Library
+from typing import Optional
+
+# Third-party
+from sqlalchemy import Column, ForeignKey, types
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import Mapped, declarative_mixin
+
+
+@declarative_mixin
+class HasOrganizationMixin:
+    """
+    Mixin for models that may have an associated Organization.
+
+    Attributes
+    ----------
+    organization_id: Optional[str]
+        The ID of the Organization, if any.
+    """
+
+    @declared_attr
+    def organization_id(cls) -> Mapped[Optional[str]]:
+        return Column(types.String(), ForeignKey("organizations.id"), nullable=True)

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import validates
 # Sematic
 from sematic.db.models.base import Base
 from sematic.db.models.git_info import GitInfo
+from sematic.db.models.mixins.has_organization_mixin import HasOrganizationMixin
 from sematic.db.models.mixins.has_user_mixin import HasUserMixin
 from sematic.db.models.mixins.json_encodable_mixin import (
     ENUM_KEY,
@@ -155,7 +156,7 @@ class ResolutionKind(Enum):
     KUBERNETES = "KUBERNETES"  # for detached mode
 
 
-class Resolution(HasUserMixin, Base, JSONEncodableMixin):
+class Resolution(HasUserMixin, HasOrganizationMixin, Base, JSONEncodableMixin):
     """Represents a session of a resolver.
 
     Attributes
@@ -187,6 +188,8 @@ class Resolution(HasUserMixin, Base, JSONEncodableMixin):
         be cached, as long as they also have the `cache` flag activated.
     user_id:
         User who submitted this resolution.
+    organization_id:
+        The organization under which this resolution was submitted.
     run_command:
         The CLI command used to launch this resolution, if applicable.
     build_config:

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -156,7 +156,7 @@ class ResolutionKind(Enum):
     KUBERNETES = "KUBERNETES"  # for detached mode
 
 
-class Resolution(HasUserMixin, HasOrganizationMixin, Base, JSONEncodableMixin):
+class Resolution(Base, HasUserMixin, HasOrganizationMixin, JSONEncodableMixin):
     """Represents a session of a resolver.
 
     Attributes

--- a/sematic/db/models/run.py
+++ b/sematic/db/models/run.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import relationship, validates
 from sematic.abstract_function import AbstractFunction
 from sematic.abstract_future import FutureState
 from sematic.db.models.base import Base
+from sematic.db.models.mixins.has_organization_mixin import HasOrganizationMixin
 from sematic.db.models.mixins.has_user_mixin import HasUserMixin
 from sematic.db.models.mixins.json_encodable_mixin import (
     CONTAIN_FILTER_KEY,
@@ -30,7 +31,7 @@ from sematic.types.serialization import (
 from sematic.utils.exceptions import ExceptionMetadata
 
 
-class Run(HasUserMixin, Base, JSONEncodableMixin):
+class Run(HasUserMixin, HasOrganizationMixin, Base, JSONEncodableMixin):
     """
     SQLAlchemy model for runs.
 
@@ -89,6 +90,8 @@ class Run(HasUserMixin, Base, JSONEncodableMixin):
         If present, the key under which the run's output artifact will be cached.
     user_id: Optional[str]
         Users who submitted this run.
+    organization_id: Optional[str]
+        The organization under which this resolution was submitted.
     """
 
     __tablename__ = "runs"

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -181,6 +181,84 @@ CREATE TABLE organizations_users (
     FOREIGN KEY(organization_id) REFERENCES organizations (id),
     FOREIGN KEY(user_id) REFERENCES users (id)
 );
+CREATE TABLE IF NOT EXISTS "resolutions" (
+                    root_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    container_image_uri TEXT,
+                    settings_env_vars JSONB NOT NULL,
+                    git_info_json JSONB,
+                    container_image_uris JSONB,
+                    client_version TEXT,
+                    cache_namespace TEXT,
+                    user_id character(32),
+                    run_command TEXT,
+                    build_config TEXT,
+                    organization_id character(32),
+
+                    PRIMARY KEY (root_id),
+                    FOREIGN KEY (root_id) REFERENCES runs(id),
+                    FOREIGN KEY (user_id) REFERENCES users(id),
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+CREATE TABLE IF NOT EXISTS "runs" (
+                    id character(32) NOT NULL,
+                    future_state TEXT NOT NULL,
+                    name TEXT,
+                    function_path TEXT NOT NULL,
+                    created_at timestamp WITH time zone NOT NULL,
+                    updated_at timestamp WITH time zone NOT NULL,
+                    started_at timestamp,
+                    ended_at timestamp,
+                    resolved_at timestamp,
+                    failed_at timestamp,
+                    parent_id character(32),
+                    description TEXT,
+                    tags TEXT NOT NULL,
+                    source_code TEXT NOT NULL,
+                    root_id character(32) NOT NULL,
+                    nested_future_id character(32),
+                    resource_requirements_json JSONB,
+                    exception_metadata_json JSONB,
+                    container_image_uri TEXT,
+                    external_exception_metadata_json JSONB,
+                    original_run_id character(32),
+                    cache_key TEXT,
+                    user_id character(32),
+                    organization_id character(32),
+
+                    PRIMARY KEY (id),
+
+                    FOREIGN KEY(root_id) REFERENCES runs (id),
+                    FOREIGN KEY (user_id) REFERENCES users(id),
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+CREATE INDEX ix_runs_cache_key ON runs (cache_key);
+CREATE INDEX ix_runs_function_path ON runs (function_path);
+CREATE TABLE IF NOT EXISTS "metric_labels" (
+                    metric_id TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    metric_labels JSONB NOT NULL DEFAULT '{}',
+                    metric_type SMALLINT NOT NULL,
+                    organization_id character(32),
+
+                    PRIMARY KEY (metric_id),
+
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+CREATE UNIQUE INDEX metric_labels_name_labels_idx ON metric_labels(metric_name, metric_labels);
+CREATE TABLE IF NOT EXISTS "artifacts" (
+                id character(40) NOT NULL,
+                json_summary JSONB NOT NULL,
+                created_at timestamp NOT NULL,
+                updated_at timestamp NOT NULL,
+                type_serialization JSONB NOT NULL,
+                organization_id character(32),
+
+                PRIMARY KEY (id),
+
+                FOREIGN KEY (organization_id) REFERENCES organizations(id)
+            );
 -- schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20220424062956'),

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -31,72 +31,6 @@ CREATE TABLE IF NOT EXISTS "users" (
 
     PRIMARY KEY (id)
 );
-CREATE TABLE metric_labels (
-    metric_id TEXT NOT NULL PRIMARY KEY,
-    metric_name TEXT NOT NULL,
-    metric_labels JSONB NOT NULL DEFAULT '{}',
-    metric_type SMALLINT NOT NULL
-);
-CREATE UNIQUE INDEX metric_labels_name_labels_idx ON metric_labels(metric_name, metric_labels);
-CREATE TABLE IF NOT EXISTS "runs" (
-                id character(32) NOT NULL,
-                future_state TEXT NOT NULL,
-                name TEXT,
-                function_path TEXT NOT NULL,
-                created_at timestamp WITH time zone NOT NULL,
-                updated_at timestamp WITH time zone NOT NULL,
-                started_at timestamp,
-                ended_at timestamp,
-                resolved_at timestamp,
-                failed_at timestamp,
-                parent_id character(32),
-                description TEXT,
-                tags TEXT NOT NULL,
-                source_code TEXT NOT NULL,
-                root_id character(32) NOT NULL,
-                nested_future_id character(32),
-                resource_requirements_json JSONB,
-                exception_metadata_json JSONB,
-                container_image_uri TEXT,
-                external_exception_metadata_json JSONB,
-                original_run_id character(32),
-                cache_key TEXT,
-                user_id character(32),
-
-                PRIMARY KEY (id),
-
-                FOREIGN KEY(root_id) REFERENCES runs (id),
-                FOREIGN KEY(user_id) REFERENCES users (id)
-            );
-CREATE INDEX ix_runs_cache_key ON runs (cache_key);
-CREATE INDEX ix_runs_function_path ON runs (function_path);
-CREATE TABLE IF NOT EXISTS "artifacts" (
-                id character(40) NOT NULL,
-                json_summary JSONB NOT NULL,
-                created_at timestamp NOT NULL,
-                updated_at timestamp NOT NULL,
-                type_serialization JSONB NOT NULL,
-
-                PRIMARY KEY (id)
-            );
-CREATE TABLE IF NOT EXISTS "resolutions" (
-                root_id TEXT NOT NULL,
-                status TEXT NOT NULL,
-                kind TEXT NOT NULL,
-                container_image_uri TEXT,
-                settings_env_vars JSONB NOT NULL,
-                git_info_json JSONB,
-                container_image_uris JSONB,
-                client_version TEXT,
-                cache_namespace TEXT,
-                user_id character(32),
-                run_command TEXT,
-                build_config TEXT,
-
-                PRIMARY KEY (root_id),
-                FOREIGN KEY (root_id) REFERENCES runs(id),
-                FOREIGN KEY (user_id) REFERENCES users(id)
-            );
 CREATE TABLE IF NOT EXISTS "jobs" (
                 name TEXT NOT NULL,
                 namespace TEXT NOT NULL,
@@ -306,4 +240,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20230526141354'),
   ('20230627153433'),
   ('20230706150252'),
-  ('20230712105529');
+  ('20230712105529'),
+  ('20230712121255');

--- a/sematic/plugins/metrics_storage/sql/models/BUILD
+++ b/sematic/plugins/metrics_storage/sql/models/BUILD
@@ -4,6 +4,7 @@ sematic_py_lib(
     pip_deps = ["sqlalchemy"],
     deps = [
         "//sematic/db/models:base",
+        "//sematic/db/models/mixins:has_organization_mixin",
         "//sematic/metrics:metric_point",
         "//sematic/utils:db",
     ],

--- a/sematic/plugins/metrics_storage/sql/models/metric_label.py
+++ b/sematic/plugins/metrics_storage/sql/models/metric_label.py
@@ -4,11 +4,12 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 # Sematic
 from sematic.db.models.base import Base
+from sematic.db.models.mixins.has_organization_mixin import HasOrganizationMixin
 from sematic.metrics.metric_point import MetricsLabels, MetricType
 from sematic.utils.db import IntEnum
 
 
-class MetricLabel(Base):
+class MetricLabel(HasOrganizationMixin, Base):
     """
     A unique set of labels for a given metric name.
 
@@ -25,6 +26,8 @@ class MetricLabel(Base):
         A key/value dictionary of labels.
     metric_type: MetricType
         The metric's type.
+    organization_id: Optional[str]
+        The organization under which this resolution was submitted.
     """
 
     __tablename__ = "metric_labels"


### PR DESCRIPTION
This is the second of a series of PRs that will introduce the capability of defining and managing user organizations. The previous PR in the chain is #915.

This PR propagates the associations between existing data models and the `organizations` model, without code propagations. The new foreign key columns remain `NULL`. These will start to be populated once the Resolution submission API will supply an Organization ID.
