### PR TITLE
Fixes the clustering in the artifact headline

### DIFF
--- a/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
+++ b/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
@@ -10,6 +10,8 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useTheme } from "@mui/material/styles";
 import ErrorBoundary from "src/component/ErrorBoundary";
+import ImportPath from "src/component/ImportPath";
+import { css } from "@emotion/css";
 
 
 const ContainerBase = styled.div`
@@ -23,6 +25,7 @@ const ContainerBase = styled.div`
 
 const Container = styled(ContainerBase)`
     min-height: 50px;
+    column-gap: ${theme.spacing(2)};
 `;
 
 const NestedContainer = styled.div`
@@ -36,18 +39,25 @@ const NestedContainer = styled.div`
 `;
 
 const NameType = styled.div`
-    flex-shrink: 0;
+    flex-shrink: 2;    
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
     & > span:last-of-type {
+        flex-shrink: 1;
         font-size: 12px;
+        overflow: hidden;
         color: ${theme.palette.grey[400]};
     }
 
     & > span:first-of-type {
+        flex-shrink: 0;
         font-weight: ${fontWeightBold};
         margin-right: ${theme.spacing(5)}};
     }
 `;
 const ExpandMoreIconCotainer = styled.span`
+    flex-shrink: 0;
 `;
 
 const ExpandLessIconCotainer = styled.div`
@@ -67,6 +77,17 @@ const ExpandLessIconCotainer = styled.div`
 
 const Value = styled.div`
     flex-shrink: 1;
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+    white-space: nowrap;
+    column-gap: ${theme.spacing(2)};
+`;
+
+const valueComponentClass = css`
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `;
 
 function RenderError({children}: {
@@ -80,9 +101,11 @@ function RenderError({children}: {
 export function ArtifactLine(props: { name: string, type?: string, children: React.ReactNode }) {
     const { name, type, children } = props;
     return <Container className={"artifact-row"} style={{ marginRight: "-20px" }}>
-        <NameType>
+        <NameType >
             <span>{name}</span>
-            <span>{type}</span>
+            <span>
+                <ImportPath>{type}</ImportPath>
+            </span>
         </NameType>
         <Value>
             {children}
@@ -119,12 +142,12 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
             typeSerialization={typeSerialization} />;
 
         if (hasNested) {
-            return <span onClick={toggleOpen} style={{ cursor: "pointer" }}>
+            return <span onClick={toggleOpen} style={{ cursor: "pointer" }} className={valueComponentClass}>
                 {component}
             </span>;
         }
 
-        return <div style={{ marginRight: theme.spacing(8) }}>
+        return <div style={{marginRight: theme.spacing(8)}} className={valueComponentClass}>
             {component}
         </div>;
     }, [toggleOpen, open, hasNested, theme, ValueComponent, valueSummary, typeSerialization]);


### PR DESCRIPTION
**Before:**

When the page is not wide enough, the "type" and "value" part of the artifact line will cluster together.

<img width="791" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/05bc8e7f-ad0a-4576-bdf1-d42dd7a5832d">


**After:**

If the page is wide enough, then:

<img width="1276" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/ceeb4707-9f92-48df-83a3-aee4b11c48f1">

When the page width is narrow, we get:

<img width="798" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/8e4474eb-e358-459f-a7cf-c7484e25b482">

Note: "and some othere bla bla text" is merely a temporary test code to enlarge the size of the value part., it will not be part of the PR.