### PR TITLE
Add background color to side panels

### DIFF
--- a/sematic/ui/packages/common/src/component/menu.tsx
+++ b/sematic/ui/packages/common/src/component/menu.tsx
@@ -35,7 +35,7 @@ const HeaderMenu = (props: HeaderMenuProps) => {
                 className={selectedKey === "pipelines" ? "selected" : ""}>
                 Pipelines
             </MuiRouterLink>
-            <Link variant="subtitle1" type='menu' className={selectedKey === "metrics" ? "selected" : ""}>Metrics</Link>
+            {/* <Link variant="subtitle1" type='menu' className={selectedKey === "metrics" ? "selected" : ""}>Metrics</Link> */}
         </Box>
         <Box style={{ flexGrow: 1, display: "flex", justifyContent: "end" }} >
             <Link variant="subtitle1" type='menu'>Get Started</Link>

--- a/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/ThreeColumns.tsx
@@ -17,6 +17,7 @@ export const Left = styled.div`
     padding: 0 25px;
     box-sizing: border-box;
     overflow: hidden;
+    background: ${theme.palette.p1black.main};
 
     display: flex;
     flex-direction: column;
@@ -63,6 +64,7 @@ export const Right = styled.div`
     height: 100%;
     padding: 0 ${theme.spacing(2.4)};
     box-sizing: border-box;
+    background: ${theme.palette.p1black.main};
 `;
 
 export const Container = styled.div`

--- a/sematic/ui/packages/common/src/muitypes.d.ts
+++ b/sematic/ui/packages/common/src/muitypes.d.ts
@@ -20,6 +20,7 @@ declare module "@mui/material/styles" {
         lightGrey: PaletteColor;
         mediumGrey: PaletteColor;
         p3border: PaletteColor;
+        p1black: PaletteColor;
         white: PaletteColor;
     }
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/MetaDataPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/MetaDataPane.tsx
@@ -1,4 +1,3 @@
-import DebugSection from "src/pages/RunDetails/DebugSection";
 import GitSection from "src/pages/RunDetails/GitSection";
 import PipelineSection from "src/pages/RunDetails/PipelineSection";
 import RunSection from "src/pages/RunDetails/RunSection";
@@ -10,7 +9,6 @@ const MetaDataPane = () => {
         <RunSection />
         <GitSection />
         <RunTreeSection />
-        <DebugSection />
     </>;
 }
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunTreeSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunTreeSection.tsx
@@ -18,6 +18,7 @@ const StyledSection = styled(Section)`
 
 const ScrollableStyledSection = styled(StyledSection)`
     margin-top: 0;
+    padding-top: 0;
     margin-bottom: ${theme.spacing(3)};
     overflow-y: auto;
     overflow-x: hidden;

--- a/sematic/ui/packages/common/src/theme/new/palette.ts
+++ b/sematic/ui/packages/common/src/theme/new/palette.ts
@@ -18,6 +18,9 @@ const pallette: Record<string, PaletteColorOptions> = {
     p3border: {
         main: "rgba(0, 0, 0, 0.03)"
     },
+    p1black: {
+        main: "rgba(0, 0, 0, 0.01)"
+    },
     white: {
         main: common["white"],
         contrastText: "#2D2C2E",


### PR DESCRIPTION
The PR covers:

1. Add a background color (1% Black) to the side panels.
2. Hide the "building information", and "resolution logs" sections from the left side panel. (excluded from the first version of the new dashboard)
3. Hide the "metrics" menu item from the header bar. (excluded from the first version of the new dashboard)


Before:

<img width="1511" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/f2d3961c-157e-4ccd-945b-67dd4f94ce21">


After:

<img width="1514" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/8c31ae57-d9e9-4adf-a03d-166d1abdd84b">
