### PR TITLE
Fixes a bug when function path is none

### DIFF
--- a/sematic/db/queries.py
+++ b/sematic/db/queries.py
@@ -249,7 +249,9 @@ def get_basic_pipeline_metrics(function_path: str):
     return BasicPipelineMetrics(
         total_count=total_count,
         count_by_state={state: count for state, count in count_by_state},
-        avg_runtime_children={path: runtime for path, runtime in avg_runtime_children},
+        avg_runtime_children={
+            str(path): runtime for path, runtime in avg_runtime_children
+        },
     )
 
 


### PR DESCRIPTION
This PR fixes a bug that sometimes runs would have the `function_path` column as "none", so when aggregated against the `function_path` column, we end up with a "none" key in the aggregated dictionary. This dictionary does not work with "flask.jsonify()".