### PR TITLE
Align DAG node handles and remove border of the handles

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
@@ -6,7 +6,7 @@ import { useCallback, useContext, useMemo } from "react";
 import { NodeProps, Position } from "reactflow";
 import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming, useNodeExpandStateToggle } from "src/hooks/dagHooks";
-import { DagViewServiceContext, StyledHandle } from "src/pages/RunDetails/dag/common";
+import { DagViewServiceContext, StyledHandleTop, StyledHandleBottom } from "src/pages/RunDetails/dag/common";
 import theme from "src/theme/new";
 
 const CompoundNodeContainer = styled("div", {
@@ -68,7 +68,7 @@ function CompoundNode(props: NodeProps) {
 
     return <CompoundNodeContainer selected={selected} onClick={onClick}
         style={{ width: `${data.width}px`, height: `${data.height}px`, borderColor: color }}>
-        {hasIncoming && <StyledHandle type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
+        {hasIncoming && <StyledHandleTop type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
             {stateChip}
             <label style={{ flexGrow: 1 }}>{data.label}</label>
@@ -76,13 +76,13 @@ function CompoundNode(props: NodeProps) {
                 {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             </StyledIconButton>
         </LabelContainer>
-        <StyledHandle
+        <StyledHandleBottom
             type="source"
             position={Position.Bottom}
             id="sb"
             isConnectable={false}
         />
-        <StyledHandle type="target" position={Position.Bottom} isConnectable={false} id={"tb"} />
+        <StyledHandleBottom type="target" position={Position.Bottom} isConnectable={false} id={"tb"} />
     </CompoundNodeContainer>
 }
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
@@ -3,11 +3,11 @@ import { useMemo, useCallback, useContext } from "react";
 import { NodeProps, Position } from "reactflow";
 import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming } from "src/hooks/dagHooks";
-import { DagViewServiceContext, LEFT_NODE_MAX_WIDTH, StyledHandle } from "src/pages/RunDetails/dag/common";
+import { DagViewServiceContext, LEFT_NODE_MAX_WIDTH, StyledHandleTop, StyledHandleBottom } from "src/pages/RunDetails/dag/common";
 import { SPACING } from "src/pages/RunDetails/dag/dagLayout";
 import theme from "src/theme/new";
 
-const LeftNodeContainer = styled("div", {
+const LeafNodeContainer = styled("div", {
     shouldForwardProp: (prop) => prop !== "selected"
 }) <{
     selected?: boolean;
@@ -47,22 +47,21 @@ function LeafNode(props: NodeProps) {
         onNodeClick(run.id);
     }, [onNodeClick, run]);
 
-    return <LeftNodeContainer selected={selected} style={{ paddingRight: `${SPACING}px`, borderColor: color }}
+    return <LeafNodeContainer selected={selected} style={{ paddingRight: `${SPACING}px`, borderColor: color }}
         onClick={onClick}
     >
-        {hasIncoming && <StyledHandle type="target" position={Position.Top} isConnectable={false} id={"t"} />}
+        {hasIncoming && <StyledHandleTop type="target" position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
             {stateChip}
             <label >{data.label}</label>
         </LabelContainer>
-        <StyledHandle
+        <StyledHandleBottom
             type="source"
             position={Position.Bottom}
             id="sb"
             isConnectable={false}
         />
-        <StyledHandle type="target" position={Position.Bottom} isConnectable={false} id={"tb"} />
-    </LeftNodeContainer>
+    </LeafNodeContainer>
 }
 
 export default LeafNode;

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/common.ts
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/common.ts
@@ -11,7 +11,7 @@ export enum NodeTypes {
     COMPOUND = "compoundNode",
 }
 
-export const StyledHandle = styled(Handle, {
+const StyledHandle = styled(Handle, {
     shouldForwardProp: (prop) => prop !== "color",
 }) <{
     color?: string;
@@ -19,7 +19,16 @@ export const StyledHandle = styled(Handle, {
     height: 12px;
     width: 12px;
     background-color: ${(props) => props.color || theme.palette.success.main};
+    border: none;
 `;
+
+export const StyledHandleTop = styled(StyledHandle)`
+    transform: translateX(-50%) translateY(-1px);
+`; 
+
+export const StyledHandleBottom = styled(StyledHandle)`
+    transform: translateX(-50%) translateY(1px);
+`; 
 
 export const DagViewServiceContext = createContext<{
     onNodeClick: (nodeId: string) => void;

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/dagLayout.ts
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/dagLayout.ts
@@ -161,6 +161,7 @@ export function getReactFlowDag(graph: Graph | undefined, selectedRun: Run | und
         }
 
         if (!newEdge.target) {
+            // This is the case that a child node is connected to the parent node.
             newEdge.target = runsById.get(newEdge.source)?.parent_id!;
             newEdge.targetHandle = "tb";
             newEdge.sourceHandle = "sb";


### PR DESCRIPTION
This PR:

1. remove the round border of the handles, so there is no space between the handle and the box border
2. Align the center of the handle vertically with the box border.

Before:

<img width="709" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/8e56d2ce-5aad-4e65-ad72-afb4d73f4dc6">


After:

<img width="692" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/4ea7523a-816a-4d56-be0d-6fa15b1348ca">
