### PR TITLE
Release 0.31.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h3 align="center">Build ML pipelines with only Python, run on your laptop, or in the cloud.</h3>
 
-![PyPI](https://img.shields.io/pypi/v/sematic/0.31.0?style=for-the-badge)
+![PyPI](https://img.shields.io/pypi/v/sematic/0.31.1?style=for-the-badge)
 [![CircleCI](https://img.shields.io/circleci/build/github/sematic-ai/sematic/main?label=CircleCI&style=for-the-badge&token=60d1953bfee5b6bf8201f8e84a10eaa5bf5622fe)](https://app.circleci.com/pipelines/github/sematic-ai/sematic?branch=main&filter=all)
 ![PyPI - License](https://img.shields.io/pypi/l/sematic?style=for-the-badge)
 [![Python 3.8](https://img.shields.io/badge/Python-3.8-blue?style=for-the-badge&logo=none)](https://python.org)

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@
 
 
 
-.. image:: https://img.shields.io/pypi/v/sematic/0.31.0?style=for-the-badge
-   :target: https://img.shields.io/pypi/v/sematic/0.31.0?style=for-the-badge
+.. image:: https://img.shields.io/pypi/v/sematic/0.31.1?style=for-the-badge
+   :target: https://img.shields.io/pypi/v/sematic/0.31.1?style=for-the-badge
    :alt: PyPI
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ Lines for version numbers should always be formatted as
 with nothing else on the line.
 -->
 * HEAD
+* [0.31.1](https://pypi.org/project/sematic/0.31.1/)
+    * [improvement] Add index on edges for source/dest run ids
 * [0.31.0](https://pypi.org/project/sematic/0.31.0/)
     * [feature] Enable remote execution using pure-Docker, without bazel
     * [feature] Support live-metrics during Sematic Function execution[^1]

--- a/helm/sematic-server/Chart.yaml
+++ b/helm/sematic-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sematic-server
 description: Sematic AI Server
 type: application
-version: 1.1.10
-appVersion: v0.31.0
+version: 1.1.11
+appVersion: v0.31.1
 maintainers:
   - name: sematic-ai
     url: https://github.com/sematic-ai/sematic/

--- a/sematic/db/migrations/20230627153433_add_edges_run_indexes.sql
+++ b/sematic/db/migrations/20230627153433_add_edges_run_indexes.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+CREATE INDEX ix_edges_source_run_id ON edges (source_run_id);
+CREATE INDEX ix_edges_destination_run_id ON edges (destination_run_id);
+
+-- migrate:down
+DROP INDEX ix_edges_source_run_id;
+DROP INDEX ix_edges_destination_run_id;

--- a/sematic/db/models/edge.py
+++ b/sematic/db/models/edge.py
@@ -19,11 +19,11 @@ class Edge(Base, JSONEncodableMixin):
 
     # Edge endpoints
     source_run_id: Optional[str] = Column(
-        types.String(), ForeignKey("artifacts.id"), nullable=True
+        types.String(), ForeignKey("artifacts.id"), nullable=True, index=True
     )
     source_name: Optional[str] = Column(types.String(), nullable=True)
     destination_run_id: Optional[str] = Column(
-        types.String(), ForeignKey("artifacts.id"), nullable=True
+        types.String(), ForeignKey("artifacts.id"), nullable=True, index=True
     )
     destination_name: Optional[str] = Column(types.String(), nullable=True)
 

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -130,6 +130,8 @@ CREATE TABLE metric_values (
 );
 CREATE INDEX metric_values_id_time_idx ON metric_values(metric_id, metric_time DESC);
 CREATE INDEX metric_values_time_idx ON metric_values(metric_time DESC);
+CREATE INDEX ix_edges_source_run_id ON edges (source_run_id);
+CREATE INDEX ix_edges_destination_run_id ON edges (destination_run_id);
 -- schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20220424062956'),
@@ -174,4 +176,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20230403153220'),
   ('20230419080554'),
   ('20230428225443'),
-  ('20230526141354');
+  ('20230526141354'),
+  ('20230627153433');

--- a/sematic/versions.py
+++ b/sematic/versions.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 # the sdk. Should be bumped any time a release is made. Should be set
 # to whatever is the version after the most recent one in changelog.md,
 # as well as the version for the sematic wheel in wheel_constants.bzl
-CURRENT_VERSION = (0, 31, 0)
+CURRENT_VERSION = (0, 31, 1)
 
 # TO DEPRECATE
 # 0.32.0

--- a/sematic/wheel_constants.bzl
+++ b/sematic/wheel_constants.bzl
@@ -2,7 +2,7 @@
 # changelog.md.
 # This is the version that will be attached to the
 # wheel that bazel builds for sematic.
-wheel_version_string = "0.31.0"
+wheel_version_string = "0.31.1"
 
 wheel_author = "Sematic AI, Inc."
 wheel_author_email = "emmanuel@sematic.ai"


### PR DESCRIPTION
Only contains the contents of 0.31.0 and a migration to add two indexes to the `edges` table.  Fully tested.