### PR TITLE
Some bug fixes for the new UI

### DIFF
--- a/sematic/ui/packages/common/src/component/GitInfo.tsx
+++ b/sematic/ui/packages/common/src/component/GitInfo.tsx
@@ -62,7 +62,7 @@ export const GitInfoBoxPresentation = (prop: GitInfoBoxProps) => {
         </StyledBox>
         {!!hasUncommittedChanges && <StyledBox>
             <Code />
-            <Tooltip title={"This run used code with uncommitted changed on top of the above commit."} arrow={true} >
+            <Tooltip title={"This run used code with uncommitted changes on top of the above commit."} arrow={true} >
                 <Typography variant="small">Uncommited changes</Typography>
             </Tooltip>
         </StyledBox>}

--- a/sematic/ui/packages/common/src/component/Note.tsx
+++ b/sematic/ui/packages/common/src/component/Note.tsx
@@ -75,7 +75,7 @@ const Footer = styled(Box,  {
     width: 100%;
     padding-bottom: ${theme.spacing(1)};
     bottom: 0;
-    background-image: linear-gradient(rgba(255,255,255,0), ${theme.palette.background.paper} 60%);
+    background-image: linear-gradient(rgba(0,0,0,0), ${theme.palette.p1black.main} 60%);
 
     & svg {
         margin-right: ${theme.spacing(2)};

--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -2,7 +2,7 @@ import BoltIcon from "@mui/icons-material/Bolt";
 import Check from "@mui/icons-material/Check";
 import ClearIcon from "@mui/icons-material/Clear";
 import StopIcon from "@mui/icons-material/Stop";
-import ArrowUpward from "@mui/icons-material/ArrowUpward";
+import HourglassEmpty from "@mui/icons-material/HourglassEmpty";
 import { useMemo } from "react";
 import theme from "src/theme/new";
 import { SvgIconTypeMap } from "@mui/material/SvgIcon";
@@ -63,7 +63,7 @@ export const SubmittedStateChip = (props: StateChipBaseProps) => {
     const { size } = props;
     const styles = useStylesHook({ size });
     const color = RunStateColorMap.get(SubmittedStateChip)!.color;
-    return <ArrowUpward color={color} style={styles} />;
+    return <HourglassEmpty color={color} style={styles} />;
 }
 
 const RunStateColorMap: Map<React.FC<StateChipBaseProps>, {

--- a/sematic/ui/packages/common/src/component/RunsDropdown.tsx
+++ b/sematic/ui/packages/common/src/component/RunsDropdown.tsx
@@ -48,7 +48,7 @@ interface ValuePresentationProps {
 }
 const ValuePresentation = (props: ValuePresentationProps) => {
     const { run } = props;
-    const stateChip = useMemo(() => getRunStateChipByState(run.future_state, "small"), [run.future_state]);
+    const stateChip = useMemo(() => getRunStateChipByState(run.future_state, "large"), [run.future_state]);
     return <StyledBox {...props}>
         {stateChip}
         <Typography variant="code">{run.id.substring(0, 7)}</Typography>

--- a/sematic/ui/packages/common/src/component/menu.tsx
+++ b/sematic/ui/packages/common/src/component/menu.tsx
@@ -29,7 +29,7 @@ const HeaderMenu = (props: HeaderMenuProps) => {
 
     const { user } = useContext(UserContext);
     const contextMenuAnchor = useRef(null);
-    const [renderTimes, {inc}] = useCounter();
+    const [renderTimes, { inc }] = useCounter();
 
     const latestAnchor = useLatest(contextMenuAnchor.current);
 
@@ -61,10 +61,10 @@ const HeaderMenu = (props: HeaderMenuProps) => {
                 className={selectedKey === "gettingstarted" ? "selected" : ""}>
                 Get Started
             </MuiRouterLink>
-            <Link variant="subtitle1" type='menu'>Docs</Link>
-            <Link variant="subtitle1" type='menu'>Support</Link>
+            <MuiRouterLink href={"https://docs.sematic.dev"} variant="subtitle1" type='menu'>Docs</MuiRouterLink>
+            <MuiRouterLink href={"https://discord.gg/4KZJ6kYVax"} variant="subtitle1" type='menu'>Discord</MuiRouterLink>
             <Link variant="subtitle1" type='menu'>
-                <NameTag firstName={user?.first_name} lastName={user?.last_name} variant={"inherit"} 
+                <NameTag firstName={user?.first_name} lastName={undefined} variant={"inherit"}
                     ref={contextMenuAnchor} />
             </Link>
             <UserMenu anchorEl={contextMenuAnchor.current} />

--- a/sematic/ui/packages/common/src/layout/TwoColumns.tsx
+++ b/sematic/ui/packages/common/src/layout/TwoColumns.tsx
@@ -16,6 +16,7 @@ const Right = styled(RightBase)`
     & .runs-table {
         min-width: 850px;
     }
+    background: ${theme.palette.white.main};
 `
 
 const LoadingOverlay = styled(Box)`

--- a/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
@@ -15,7 +15,6 @@ const StyledChipContainer = styled.span`
     display: inline-block;
     &:hover {
         filter: drop-shadow(1px 2px 2px rgb(0 0 0 / 0.4));
-        transform: translate(-1px, -1px);
     }
 `;
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunTabs.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunTabs.tsx
@@ -46,6 +46,10 @@ const StyledTabPanelWithoutMargin = styled(StyledTabPanel)`
     margin-right: -${theme.spacing(5)};
 `;
 
+const ArtifactPanel = styled(StyledTabPanelWithoutMargin)`
+    scrollbar-gutter: stable;
+`;
+
 const FixedTabPanel = styled(TabPanel)`
     flex-grow: 1;
     overflow: hidden;
@@ -75,12 +79,12 @@ const RunTabs = (props: RunTabsProps) => {
                 <Tab label="Pods" value="pod_lifecycle" />
             </TabList>
         </StyledTabsContainer>
-        <StyledTabPanelWithoutMargin value="input">
+        <ArtifactPanel value="input">
             <InputPane />
-        </StyledTabPanelWithoutMargin>
-        <StyledTabPanelWithoutMargin value="output">
+        </ArtifactPanel>
+        <ArtifactPanel value="output">
             <OutputPane />
-        </StyledTabPanelWithoutMargin>
+        </ArtifactPanel>
         <StyledTabPanelWithoutMargin value="source">
             <SourceCodePanel />
         </StyledTabPanelWithoutMargin>

--- a/sematic/ui/packages/common/src/pages/RunDetails/externalResource/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/externalResource/index.tsx
@@ -2,11 +2,16 @@ import ExternalResourcePanelComponent from "@sematic/common/src/pages/RunDetails
 import { useContext } from "react";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
+import useUnmount from "react-use/lib/useUnmount";
 
 export default function ExternalResourcePanel() {
     const { selectedRun } = useRunDetailsSelectionContext();
 
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    useUnmount(() => {
+        setIsLoading(false);
+    });
 
     if (!selectedRun) {
         return null;

--- a/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
@@ -6,6 +6,7 @@ import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 import theme from "src/theme/new";
 import { buttonClasses } from "@mui/material/Button"
+import useUnmount from "react-use/lib/useUnmount";
 
 const Container = styled.div`
     max-height: 100%;
@@ -72,6 +73,10 @@ export default function LogsPane() {
     }, []);
 
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    useUnmount(() => {
+        setIsLoading(false);
+    });
 
     if (!selectedRun) {
         return null;

--- a/sematic/ui/packages/common/src/pages/RunDetails/metricsTab/MetricsPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/metricsTab/MetricsPane.tsx
@@ -78,7 +78,7 @@ export default function MetricsPane(props: MetricsPaneProps) {
                     <Typography sx={{ color: "gray" }}>
                             No metrics logged for this run.
                         <br />
-                            Read the <Link to="TODO">documentation</Link> to get
+                            Read the <Link to="https://docs.sematic.dev/diving-deeper/metrics#custom-metrics">documentation</Link> to get
                             started.
                     </Typography>
                 </Box>

--- a/sematic/ui/packages/common/src/pages/RunDetails/metricsTab/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/metricsTab/index.tsx
@@ -2,11 +2,16 @@ import MetricsPane from "src/pages/RunDetails/metricsTab/MetricsPane";
 import { useContext } from "react";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
+import useUnmount from "react-use/lib/useUnmount";
 
 export default function RunMetricsPanel() {
 
     const { selectedRun } = useRunDetailsSelectionContext();
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    useUnmount(() => {
+        setIsLoading(false);
+    });
 
     if (!selectedRun) {
         return null;

--- a/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/index.tsx
@@ -2,11 +2,16 @@ import { useContext } from "react";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { useRootRunContext } from "src/context/RootRunContext";
 import BasicMetricsPanel from "src/pages/RunDetails/pipelineMetrics/BasicMetricsPanel";
+import useUnmount from "react-use/lib/useUnmount";
 
 function PipelineMetrics() {
     const { rootRun } = useRootRunContext();
 
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    useUnmount(() => {
+        setIsLoading(false);
+    });
 
     if (!rootRun ) {
         return null;

--- a/sematic/ui/packages/common/src/pages/RunDetails/podLifecycle/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/podLifecycle/index.tsx
@@ -5,6 +5,7 @@ import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionCo
 import styled from "@emotion/styled";
 import { accordionDetailsClasses} from "@mui/material/AccordionDetails";
 import theme from "src/theme/new";
+import useUnmount from "react-use/lib/useUnmount";
 
 const StyledPodLifecycleComponent = styled(PodLifecycleComponent)`
     & .${accordionDetailsClasses.root} {
@@ -15,6 +16,10 @@ const StyledPodLifecycleComponent = styled(PodLifecycleComponent)`
 export default function PodLifecyclePanel() {
     const { selectedRun } = useRunDetailsSelectionContext();
     const { setIsLoading } = useContext(LayoutServiceContext);
+
+    useUnmount(() => {
+        setIsLoading(false);
+    });
 
     if (!selectedRun) {
         return null;

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/CollapseableFilterSection.tsx
@@ -14,6 +14,7 @@ const BoldHeader = styled.div`
 
 const StyledAccordion = styled(Accordion)`
     max-height: 100%;
+    background-color: ${theme.palette.p1black.main};
 `;
 
 interface CollapseableFilterSectionProps {

--- a/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/filters/StatusFilterSection.tsx
@@ -1,12 +1,11 @@
 import styled from "@emotion/styled";
 import Chip, { chipClasses } from "@mui/material/Chip";
-import { useCallback, useImperativeHandle, forwardRef, useState } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
 import { CanceledStateChip, FailedStateChip, RunningStateChip, SuccessStateChip } from "src/component/RunStateChips";
-import CollapseableFilterSection from "src/pages/RunSearch/filters/CollapseableFilterSection";
-import theme from "src/theme/new";
-import memoize from "lodash/memoize";
 import { ResettableHandle } from "src/component/common";
+import CollapseableFilterSection from "src/pages/RunSearch/filters/CollapseableFilterSection";
 import { StatusFilters } from "src/pages/RunTableCommon/filters";
+import theme from "src/theme/new";
 
 const StyledChip = styled(Chip)`
     padding-left: ${theme.spacing(1)};
@@ -37,12 +36,11 @@ interface StatusFilterSectionProps {
     onFiltersChanged?: (filters: string[]) => void;
 }
 
-const toogleFilterGenerator = memoize((
+const useToogleFilterCallbackGenerator = (
     filter: StatusFilters,
     setFilters: React.Dispatch<React.SetStateAction<Set<string>>>,
-    onFiltersChanged: StatusFilterSectionProps["onFiltersChanged"]
-) =>
-    () => useCallback(() => {
+    onFiltersChanged: StatusFilterSectionProps["onFiltersChanged"]) =>
+    useCallback(() => {
         let newFilters: any;
         setFilters((filters) => {
             if (filters.has(filter)) {
@@ -52,20 +50,19 @@ const toogleFilterGenerator = memoize((
             }
 
             newFilters = filters;
+            onFiltersChanged?.(Array.from(newFilters));
             return new Set(filters);
         });
-
-        onFiltersChanged?.(Array.from(newFilters));
-    }, []));
+    }, [filter, setFilters, onFiltersChanged]);
 
 const StatusFilterSection = forwardRef<ResettableHandle, StatusFilterSectionProps>((props, ref) => {
     const { onFiltersChanged } = props;
     const [filters, setFilters] = useState<Set<string>>(() => new Set());
 
-    const toggleFilterComplete = toogleFilterGenerator("completed", setFilters, onFiltersChanged!)();
-    const toggleFilterFailed = toogleFilterGenerator("failed", setFilters, onFiltersChanged!)();
-    const toggleFilterRunning = toogleFilterGenerator("running", setFilters, onFiltersChanged!)();
-    const toggleFilterCanceled = toogleFilterGenerator("canceled", setFilters, onFiltersChanged!)();
+    const toggleFilterComplete = useToogleFilterCallbackGenerator("completed", setFilters, onFiltersChanged!);
+    const toggleFilterFailed = useToogleFilterCallbackGenerator("failed", setFilters, onFiltersChanged!);
+    const toggleFilterRunning = useToogleFilterCallbackGenerator("running", setFilters, onFiltersChanged!);
+    const toggleFilterCanceled = useToogleFilterCallbackGenerator("canceled", setFilters, onFiltersChanged!);
 
     useImperativeHandle(ref, () => ({
         reset: () => setFilters(new Set())

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/RunListEmptyState.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/RunListEmptyState.tsx
@@ -48,5 +48,4 @@ export const NoRunNoFilters = () => <InitialGuide >
     </StyledTypography>
 </InitialGuide>
 
-export const NoRunWithFilters = () => <StyledTitle>No runs found.&nbsp; 
-    <StyledLink href="/get_started">Get Started</StyledLink>.</StyledTitle>
+export const NoRunWithFilters = () => <StyledTitle>No runs found.</StyledTitle>

--- a/sematic/ui/packages/common/src/theme/new/palette.ts
+++ b/sematic/ui/packages/common/src/theme/new/palette.ts
@@ -16,10 +16,10 @@ const pallette: Record<string, PaletteColorOptions> = {
         contrastText: common["white"]
     },
     p3border: {
-        main: "rgba(0, 0, 0, 0.03)"
+        main: "rgba(246, 246, 246, 1)"
     },
     p1black: {
-        main: "rgba(0, 0, 0, 0.01)"
+        main: "rgba(252, 252, 252, 1)"
     },
     white: {
         main: common["white"],

--- a/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
+++ b/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
@@ -9,6 +9,7 @@ import IconButton from "@mui/material/IconButton";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useTheme } from "@mui/material/styles";
+import ErrorBoundary from "src/component/ErrorBoundary";
 
 
 const ContainerBase = styled.div`
@@ -68,6 +69,14 @@ const Value = styled.div`
     flex-shrink: 1;
 `;
 
+function RenderError({children}: {
+    children: React.ReactNode;
+}) {
+    return <ArtifactExpanderContainer>
+        <span style={{color: theme.palette.error.main}}>{children}</span>
+    </ArtifactExpanderContainer>
+}
+
 export function ArtifactLine(props: { name: string, type?: string, children: React.ReactNode }) {
     const { name, type, children } = props;
     return <Container className={"artifact-row"} style={{ marginRight: "-20px" }}>
@@ -115,7 +124,7 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
             </span>;
         }
 
-        return <div style={{marginRight: theme.spacing(8)}}>
+        return <div style={{ marginRight: theme.spacing(8) }}>
             {component}
         </div>;
     }, [toggleOpen, open, hasNested, theme, ValueComponent, valueSummary, typeSerialization]);
@@ -128,7 +137,9 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
 
     return <Fragment key={name}>
         <ArtifactLine name={name} type={type}>
-            {valueComponent}
+            <ErrorBoundary fallback={<RenderError>Cannot render value</RenderError>}>
+                {valueComponent}
+            </ErrorBoundary>
             {hasNested && <ExpandMoreIconCotainer>
                 <IconButton onClick={toggleOpen} style={{ visibility: open ? "hidden" : "visible" }}>
                     <ExpandMoreIcon />
@@ -136,7 +147,13 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
             </ExpandMoreIconCotainer>}
         </ArtifactLine>
         {open && !!NestedComponent && <NestedContainer className={expandLessHovered ? "hover" : ""}>
-            <NestedComponent valueSummary={valueSummary} typeSerialization={typeSerialization} />
+            <ErrorBoundary fallback={
+                <RenderError>
+                    Error encountered when rendering the nested representation.
+                </RenderError>}>
+                <NestedComponent valueSummary={valueSummary} typeSerialization={typeSerialization} />
+            </ErrorBoundary>
+
             <ExpandLessIconCotainer>
                 <IconButton onClick={toggleOpen} onMouseEnter={() => setExpandLessHovered(true)}
                     onMouseLeave={() => setExpandLessHovered(false)}>

--- a/sematic/ui/packages/storybook/src/stories/Header.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/Header.stories.tsx
@@ -2,6 +2,8 @@ import { ThemeProvider } from "@mui/material/styles";
 import Menu from "@sematic/common/src/component/menu";
 import theme from "@sematic/common/src/theme/new";
 import { Meta, StoryObj } from "@storybook/react";
+import { Route, createBrowserRouter, createRoutesFromElements, RouterProvider } from "react-router-dom";
+import { ReactElement } from "react";
 
 export default {
     title: "Sematic/Header",
@@ -19,16 +21,24 @@ interface StoryProps {
     selectedItem: string;
 }
 
+const dummyRouter = (node: ReactElement) => createBrowserRouter(
+    createRoutesFromElements(
+        <Route path="*" index element={node} />
+    ));
 
 export const Header: StoryObj<StoryProps> = {
     render: (props) => {
         const { selectedItem } = props;
 
-        return <Menu selectedKey={selectedItem}/>
+        const router = dummyRouter(
+            <Menu selectedKey={selectedItem} />
+        );
+
+        return <RouterProvider router={router} />;
     },
     argTypes: {
         selectedItem: {
-            control: "select", 
+            control: "select",
             options: [
                 undefined, "runs", "pipelines", "metrics"
             ]

--- a/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
+++ b/sematic/ui/packages/storybook/src/stories/RunFilter.stories.tsx
@@ -1,6 +1,6 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
-import OwnersFilterSection from "@sematic/common/src/pages/RunSearch/filters/OwnersFilterSection";
+import OwnersFilterSection from "@sematic/common/src/pages/RunTableCommon/filters/OwnersFilterSection";
 import StatusFilterSection from "@sematic/common/src/pages/RunSearch/filters/StatusFilterSection";
 import UserContext from "@sematic/common/src/context/UserContext";
 import { ResettableHandle } from "@sematic/common/src/component/common";


### PR DESCRIPTION
This PR fixes the following defects:

1. Fixes a typo for the uncommitted changes tooltip.
![image](https://github.com/sematic-ai/sematic/assets/133257643/7457a5e8-f8d3-41ca-aa9e-a975036f2a55)

2. Fixes the shading of the notes
![image](https://github.com/sematic-ai/sematic/assets/133257643/66007fd4-60be-4187-8d03-33b8f8b4605a)

3. Fixes the background of the run search result ( => white)
4. Fixes the background of the run search filters ( => %1 Black)

![image](https://github.com/sematic-ai/sematic/assets/133257643/d58409de-d4b2-4499-87b6-05c875a9c707)

5. Add a link to the Docs header menu

6. Renamed "Support" header menu to "Discord" and provided a link as such.

7. Fixed the artifact menu too lose to the edge.

![image](https://github.com/sematic-ai/sematic/assets/133257643/00d4ead6-91af-4432-9a99-d89c564b4f3b)

8. Fixes an issue that switching tabs on the Run Detail page might sometimes leave a lingering loading indicator. 

9. When rendering artifacts, prevents incorrect artifact payload crashes the rendering process and explodes the whole page. 

10. Fixes compile errors and broken pages in Storybook.

11. Fixes an issue that not having a logged-in user would cause the run search page to crash for local deployment.

12. Add the missing documentation link in the metrics tab.

![image](https://github.com/sematic-ai/sematic/assets/133257643/72370a88-8980-4326-aa7a-3494a7c90ade)

13. Fixes a bug that sometimes the status filter is not clickable.

Improvements:
14. Enlarged the state chip size in the runs dropdown
<img width="162" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/119c3a7f-9346-4e2d-870c-09465c72104e">

15. Changed `submitted` run status icon to an hourglass.
<img width="237" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/6afde7e1-c585-48d9-8c01-b1ac8929595b">

