### PR TITLE
Fixes broken metrics link

### DIFF
--- a/sematic/ui/packages/common/src/pages/PipelineRuns/PipelineInfoPane.tsx
+++ b/sematic/ui/packages/common/src/pages/PipelineRuns/PipelineInfoPane.tsx
@@ -32,12 +32,12 @@ interface PipelineInfoPaneProps {
 
 function PipelineInfoPane(props: PipelineInfoPaneProps) {
     const { onFiltersChanged } = props;
-    const { setSelectedPanel, selectedRun } = useRunDetailsSelectionContext();
+    const { selectedRun, setSelectedPanel } = useRunDetailsSelectionContext();
 
     const navigate = useRunNavigation();
 
     const onMetricsSectionClicked = useCallback(() => {
-        navigate(selectedRun!.id);
+        navigate(selectedRun!.id, false, { panel: "metrics"});
         setSelectedPanel("metrics");
     }, [selectedRun, setSelectedPanel, navigate]);
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/PipelineSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/PipelineSectionMenu.tsx
@@ -2,7 +2,7 @@ import ContextMenu from "src/component/ContextMenu";
 import { useMemo } from "react";
 import { useRootRunContext } from "src/context/RootRunContext";
 import { useNavigate } from "react-router-dom";
-import { getPipelineRunsPattern } from "src/hooks/runHooks";
+import { getPipelineRunsPattern, useRunNavigation } from "src/hooks/runHooks";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 
 const ANCHOR_OFFSET = {x: 13, y: -11};
@@ -16,6 +16,7 @@ function PipelineSectionActionMenu(props: PipelineSectionActionMenuProps) {
     const { rootRun } = useRootRunContext();
     const navigate = useNavigate();
     const { setSelectedPanel } = useRunDetailsSelectionContext();
+    const navigateToRun = useRunNavigation();
 
 
     const commands = useMemo(() => {
@@ -29,11 +30,12 @@ function PipelineSectionActionMenu(props: PipelineSectionActionMenuProps) {
             {
                 title: "Metrics",
                 onClick: () => { 
+                    navigateToRun(rootRun!.id, false, { panel: "metrics"});
                     setSelectedPanel("metrics");
                 }
             }
         ]
-    }, [rootRun, navigate, setSelectedPanel]);
+    }, [rootRun, navigate, navigateToRun, setSelectedPanel]);
 
     return <ContextMenu anchorEl={anchorEl} commands={commands} anchorOffset={ANCHOR_OFFSET} />;
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/BasicMetricsPanel.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/BasicMetricsPanel.tsx
@@ -124,7 +124,7 @@ export default function BasicMetricsPanel(props: BasicMetricsPanelProps) {
                     </Grid>
                     <Typography variant="h3">Average run time by function</Typography>
                     <Box sx={{ my: 10 }}>
-                        <Table>
+                        <Table sx={{position: "relative"}}>
                             <TableBody>
                                 {sortedAvgRuntimeChildren.map(
                                     ([functionPath, runtimeS], idx) => (

--- a/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/index.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/pipelineMetrics/index.tsx
@@ -3,6 +3,14 @@ import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { useRootRunContext } from "src/context/RootRunContext";
 import BasicMetricsPanel from "src/pages/RunDetails/pipelineMetrics/BasicMetricsPanel";
 import useUnmount from "react-use/lib/useUnmount";
+import styled from "@emotion/styled";
+
+
+const ScrollContainerWrapper = styled.div`
+    overflow-y: auto;
+    margin-right: -25px;
+    height: 100%;
+`;
 
 function PipelineMetrics() {
     const { rootRun } = useRootRunContext();
@@ -13,13 +21,15 @@ function PipelineMetrics() {
         setIsLoading(false);
     });
 
-    if (!rootRun ) {
+    if (!rootRun) {
         return null;
     }
 
-    return <BasicMetricsPanel runId={rootRun.id} functionPath={rootRun.function_path}
-        setIsLoading={setIsLoading} />
-        
+    return <ScrollContainerWrapper>
+        <BasicMetricsPanel runId={rootRun.id} functionPath={rootRun.function_path}
+            setIsLoading={setIsLoading} />
+    </ScrollContainerWrapper>;
+
 }
 
 


### PR DESCRIPTION
1. Fixes a bug that the "Metrics" menu item does not trigger page navigation if it is triggered from the Run Resolutions page. (It only worked on the run details page)

![image](https://github.com/sematic-ai/sematic/assets/133257643/99f16e9b-df36-4769-9fbd-20cd98238c15)

2. Changes the scrolling behavior of the pipeline metrics panel from full-page scrolling to scrolling from only within the center pane.

Before:
![capture1](https://github.com/sematic-ai/sematic/assets/133257643/f69e34ed-badb-49c6-a003-0be004f9fe4c)


After:
![capture1](https://github.com/sematic-ai/sematic/assets/133257643/02e6889d-ac98-4fad-b17b-de898f3f2362)

