### PR TITLE
Adapt source code panel to the new dashboard

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/RunTabs.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunTabs.tsx
@@ -12,6 +12,7 @@ import RunMetricsPanel from "src/pages/RunDetails/metrics";
 import ExternalResourcePanel from "src/pages/RunDetails/externalResource";
 import theme from "src/theme/new";
 import { useAtom } from "jotai";
+import SourceCodePanel from "src/pages/RunDetails/sourcecode";
 
 
 const StyledTabsContainer = styled(Box)`
@@ -35,7 +36,6 @@ const StyledTabPanel = styled(TabPanel)`
     flex-shrink: 1;
     overflow-x: hidden;
     overflow-y: auto;
-    scrollbar-gutter: stable;
     padding-top: ${theme.spacing(5)};
 `;
 
@@ -79,9 +79,9 @@ const RunTabs = (props: RunTabsProps) => {
         <StyledTabPanelWithoutMargin value="output">
             <OutputPane />
         </StyledTabPanelWithoutMargin>
-        <TabPanel value="source">
-            <div />
-        </TabPanel>
+        <StyledTabPanelWithoutMargin value="source">
+            <SourceCodePanel />
+        </StyledTabPanelWithoutMargin>
         <FixedTabPanel value="logs">
             <LogsPane />
         </FixedTabPanel>

--- a/sematic/ui/packages/common/src/pages/RunDetails/sourcecode/SourceCode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/sourcecode/SourceCode.tsx
@@ -1,0 +1,31 @@
+import Box from "@mui/material/Box";
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import docco from "react-syntax-highlighter/dist/esm/styles/hljs/docco";
+import python from "react-syntax-highlighter/dist/esm/languages/hljs/python";
+import { Run } from "src/Models";
+
+SyntaxHighlighter.registerLanguage("python", python);
+
+interface SourceCodeProps {
+    run: Run;
+    className?: string;
+}
+
+function SourceCode(props: SourceCodeProps) {
+    const { run, className } = props;
+  
+    return (
+        <Box key={run.function_path} sx={{ marginTop: 2 }} className={className}>
+            <SyntaxHighlighter
+                language="python"
+                style={docco}
+                showLineNumbers
+                customStyle={{ fontSize: 12 }}
+            >
+                {run.source_code}
+            </SyntaxHighlighter>
+        </Box>
+    );
+}
+
+export default SourceCode;

--- a/sematic/ui/packages/common/src/pages/RunDetails/sourcecode/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/sourcecode/index.tsx
@@ -1,0 +1,24 @@
+import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
+import SourceCode from "src/pages/RunDetails/sourcecode/SourceCode";
+import styled from "@emotion/styled";
+import theme from "src/theme/new";
+
+const StyledSourceCode = styled(SourceCode)`
+    margin: 0;
+
+    & pre {
+        margin: 0;
+        padding: ${theme.spacing(2)} ${theme.spacing(5)}!important;
+    }
+`;
+
+export default function SourceCodePanel() {
+
+    const { selectedRun } = useRunDetailsSelectionContext();
+
+    if (!selectedRun) {
+        return null;
+    }
+
+    return <StyledSourceCode run={selectedRun}  />;
+}

--- a/sematic/ui/packages/main/src/components/SourceCode.tsx
+++ b/sematic/ui/packages/main/src/components/SourceCode.tsx
@@ -1,28 +1,10 @@
-import Box from "@mui/material/Box";
-import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
-import docco from "react-syntax-highlighter/dist/esm/styles/hljs/docco";
-import python from "react-syntax-highlighter/dist/esm/languages/hljs/python";
+import SourceCodeComponent from "@sematic/common/src/pages/RunDetails/sourcecode/SourceCode";
 import { usePipelinePanelsContext } from "../hooks/pipelineHooks";
-
-SyntaxHighlighter.registerLanguage("python", python);
 
 function SourceCode() {
     const { selectedRun } = usePipelinePanelsContext();
 
-    let run = selectedRun!;
-
-    return (
-        <Box key={run.function_path} sx={{ marginTop: 2 }}>
-            <SyntaxHighlighter
-                language="python"
-                style={docco}
-                showLineNumbers
-                customStyle={{ fontSize: 12 }}
-            >
-                {run.source_code}
-            </SyntaxHighlighter>
-        </Box>
-    );
+    return <SourceCodeComponent run={selectedRun!} />;
 }
 
 export default SourceCode;


### PR DESCRIPTION
Screenshot:

<img width="1586" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/b935c77e-7154-4e67-a64d-fd76ab9987e8">


