### PR TITLE
Fixes frequent updates on the artifact list

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/artifacts/InputPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/artifacts/InputPane.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import Typography from "@mui/material/Typography";
+import isEmpty from "lodash/isEmpty";
 import { useMemo } from "react";
 import { Artifact } from "src/Models";
 import { useRootRunContext } from "src/context/RootRunContext";
@@ -8,6 +9,7 @@ import ArtifactComponent from "src/pages/RunDetails/artifacts/artifact";
 import { ArtifactPaneContainer } from "src/pages/RunDetails/artifacts/common";
 import theme from "src/theme/new";
 
+
 const StyledTypography = styled(Typography)`
     margin-top: ${theme.spacing(5)};
 `;
@@ -15,7 +17,7 @@ const StyledTypography = styled(Typography)`
 
 function InputPane() {
     const { selectedRun } = useRunDetailsSelectionContext();
-    const { graph, isGraphLoading } = useRootRunContext();
+    const { graph } = useRootRunContext();
 
     const inputArtifacts = useMemo(() => {
         if (!graph) {
@@ -43,11 +45,11 @@ function InputPane() {
 
     }, [graph, selectedRun?.id]);
 
-    if (isGraphLoading) {
+    if (isEmpty(inputArtifacts)) {
         return null;
     }
 
-    return <InputPanePresentation inputArtifacts={inputArtifacts || []} />;
+    return <InputPanePresentation inputArtifacts={inputArtifacts!} />;
 }
 
 interface InputPanePresentationProps {

--- a/sematic/ui/packages/common/src/pages/RunDetails/artifacts/OutputPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/artifacts/OutputPane.tsx
@@ -1,12 +1,12 @@
+import { Box } from "@mui/material";
+import Alert from "@mui/material/Alert";
+import { useMemo } from "react";
+import { Artifact } from "src/Models";
+import { Exception, ExternalException } from "src/component/Exception";
 import { useRootRunContext } from "src/context/RootRunContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 import ArtifactComponent from "src/pages/RunDetails/artifacts/artifact";
-import { useMemo } from "react";
-import { Artifact } from "src/Models";
 import { ArtifactPaneContainer } from "src/pages/RunDetails/artifacts/common";
-import { Exception, ExternalException } from "src/component/Exception";
-import { Box } from "@mui/material";
-import Alert from "@mui/material/Alert";
 
 function OutputPane() {
     const { selectedRun } = useRunDetailsSelectionContext();
@@ -59,11 +59,11 @@ function OutputPane() {
         return null;
     }, [isGraphLoading, selectedRun]);
 
-    if (isGraphLoading) {
+    const { future_state } = selectedRun! || {};
+
+    if (!future_state) {
         return null;
     }
-
-    const { future_state } = selectedRun! || {};
 
     if (["CREATED", "SCHEDULED", "RAN"].includes(future_state)) {
         return <Alert severity="info">No output yet. Run has not completed.</Alert>;

--- a/sematic/ui/packages/common/src/pages/RunDetails/artifacts/artifact.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/artifacts/artifact.tsx
@@ -26,7 +26,7 @@ const StyledVertButton = styled(MoreVertButton)`
 `;
 
 const ArtifactRepresentation = styled.div`
-    margin-left: -${theme.spacing(5)};
+    margin-left: 0;
 `;
 
 interface ArtifactProps {

--- a/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
+++ b/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
@@ -88,6 +88,8 @@ const valueComponentClass = css`
     flex-shrink: 1;
     overflow: hidden;
     text-overflow: ellipsis;
+    align-items: center;
+    display: flex;
 `;
 
 function RenderError({children}: {

--- a/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
+++ b/sematic/ui/packages/common/src/typeViz/ArtifactVizTemplate.tsx
@@ -19,8 +19,6 @@ const ContainerBase = styled.div`
     align-items: center;
     justify-content: space-between;
 
-    padding-left: ${theme.spacing(5)};
-    border-left: 1px solid ${theme.palette.p3border.main};
 `;
 
 const Container = styled(ContainerBase)`
@@ -29,13 +27,27 @@ const Container = styled(ContainerBase)`
 `;
 
 const NestedContainer = styled.div`
-    margin-left: ${theme.spacing(5)};
+    margin-left: ${theme.spacing(5)};    
+
+    > .nested-artifact-container {
+        border-left: 1px solid ${theme.palette.p3border.main};
+
+        margin-left: -${theme.spacing(5)};
+        padding-left: ${theme.spacing(5)};
+    }
 
     &.hover {
-        > .artifact-row {
+        > .nested-artifact-container {
             border-left: 1px solid ${theme.palette.primary.main};
         }
     }
+`;
+
+const NestedValueContainer = styled(ContainerBase)`
+    display: flex;
+    flex-direction: column;
+
+    align-items: stretch;
 `;
 
 const NameType = styled.div`
@@ -92,11 +104,11 @@ const valueComponentClass = css`
     display: flex;
 `;
 
-function RenderError({children}: {
+function RenderError({ children }: {
     children: React.ReactNode;
 }) {
     return <ArtifactExpanderContainer>
-        <span style={{color: theme.palette.error.main}}>{children}</span>
+        <span style={{ color: theme.palette.error.main }}>{children}</span>
     </ArtifactExpanderContainer>
 }
 
@@ -149,7 +161,7 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
             </span>;
         }
 
-        return <div style={{marginRight: theme.spacing(8)}} className={valueComponentClass}>
+        return <div style={{ marginRight: theme.spacing(8) }} className={valueComponentClass}>
             {component}
         </div>;
     }, [toggleOpen, open, hasNested, theme, ValueComponent, valueSummary, typeSerialization]);
@@ -172,12 +184,15 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
             </ExpandMoreIconCotainer>}
         </ArtifactLine>
         {open && !!NestedComponent && <NestedContainer className={expandLessHovered ? "hover" : ""}>
-            <ErrorBoundary fallback={
-                <RenderError>
-                    Error encountered when rendering the nested representation.
-                </RenderError>}>
-                <NestedComponent valueSummary={valueSummary} typeSerialization={typeSerialization} />
-            </ErrorBoundary>
+            <NestedValueContainer className={"nested-artifact-container"}>
+                <ErrorBoundary fallback={
+                    <RenderError>
+                        Error encountered when rendering the nested representation.
+                    </RenderError>}>
+                    <NestedComponent valueSummary={valueSummary} typeSerialization={typeSerialization} />
+                </ErrorBoundary>
+            </NestedValueContainer>
+
 
             <ExpandLessIconCotainer>
                 <IconButton onClick={toggleOpen} onMouseEnter={() => setExpandLessHovered(true)}
@@ -189,18 +204,24 @@ function ArtifactVizTemplate(props: ArtifactVizTemplateProps) {
     </Fragment>;
 }
 
+const ArtifactInfoWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+`;
+
 export function ArtifactInfoContainer(props: { children: React.ReactNode }) {
-    return <Container className={"artifact-row"}>
+    return <ArtifactInfoWrapper>
         {props.children}
-    </Container>;
+    </ArtifactInfoWrapper>;
 }
 
-const ExpanderContainer = styled(ContainerBase)`
+const ExpanderContainer = styled(ArtifactInfoWrapper)`
     justify-content: flex-end;
 `;
 
 export function ArtifactExpanderContainer(props: { children: React.ReactNode }) {
-    return <ExpanderContainer className={"artifact-row"}>
+    return <ExpanderContainer>
         {props.children}
     </ExpanderContainer>;
 }

--- a/sematic/ui/packages/common/src/typeViz/views/HuggingFaceReference.tsx
+++ b/sematic/ui/packages/common/src/typeViz/views/HuggingFaceReference.tsx
@@ -4,7 +4,8 @@ import { Button, Chip, Tooltip } from "@mui/material";
 import { ContentCopy } from "@mui/icons-material";
 import SnackBarContext from "@sematic/common/src/context/SnackBarContext";
 import { useTextSelection } from "@sematic/common/src/hooks/textSelectionHooks";
-import { ViewComponentProps, ValueComponentProps} from "src/typeViz/common";
+import { ViewComponentProps, ValueComponentProps } from "src/typeViz/common";
+import { ArtifactInfoContainer } from "src/typeViz/ArtifactVizTemplate";
 
 type Reference = {
     owner: string | null;
@@ -38,7 +39,7 @@ export function HuggingFaceDatasetReferenceShortView(props: ValueComponentProps)
 export function HuggingFaceModelReferenceValueView(props: ViewComponentProps) {
     const { valueSummary } = props;
     const { values } = valueSummary;
-  
+
     return <SlugChip reference={values} />;
 }
 
@@ -66,9 +67,9 @@ function HuggingFaceButton(props: {
             // commit and subset in the UI at the same time. If there
             // is a specific commit referenced, let that take precedence.
             let path = repoPath;
-            if(commit_sha) {
+            if (commit_sha) {
                 path = repoPath + "/tree/" + commit_sha;
-            } else if(subset) {
+            } else if (subset) {
                 path = repoPath + "/viewer/" + subset;
             }
 
@@ -80,14 +81,14 @@ function HuggingFaceButton(props: {
     const displayedSlug = useMemo(
         () => {
             let slug = (owner ? owner + "/" : "") + repo;
-            if(subset) {
+            if (subset) {
                 slug += ":" + subset;
             }
-            if(commit_sha) {
+            if (commit_sha) {
                 slug += "@" + commit_sha.substring(0, 7);
             }
-  
-            if(short) {
+
+            if (short) {
                 slug = "";
             }
             return slug;
@@ -118,37 +119,39 @@ function SlugChip(props: {
     const [displayedSlug, fullSlug] = useMemo(
         () => {
             let slug = (owner ? owner + "/" : "") + repo;
-            if(subset) {
+            if (subset) {
                 slug += ":" + subset;
             }
             let fullSlug = slug;
-            if(commit_sha) {
+            if (commit_sha) {
                 slug += "@" + commit_sha.substring(0, 7);
                 fullSlug += "@" + commit_sha;
             }
             return [slug, fullSlug];
         }, [owner, repo, subset, commit_sha]
     );
-    
+
     const { setSnackMessage } = useContext(SnackBarContext);
 
     const copy = useCallback(() => {
         setSnackMessage({ message: "Copied " + fullSlug });
         navigator.clipboard.writeText(fullSlug);
     }, [fullSlug, setSnackMessage]);
-    
+
     const contents = useMemo(
         () => {
             return (
-                <Tooltip title={"Copy " + fullSlug}>
-                    <Chip
-                        icon={<ContentCopy />}
-                        sx={{ paddingLeft: 2, paddingRight: 2}}
-                        onClick={copy}
-                        label={"🤗 "+ displayedSlug}
-                        variant="outlined"
-                    />
-                </Tooltip>
+                <ArtifactInfoContainer>
+                    <Tooltip title={"Copy " + fullSlug}>
+                        <Chip
+                            icon={<ContentCopy />}
+                            sx={{ paddingLeft: 2, paddingRight: 2 }}
+                            onClick={copy}
+                            label={"🤗 " + displayedSlug}
+                            variant="outlined"
+                        />
+                    </Tooltip>
+                </ArtifactInfoContainer>
             );
         }, [displayedSlug, fullSlug, copy]
     );

--- a/sematic/ui/packages/common/src/typeViz/views/HuggingFaceStoredModel.tsx
+++ b/sematic/ui/packages/common/src/typeViz/views/HuggingFaceStoredModel.tsx
@@ -2,7 +2,8 @@ import { useCallback, useContext, useMemo } from "react";
 import { Chip, Tooltip } from "@mui/material";
 import { ContentCopy } from "@mui/icons-material";
 import SnackBarContext from "@sematic/common/src/context/SnackBarContext";
-import { ViewComponentProps} from "src/typeViz/common";
+import { ViewComponentProps } from "src/typeViz/common";
+import { ArtifactInfoContainer } from "src/typeViz/ArtifactVizTemplate";
 
 
 export function HuggingFaceStoredModelShortView() {
@@ -24,15 +25,17 @@ export function HuggingFaceStoredModelFullView(props: ViewComponentProps) {
             const modelTypeShortName = getShortName(values.peft_model_type, values.model_type);
 
             return (
-                <Tooltip title={"Copy path to model: " + values.path}>
-                    <Chip
-                        icon={<ContentCopy />}
-                        onClick={copy}
-                        sx={{ paddingLeft: 2, paddingRight: 2}}
-                        label={"🤗 "+ modelTypeShortName}
-                        variant="outlined"
-                    />
-                </Tooltip>
+                <ArtifactInfoContainer>
+                    <Tooltip title={"Copy path to model: " + values.path}>
+                        <Chip
+                            icon={<ContentCopy />}
+                            onClick={copy}
+                            sx={{ paddingLeft: 2, paddingRight: 2 }}
+                            label={"🤗 " + modelTypeShortName}
+                            variant="outlined"
+                        />
+                    </Tooltip>
+                </ArtifactInfoContainer>
             );
         }, [values, copy]
     );


### PR DESCRIPTION
1. Fixes an issue that when the graph is updating, the artifact list always refreshes, despite no change

2. Fixes an issue that the Link type artifact cannot be rendered correctly. 

Before:

<img width="1307" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/4f626563-c3b9-4ac8-8756-7d7dc47d2c15">


After:
<img width="1298" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/769ba798-211c-4d39-9a9d-99b3bdde1c77">


3. Refactor the code of high-lightening the expanded artifact section. Now all nested artifact values will have the indentation indicator. 

<img width="1290" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/0b9cbac8-e8c2-4a48-866a-b8af6e57c501">
