### PR TITLE
Make Docker image URI parsing more robust

### DIFF
--- a/sematic/cli/cli.py
+++ b/sematic/cli/cli.py
@@ -1,5 +1,6 @@
 # Standard Library
 import logging
+import os
 from logging.config import dictConfig
 
 # Third-party
@@ -23,6 +24,12 @@ def cli(verbose: int):
     Run an example:
         $ sematic run examples/mnist/pytorch
     """
+    if "BUILD_WORKING_DIRECTORY" in os.environ:
+        # if the CLI is being executed via bazel (ex: during development
+        # of the CLI), run from the directory the user invoked bazel
+        # from, rather than the sandbox dir bazel uses by default. That
+        # emulates how the real CLI will behave more accurately.
+        os.chdir(os.environ["BUILD_WORKING_DIRECTORY"])
     if verbose == 1:
         dictConfig(make_log_config(log_to_disk=False, level=logging.INFO))
     elif verbose > 1:

--- a/sematic/examples/add/__main__.yaml
+++ b/sematic/examples/add/__main__.yaml
@@ -1,0 +1,9 @@
+version: 1
+base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
+build:
+  platform: "linux/amd64"
+  requirements: "requirements.txt"
+push:
+  registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com" # update this to your own registry
+  repository: "sematic-dev" # update this to your own repository
+  tag_suffix: "main_example"

--- a/sematic/plugins/building/docker_builder_config.py
+++ b/sematic/plugins/building/docker_builder_config.py
@@ -28,6 +28,14 @@ _PROJECT_ROOT_PREFIX = "//"
 _PARENT_PATH_ELEMENT = ".."
 
 
+_URI_QUOTES = "[\"']"
+_URI_NON_RESERVED_CHARS = "[^\"'@:]"
+_URI_TAGGED_IMAGE = f"({_URI_NON_RESERVED_CHARS}+):({_URI_NON_RESERVED_CHARS}+)"
+_URI_DIGEST = f"{_URI_NON_RESERVED_CHARS}+:?{_URI_NON_RESERVED_CHARS}*"
+_URI_TAGGED_IMAGE_WITH_DIGEST = f"{_URI_TAGGED_IMAGE}@({_URI_DIGEST})"
+_URI_REGEX = f"{_URI_QUOTES}?{_URI_TAGGED_IMAGE_WITH_DIGEST}{_URI_QUOTES}?"
+
+
 @dataclass
 class ImageURI:
     """
@@ -49,7 +57,7 @@ class ImageURI:
             The specified value is not a correct and complete container image URI in the
             required `<repository>:<tag>@<digest>` format.
         """
-        match = re.match("(.+):(.+)@(.+)", uri)
+        match = re.match(_URI_REGEX, uri)
 
         if match is None:
             raise BuildConfigurationError(

--- a/sematic/plugins/building/tests/test_docker_builder_config.py
+++ b/sematic/plugins/building/tests/test_docker_builder_config.py
@@ -23,6 +23,22 @@ def test_image_uri_happy():
     assert str(image_uri) == "a:b"
     assert repr(image_uri) == "a:b@c"
 
+    image_uri = docker_builder_config.ImageURI.from_uri("'ab:cd@ef'")
+
+    assert image_uri.repository == "ab"
+    assert image_uri.tag == "cd"
+    assert image_uri.digest == "ef"
+    assert str(image_uri) == "ab:cd"
+    assert repr(image_uri) == "ab:cd@ef"
+
+    image_uri = docker_builder_config.ImageURI.from_uri('"a:b@sha256:c"')
+
+    assert image_uri.repository == "a"
+    assert image_uri.tag == "b"
+    assert image_uri.digest == "sha256:c"
+    assert str(image_uri) == "a:b"
+    assert repr(image_uri) == "a:b@sha256:c"
+
 
 def test_image_uri_malformed():
     with pytest.raises(
@@ -30,6 +46,12 @@ def test_image_uri_malformed():
         match=".*does not conform to the required.*",
     ):
         docker_builder_config.ImageURI.from_uri("a:b")
+
+    with pytest.raises(
+        docker_builder_config.BuildConfigurationError,
+        match=".*does not conform to the required.*",
+    ):
+        docker_builder_config.ImageURI.from_uri("a'b:c@sha256:d")
 
 
 def test_validate_paths_happy():


### PR DESCRIPTION
If a docker image URI is surrounded in quotes, it can throw off the image pushing. This change ensures that we strip quotes if they're present. This PR also introduces two changes which were introduced to allow testing the change on a Mac:

- make sure that when a Sematic developer does `bazel run //sematic/cli:main`, it runs from the directory you ran that command from (basically as if you had actually executed the `sematic` cli).
- add a build yaml for the add pipeline

Testing
--------

`bazel run //sematic/cli:main -- run --build ./sematic/examples/add/__main__.py -- --cloud --detach`

[run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/97dd47094bb34609961ae9a58fb53e3f#tab=output)