### PR TITLE
Deeplink search term in new UI

### DIFF
--- a/sematic/ui/packages/common/src/hooks/runHooks.ts
+++ b/sematic/ui/packages/common/src/hooks/runHooks.ts
@@ -11,6 +11,7 @@ import useAsync from "react-use/lib/useAsync";
 export const selectedRunHashAtom = atomWithHashCustomSerialization("run", "")
 export const selectedPanelAtom = atomWithHashCustomSerialization("panel", "")
 export const selectedTabHashAtom = atomWithHashCustomSerialization("tab", "")
+export const searchAtom = atomWithHashCustomSerialization("search", "");
 
 export type QueryParams = {[key: string]: string};
 export const PAGE_SIZE = 25;

--- a/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/SearchFilters.tsx
@@ -10,6 +10,7 @@ import { ResettableHandle } from "src/component/common";
 import theme from "src/theme/new";
 import { AllFilters, FilterType } from "src/pages/RunTableCommon/filters";
 import isEmpty from "lodash/isEmpty";
+import useEffectOnce from "react-use/lib/useEffectOnce";
 
 const StyledButton = styled(Button)`
     margin: 0 -${theme.spacing(5)};
@@ -88,6 +89,12 @@ const SearchFilters = (props: SearchFiltersProps) => {
     const applyFilters = useCallback(() => {
         onFiltersChanged({...allFilters.current});
     }, [onFiltersChanged]);
+
+    useEffectOnce(() => {
+        if (!isEmpty(allFilters.current)) {
+            applyFilters();
+        }
+    });
 
     return <>
         <SearchTextSection ref={searchTextRef} onSearchChanged={onSearchTextChanged} />

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -1,15 +1,19 @@
-import { useCallback, useState, useMemo } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 import TwoColumns from "src/layout/TwoColumns";
 import RunList from "src/pages/RunSearch/RunList";
 import SearchFilters from "src/pages/RunSearch/SearchFilters";
 import { AllFilters } from "src/pages/RunTableCommon/filters";
+import useLatest from "react-use/lib/useLatest";
 
 const RunSearch = () => {
-    const [filters, setFilters] = useState<AllFilters>({});
+    const [filters, setFilters] = useState<AllFilters | null>(null);
+
+    const latestFilters = useLatest(filters);
 
     const onFiltersChanged = useCallback((filters: AllFilters) => {
         setFilters(filters);
-    }, []);
+        (latestFilters.current as any) = filters;
+    }, [latestFilters]);
 
     const onRenderLeft = useCallback(() => {
         return <SearchFilters onFiltersChanged={onFiltersChanged} />;
@@ -18,10 +22,19 @@ const RunSearch = () => {
     const filtersKey = useMemo(() => JSON.stringify(filters), [filters]);
 
     const onRenderRight = useCallback(() => {
+        if (filters === null) {
+            return null;
+        }
         return <RunList key={filtersKey} filters={filters} />;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filtersKey]);
 
+    useEffect(() => {
+        if (latestFilters.current === null) {
+            setFilters({});
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return <TwoColumns onRenderLeft={onRenderLeft} onRenderRight={onRenderRight} />;
 }

--- a/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/index.tsx
@@ -1,19 +1,30 @@
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useAtom } from "jotai";
+import { RESET } from "jotai/utils";
+import isEmpty from "lodash/isEmpty";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import useLatest from "react-use/lib/useLatest";
+import { searchAtom } from "src/hooks/runHooks";
 import TwoColumns from "src/layout/TwoColumns";
 import RunList from "src/pages/RunSearch/RunList";
 import SearchFilters from "src/pages/RunSearch/SearchFilters";
-import { AllFilters } from "src/pages/RunTableCommon/filters";
-import useLatest from "react-use/lib/useLatest";
+import { AllFilters, FilterType } from "src/pages/RunTableCommon/filters";
 
 const RunSearch = () => {
     const [filters, setFilters] = useState<AllFilters | null>(null);
 
     const latestFilters = useLatest(filters);
+    const [, setSearchHash] = useAtom(searchAtom);
+
 
     const onFiltersChanged = useCallback((filters: AllFilters) => {
         setFilters(filters);
+        if (!isEmpty(filters[FilterType.SEARCH])) {
+            setSearchHash(filters[FilterType.SEARCH]![0]);
+        }else {
+            setSearchHash(RESET);
+        }
         (latestFilters.current as any) = filters;
-    }, [latestFilters]);
+    }, [latestFilters, setSearchHash]);
 
     const onRenderLeft = useCallback(() => {
         return <SearchFilters onFiltersChanged={onFiltersChanged} />;

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/filters/SearchTextSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/filters/SearchTextSection.tsx
@@ -1,34 +1,46 @@
 import TextField from "@mui/material/TextField";
-import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
+import { useAtom } from "jotai";
+import { RESET } from "jotai/utils";
+import isEmpty from "lodash/isEmpty";
+import { forwardRef, useCallback, useImperativeHandle } from "react";
+import useEffectOnce from "react-use/lib/useEffectOnce";
 import { SectionWithBorder } from "src/component/Section";
 import { ResettableHandle } from "src/component/common";
+import { searchAtom } from "src/hooks/runHooks";
 
 interface SearchTextSectionProps {
     onSearchChanged?: (search: string) => void;
 }
 
 const SearchTextSection = forwardRef<ResettableHandle, SearchTextSectionProps>((props, ref) => {
-    const { onSearchChanged } = props;    
-    const [search, setSearch] = useState<string>("");
+    const { onSearchChanged } = props;
+    const [search, setSearch] = useAtom(searchAtom);
 
     const _onSearchChanged = useCallback((search: string) => {
         setSearch(search);
         onSearchChanged?.(search);
-    }, [onSearchChanged]);
+    }, [setSearch, onSearchChanged]);
 
     useImperativeHandle(ref, () => ({
         reset: () => {
-            setSearch("");
+            setSearch(RESET);
         }
     }));
-    
+
+    useEffectOnce(() => {
+        // Only trigger on mount
+        if (!isEmpty(search)) {
+            onSearchChanged?.(search);
+        }
+    });
+
     return <SectionWithBorder >
         <TextField
             variant="standard"
             fullWidth={true}
             placeholder={"Search..."}
-            value={search}
-            onChange={(e) => {_onSearchChanged(e.target.value)}}
+            value={search || ""}
+            onChange={(e) => { _onSearchChanged(e.target.value) }}
         />
     </SectionWithBorder>
 });

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/filters/SearchTextSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/filters/SearchTextSection.tsx
@@ -2,7 +2,7 @@ import TextField from "@mui/material/TextField";
 import { useAtom } from "jotai";
 import { RESET } from "jotai/utils";
 import isEmpty from "lodash/isEmpty";
-import { forwardRef, useCallback, useImperativeHandle } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
 import useEffectOnce from "react-use/lib/useEffectOnce";
 import { SectionWithBorder } from "src/component/Section";
 import { ResettableHandle } from "src/component/common";
@@ -14,7 +14,9 @@ interface SearchTextSectionProps {
 
 const SearchTextSection = forwardRef<ResettableHandle, SearchTextSectionProps>((props, ref) => {
     const { onSearchChanged } = props;
-    const [search, setSearch] = useAtom(searchAtom);
+    const [searchHash] = useAtom(searchAtom);
+    const [search, setSearch] = useState<string | typeof RESET>(searchHash);
+
 
     const _onSearchChanged = useCallback((search: string) => {
         setSearch(search);
@@ -29,8 +31,8 @@ const SearchTextSection = forwardRef<ResettableHandle, SearchTextSectionProps>((
 
     useEffectOnce(() => {
         // Only trigger on mount
-        if (!isEmpty(search)) {
-            onSearchChanged?.(search);
+        if (!isEmpty(searchHash)) {
+            onSearchChanged?.(searchHash);
         }
     });
 

--- a/sematic/ui/packages/main/src/runs/RunIndex.tsx
+++ b/sematic/ui/packages/main/src/runs/RunIndex.tsx
@@ -11,9 +11,8 @@ import Typography from "@mui/material/Typography";
 import { styled } from "@mui/system";
 import MuiRouterLink from "@sematic/common/src/component/MuiRouterLink";
 import TimeAgo from "@sematic/common/src/component/TimeAgo";
-import { getRunUrlPattern } from "@sematic/common/src/hooks/runHooks";
+import { getRunUrlPattern, searchAtom } from "@sematic/common/src/hooks/runHooks";
 import { Run } from "@sematic/common/src/Models";
-import { atomWithHashCustomSerialization } from "@sematic/common/src/utils/url";
 import { useAtom } from "jotai";
 import React, { ChangeEvent, FormEvent, useCallback, useState } from "react";
 import CalculatorPath from "src/components/CalculatorPath";
@@ -144,8 +143,6 @@ const TableColumns: Array<RunListColumn> = [
         render: (run: Run) => <RunStateChip run={run} variant="full" />,
     },
 ];
-
-const searchAtom = atomWithHashCustomSerialization("search", "");
 
 export function RunIndex() {
     const [searchString, setSearchString] = useAtom(searchAtom);


### PR DESCRIPTION
This PR implements deep-linking the search term in the run list search page (new dashboard). It could avoid double fetching runs when the page is initially loaded and a search term is used in the URL. 

This is a follow-up after [PR 845](https://github.com/sematic-ai/sematic/pull/845)

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/57d49297-4e9f-4cc7-9a94-fa37a3f8b282)
