### PR TITLE
[New Dashboard] Hook up the notifications with snack message

### DIFF
--- a/sematic/ui/packages/common/src/context/SnackBarContext.ts
+++ b/sematic/ui/packages/common/src/context/SnackBarContext.ts
@@ -6,11 +6,12 @@ export type SnackMessage = {
     message: string;
     closeable?: boolean;
     autoHide?: boolean;
+    actionName?: string;
+    onClick?: () => void;
 }
 
 const SnackBarContext = createContext<{
     setSnackMessage: <T extends SnackMessage>(message: T) => void;
-}>({setSnackMessage: noop});
+}>({ setSnackMessage: noop });
 
 export default SnackBarContext;
-  

--- a/sematic/ui/packages/common/src/context/SnackBarProvider.tsx
+++ b/sematic/ui/packages/common/src/context/SnackBarProvider.tsx
@@ -1,8 +1,10 @@
-import SnackBarContext, { SnackMessage } from "src/context/SnackBarContext"
-import Snackbar from "@mui/material/Snackbar";
-import IconButton from "@mui/material/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
-import { useMemo, useCallback, useState } from "react";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Snackbar from "@mui/material/Snackbar";
+import noop from "lodash/noop";
+import { useCallback, useMemo, useState } from "react";
+import SnackBarContext, { SnackMessage } from "src/context/SnackBarContext";
 
 interface SnackBarProviderProps {
     children: React.ReactNode;
@@ -21,17 +23,27 @@ const SnackBarProvider = ({ children, setSnackMessageOverride }: SnackBarProvide
     }, [setSnackMessageOverride]);
 
     const snackBarAction = useMemo(() => {
-        if (snackBarMessage?.closeable ?? false) {
-            return <IconButton
+        const { actionName, onClick, closeable } = snackBarMessage ?? {};
+
+        return <>
+            {!!actionName && <Button
+                size="small"
+                onClick={() => {
+                    (onClick ?? noop)();
+                    setSnackMessage(undefined);
+                }}
+            >
+                {actionName}
+            </Button>}
+            {(closeable ?? false) && <IconButton
                 size="small"
                 aria-label="close"
                 color="inherit"
                 onClick={() => setSnackMessage(undefined)}
             >
                 <CloseIcon fontSize="small" />
-            </IconButton>
-        };
-        return undefined
+            </IconButton>}
+        </>
     }, [snackBarMessage]);
 
     return <SnackBarContext.Provider value={{ setSnackMessage: onSetSnackBarMessage }}>

--- a/sematic/ui/packages/common/src/hooks/pipelineSocketMonitorHooks.tsx
+++ b/sematic/ui/packages/common/src/hooks/pipelineSocketMonitorHooks.tsx
@@ -1,0 +1,65 @@
+import noop from "lodash/noop";
+import { useCallback, useContext, useEffect, useRef } from "react";
+import SnackBarContext from "src/context/SnackBarContext";
+import { useFetchLatestRun, useRunNavigation } from "src/hooks/runHooks";
+import { pipelineSocket } from "@sematic/common/src/sockets";
+
+function usePipelineSocketMonitor(functionPath: string, callbacks?: {
+    onCancel?: () => void,
+}) {
+    const { onCancel = noop } = callbacks || {};
+    const { setSnackMessage } = useContext(SnackBarContext);
+
+    const cancelCallback = useCallback((args: { function_path: string }) => {
+        if (args.function_path === functionPath) {
+            setSnackMessage({ message: "Pipeline run was canceled." });
+            onCancel();
+        }
+    }, [functionPath, onCancel, setSnackMessage]);
+
+    const loadRun = useFetchLatestRun(functionPath);
+
+    const navigate = useRunNavigation();
+
+    const pipelineUpdateCallback = useCallback(async (args: { function_path: string }) => {
+        if (args.function_path === functionPath) {
+            const run = await loadRun();
+            if (run.id !== latestRunId.current) {
+                setSnackMessage({
+                    message: "New run available.",
+                    actionName: "view",
+                    autoHide: false,
+                    closable: true,
+                    onClick: () => navigate(run.id),
+                });
+            }
+        }
+    }, [functionPath, loadRun, navigate, setSnackMessage]);
+
+    const latestRunId = useRef<string>();
+
+    useEffect(() => {
+        (async () => {
+            const run = await loadRun();
+            latestRunId.current = run.id;
+        })();
+    }, [loadRun]);
+
+    useEffect(() => {
+        pipelineSocket.on("cancel", cancelCallback);
+        return () => {
+            pipelineSocket.off("cancel", cancelCallback);
+        }
+    }, [cancelCallback]);
+
+    useEffect(() => {
+        pipelineSocket.on("update", pipelineUpdateCallback);
+        return () => {
+            pipelineSocket.off("update", pipelineUpdateCallback);
+        }
+    }, [pipelineUpdateCallback]);
+
+    return <></>;
+}
+
+export default usePipelineSocketMonitor;

--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -65,6 +65,32 @@ export function useFetchRuns(runFilters: Filter | undefined = undefined,
     return {isLoaded, isLoading, error, runs: runs?.content, reloadRuns};
 }
 
+export function useFetchLatestRun(functionPath: string) {
+    const runFilters = useMemo(
+        () => ({
+            AND: [
+                { parent_id: { eq: null } },
+                { function_path: { eq: functionPath } },
+            ],
+        }),
+        [functionPath]
+    );
+
+    const otherQueryParams = useMemo(
+        () => ({
+            limit: "1",
+        }), []
+    );
+
+    const {load} = useFetchRunsFn(runFilters, otherQueryParams);
+
+    const getRun = useCallback(async () => {
+        const payload = await load();
+        return payload.content[0];
+    }, [load]);
+    return getRun;
+}
+
 export function useFiltersConverter(filters: AllFilters | null) {
     const runFilter = useMemo(() => {
         const conditions = [];

--- a/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
@@ -20,7 +20,7 @@ const StyledChipContainer = styled.span`
 `;
 
 function StatusChips({ runs }: { runs: Run[] }) {
-    return <>{runs.map(run => <MuiRouterLink href={getRunUrlPattern(run.id)}>
+    return <>{runs.map((run, index) => <MuiRouterLink key={index} href={getRunUrlPattern(run.id)}>
         <StyledChipContainer key={`${run.id}---${run.future_state}`}>
             {getRunStateChipByState(run.future_state)}
         </StyledChipContainer></MuiRouterLink>)}

--- a/sematic/ui/packages/common/src/pages/PipelineRuns/index.tsx
+++ b/sematic/ui/packages/common/src/pages/PipelineRuns/index.tsx
@@ -6,6 +6,7 @@ import { Run } from "src/Models";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
 import RootRunContext from "src/context/RootRunContext";
 import RunDetailsSelectionContext from "src/context/RunDetailsSelectionContext";
+import usePipelineSocketMonitor from "src/hooks/pipelineSocketMonitorHooks";
 import { useFetchRuns } from "src/hooks/runHooks";
 import ThreeColumns from "src/layout/ThreeColumns";
 import PipelineInfoPane from "src/pages/PipelineRuns/PipelineInfoPane";
@@ -56,6 +57,7 @@ const PipelineRuns = (props: PipelineRunsProps) => {
         setSelectedPanel: noop
     }), [rootRun]);
 
+    usePipelineSocketMonitor(rootRun.function_path);
 
     return <RootRunContext.Provider value={rootRunContextValue}>
         <RunDetailsSelectionContext.Provider value={runSelectionContextValue}>

--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import parseJSON from "date-fns/parseJSON";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { DateTimeLong } from "src/component/DateTime";
 import Headline from "src/component/Headline";
 import ImportPath from "src/component/ImportPath";
@@ -105,6 +105,8 @@ const FunctionSection = () => {
     const { isGraphLoading } = useRootRunContext();
     const { selectedRun } = useRunDetailsSelectionContext();
 
+    const [isGraphLoaded, setIsGraphLoaded] = useState(() => !isGraphLoading);
+
     const statusText = useMemo(() => {
         if (!selectedRun) {
             return null;
@@ -128,29 +130,35 @@ const FunctionSection = () => {
 
     const contextMenuAnchor = useRef<HTMLButtonElement>(null);
 
+    useEffect(() => {
+        if (!isGraphLoading) {
+            setIsGraphLoaded(true);
+        }
+    }, [isGraphLoading]);
+
     return <StyledSection>
         <Headline>Function Run</Headline>
         <BoxContainer>
             <RunStateContainer>
-                {isGraphLoading ? <SmallPlaceholderSkeleton /> : getRunStateChipByState(selectedRun!.future_state)}
+                {!isGraphLoaded ? <SmallPlaceholderSkeleton /> : getRunStateChipByState(selectedRun!.future_state)}
             </RunStateContainer>
             <div className='Info'>
                 <FunctionName>
-                    {isGraphLoading ? <MediumPlaceholderSkeleton /> : selectedRun!.name}
+                    {!isGraphLoaded ? <MediumPlaceholderSkeleton /> : selectedRun!.name}
                 </FunctionName>
                 <div>
-                    {isGraphLoading ? <MediumPlaceholderSkeleton /> : <StyledRunReferenceLink runId={selectedRun!.id} />}
-                    {isGraphLoading ? <LongPlaceholderSkeleton /> : statusText}
+                    {!isGraphLoaded ? <MediumPlaceholderSkeleton /> : <StyledRunReferenceLink runId={selectedRun!.id} />}
+                    {!isGraphLoaded ? <LongPlaceholderSkeleton /> : statusText}
                 </div>
             </div>
         </BoxContainer>
         <ImportPathContainer>
-            {isGraphLoading ? <LongPlaceholderSkeleton />
+            {!isGraphLoaded ? <LongPlaceholderSkeleton />
                 : <ImportPath>{selectedRun?.function_path}</ImportPath>}
         </ImportPathContainer>
         <StyledVertButton ref={contextMenuAnchor} />
         <FunctionSectionActionMenu anchorEl={contextMenuAnchor.current} />
-        {isGraphLoading ? <MediumPlaceholderSkeleton />
+        {!isGraphLoaded ? <MediumPlaceholderSkeleton />
             : <TagsContainer>
                 <div className={"tags-list-wrapper"} key={selectedRun?.id}><TagsList tags={selectedRun?.tags || []} /></div>
                 {/** Adding tag is not currently supported will re-enable later */}

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -11,6 +11,7 @@ import RunsDropdown from "src/component/RunsDropdown";
 import Section from "src/component/Section";
 import TagsList from "src/component/TagsList";
 import RootRunContext, { useRootRunContext } from "src/context/RootRunContext";
+import usePipelineSocketMonitor from "src/hooks/pipelineSocketMonitorHooks";
 import { getRunUrlPattern, useFetchRuns } from "src/hooks/runHooks";
 import RunSectionActionMenu from "src/pages/RunDetails/contextMenus/RunSectionMenu";
 import theme from "src/theme/new";
@@ -67,13 +68,17 @@ const RunSection = () => {
 
     }, [resolution])
 
-    const { runs } = useFetchRuns(runFilters, otherQueryParams);
+    const { runs, reloadRuns } = useFetchRuns(runFilters, otherQueryParams);
 
     const onRootRunChange = useCallback((newRootRunId: unknown) => {
         navigate(getRunUrlPattern(newRootRunId as string));
     }, [navigate]);
 
     const contextMenuAnchor = useRef<HTMLButtonElement>(null);
+
+    usePipelineSocketMonitor(rootRun.function_path, useMemo(() => ({
+        onCancel: reloadRuns
+    }), [reloadRuns]));
 
     return (
         <StyledSection>

--- a/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineBar.tsx
@@ -15,6 +15,7 @@ import TimeAgo from "@sematic/common/src/component/TimeAgo";
 import SnackBarContext from "@sematic/common/src/context/SnackBarContext";
 import UserContext from "@sematic/common/src/context/UserContext";
 import { useFetchRuns, useRunNavigation } from "@sematic/common/src/hooks/runHooks";
+import { pipelineSocket } from "@sematic/common/src/sockets";
 import { ExtractContextType } from "@sematic/common/src/utils/typings";
 import { useCallback, useContext, useEffect, useMemo } from "react";
 import { ActionMenu, ActionMenuItem } from "src/components/ActionMenu";
@@ -26,7 +27,6 @@ import {
     usePipelineRunContext,
 } from "src/hooks/pipelineHooks";
 import PipelineRunViewContext from "src/pipelines/PipelineRunViewContext";
-import { pipelineSocket } from "src/sockets";
 import { abbreviatedUserName, fetchJSON } from "src/utils";
 
 function PipelineActionMenu(props: { onCancel: () => void }) {

--- a/sematic/ui/packages/main/src/pipelines/PipelineIndex.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineIndex.tsx
@@ -14,6 +14,7 @@ import TimeAgo from "@sematic/common/src/component/TimeAgo";
 import useBasicMetrics from "@sematic/common/src/hooks/metricsHooks";
 import { useFetchRuns } from "@sematic/common/src/hooks/runHooks";
 import { Run } from "@sematic/common/src/Models";
+import { pipelineSocket } from "@sematic/common/src/sockets";
 import { useCallback, useMemo } from "react";
 import CalculatorPath from "src/components/CalculatorPath";
 import { RunList, RunListColumn } from "src/components/RunList";
@@ -22,7 +23,6 @@ import RunStateChip, {
 } from "src/components/RunStateChip";
 import { RunTime } from "src/components/RunTime";
 import Tags from "src/components/Tags";
-import { pipelineSocket } from "src/sockets";
 
 const RecentStatusesWithStyles = styled("span")`
   flex-direction: row;

--- a/sematic/ui/packages/main/src/sockets.ts
+++ b/sematic/ui/packages/main/src/sockets.ts
@@ -1,5 +1,3 @@
 import io from "socket.io-client";
 
-export const pipelineSocket = io("/pipeline");
-
 export const jobSocket = io("/job");


### PR DESCRIPTION
This PR does the below:

1. When there is a new run or a run is canceled. Show the snack bar message.
2. When there is a pipeline/update message, refresh the pipeline list. 

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/15d34e30-0582-483e-83f8-49ac21bfd8af)
