### PR TITLE
Display avatar alongside user names

### DIFF
--- a/sematic/ui/packages/common/src/component/Note.tsx
+++ b/sematic/ui/packages/common/src/component/Note.tsx
@@ -9,14 +9,8 @@ import DateTime from "src/component/DateTime";
 import NameTag from "src/component/NameTag";
 import { RunReferenceLink } from "src/component/RunReference";
 import Section from "src/component/Section";
+import UserAvatar from "src/component/UserAvatar";
 import theme from "src/theme/new";
-
-export interface Note {
-    name: string;
-    content: string;
-    createdAt: string;
-    runId: string;
-}
 
 type ExtendedStyleProps = {
     isExpanded?: boolean;
@@ -85,11 +79,22 @@ const Footer = styled(Box,  {
     }
 `;
 
-interface NoteProps extends Note {
+const StyledAvatar = styled(UserAvatar)`
+    margin-right: ${theme.spacing(1)};
+`;
+
+interface NoteProps {
+    name: string;
+    content: string;
+    createdAt: string;
+    runId: string;
+    avatarInitials?: string;
+    avatarHoverText?: string | null;
+    avatarUrl?: string | null;
 }
 
 const NoteComponent = (prop: NoteProps) => {
-    const { name, content, createdAt, runId } = prop;
+    const { name, content, createdAt, runId, avatarInitials, avatarHoverText, avatarUrl } = prop;
 
     const theme = useTheme();
     const [isExpanded, setIsExpanded] = useState(false);
@@ -107,7 +112,8 @@ const NoteComponent = (prop: NoteProps) => {
         <div ref={contentArea}>
             <Title>
                 <Box style={{ display: "flex" }}>
-                    <NameTag firstName={name} />
+                    {!!avatarInitials && <StyledAvatar initials={avatarInitials} hoverText={avatarHoverText} avatarUrl={avatarUrl} />}
+                    {!!name && <NameTag firstName={name} />}
                     <Typography variant="small" color={theme.palette.lightGrey.main} paragraph={false}>
                         {"\xa0on run"}
                     </Typography>

--- a/sematic/ui/packages/common/src/component/UserAvatar.tsx
+++ b/sematic/ui/packages/common/src/component/UserAvatar.tsx
@@ -1,0 +1,76 @@
+import { Avatar, AvatarProps } from "@mui/material";
+import { useMemo } from "react";
+import { TAG_COLORS, getTagColor } from "src/utils/color";
+
+interface UserAvatarProps extends AvatarProps {
+    avatarUrl?: string | null;
+    initials?: string;
+    hoverText?: string | null;
+    size?: "small" | "medium" | "large";
+}
+
+const useStylesHook = (options: {
+    size: NonNullable<UserAvatarProps["size"]>, 
+    hasAvatar: boolean,
+    initials: string | undefined
+}) => {
+    const { size, hasAvatar, initials } = options;
+
+    const styles = useMemo(() => {
+        const sizeMap = {
+            small: {
+                dimension: 15,
+                fontSize: "9px",
+            },
+            medium: {
+                dimension: 20,
+                fontSize: "12px",
+            },
+            large: {
+                dimension: 25,
+                fontSize: "15px",
+            }
+        };
+        const { dimension, fontSize } = sizeMap[size];
+        if (hasAvatar) {
+            return {
+                width: dimension,
+                height: dimension,
+                fontSize,
+            };
+        }
+
+        const hashInitials = initials?.split("").reduce((acc, char) => {
+            return acc * 26 + (char.toLowerCase().charCodeAt(0) - "a".charCodeAt(0));
+        }, 0);
+
+        return {
+            width: dimension,
+            height: dimension,
+            fontSize,
+            ...(hashInitials ? getTagColor(hashInitials) : TAG_COLORS[5]),
+        };
+    }, [size, initials, hasAvatar]);
+
+    return styles;
+};
+
+export default function UserAvatar(props: UserAvatarProps) {
+    const { initials, avatarUrl, hoverText, size = "small", ...other } = props;
+
+    const styles = useStylesHook({size, hasAvatar: !!avatarUrl, initials});
+
+    if (!initials) {
+        return null;
+    }
+    return (
+        <Avatar
+            alt={hoverText!}
+            src={avatarUrl || undefined}
+            sx={styles}
+            {...other}
+        >
+            { initials }
+        </Avatar >
+    );
+}

--- a/sematic/ui/packages/common/src/component/UserMenu.tsx
+++ b/sematic/ui/packages/common/src/component/UserMenu.tsx
@@ -9,7 +9,7 @@ import UserContext from "src/context/UserContext";
 import theme from "src/theme/new";
 import Link from "@mui/material/Link";
 
-const ANCHOR_OFFSET = { x: 5, y: 15 };
+const ANCHOR_OFFSET = { x: 5, y: 0 };
 
 const Container = styled.div`
     min-width: 300px;

--- a/sematic/ui/packages/common/src/component/menu.tsx
+++ b/sematic/ui/packages/common/src/component/menu.tsx
@@ -13,10 +13,26 @@ import Fox from "src/static/fox";
 import palette from "src/theme/new/palette";
 import useLatest from "react-use/lib/useLatest";
 import useCounter from "react-use/lib/useCounter";
+import UserAvatar from "src/component/UserAvatar";
+import { getUserInitials } from "src/utils/string";
+import theme from "src/theme/new";
 
 const StyledGridContainer = styled(Grid)`
     border-bottom: 1px solid ${() => (palette.p3border as SimplePaletteColorOptions).main};
     flex-wrap: nowrap;
+`;
+
+const StyledLink = styled(Link)`
+    display: flex;
+    flex-direction: row;
+
+    & > :first-of-type {
+        margin-right: ${theme.spacing(1)};
+    }
+
+    &:before {
+        display: none;
+    }
 `;
 
 interface HeaderMenuProps {
@@ -63,10 +79,11 @@ const HeaderMenu = (props: HeaderMenuProps) => {
             </MuiRouterLink>
             <MuiRouterLink href={"https://docs.sematic.dev"} variant="subtitle1" type='menu'>Docs</MuiRouterLink>
             <MuiRouterLink href={"https://discord.gg/4KZJ6kYVax"} variant="subtitle1" type='menu'>Discord</MuiRouterLink>
-            <Link variant="subtitle1" type='menu'>
-                <NameTag firstName={user?.first_name} lastName={undefined} variant={"inherit"}
-                    ref={contextMenuAnchor} />
-            </Link>
+            <StyledLink variant="subtitle1" type='menu' ref={contextMenuAnchor}>
+                {!!user && <UserAvatar initials={getUserInitials(user?.first_name, user?.last_name, user?.email)} 
+                    hoverText={user?.first_name || user?.email} avatarUrl={user?.avatar_url} size={"medium"}/>}
+                <NameTag firstName={user?.first_name} lastName={undefined} variant={"inherit"} />
+            </StyledLink>
             <UserMenu anchorEl={contextMenuAnchor.current} />
         </Box>
     </StyledGridContainer>;

--- a/sematic/ui/packages/common/src/pages/RunDetails/NotesPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/NotesPane.tsx
@@ -8,6 +8,7 @@ import UserContext from "src/context/UserContext";
 import { useNoteSubmission, usePipelineNotes } from "src/hooks/noteHooks";
 import SubmitNoteSection from "src/pages/RunDetails/SubmitNoteSection";
 import theme from "src/theme/new";
+import { getUserInitials } from "src/utils/string";
 import { ExtractContextType } from "src/utils/typings";
 
 const Notes = styled.section`
@@ -60,6 +61,8 @@ const NotesPane = () => {
         <Notes>
             {(notes || []).map(({ note, run_id, created_at, user }, index) =>
                 <Note key={index} content={note} name={getUserName(user)} runId={run_id}
+                    avatarInitials={getUserInitials(user?.first_name, user?.last_name, user?.email)}
+                    avatarUrl={user?.avatar_url} avatarHoverText={user?.first_name || user?.email}
                     createdAt={created_at as unknown as string} />)}
         </Notes>
     </>;

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -10,11 +10,13 @@ import NameTag from "src/component/NameTag";
 import RunsDropdown from "src/component/RunsDropdown";
 import Section from "src/component/Section";
 import TagsList from "src/component/TagsList";
+import UserAvatar from "src/component/UserAvatar";
 import RootRunContext, { useRootRunContext } from "src/context/RootRunContext";
 import usePipelineSocketMonitor from "src/hooks/pipelineSocketMonitorHooks";
 import { getRunUrlPattern, useFetchRuns } from "src/hooks/runHooks";
 import RunSectionActionMenu from "src/pages/RunDetails/contextMenus/RunSectionMenu";
 import theme from "src/theme/new";
+import { getUserInitials } from "src/utils/string";
 import { ExtractContextType, RemoveUndefined } from "src/utils/typings";
 
 const StyledSection = styled(Section)`
@@ -32,6 +34,12 @@ const BoxContainer = styled(Box)`
 
 const OwnerContainer = styled.span`
   margin-right: ${theme.spacing(2)};
+  display: flex;
+  flex-direction: row;
+
+  & > :first-of-type {
+    margin-right: ${theme.spacing(1)};
+  }
 `;
 
 const RunSection = () => {
@@ -57,8 +65,17 @@ const RunSection = () => {
         []
     );
 
-    const owner = useMemo(() => <NameTag firstName={rootRun.user?.first_name} lastName={rootRun.user?.last_name} />
-        , [rootRun]);
+    const owner = useMemo(() => {
+        if (!rootRun.user) {
+            return null;
+        }
+        const user = rootRun.user;
+        return <>
+            <UserAvatar initials={getUserInitials(user?.first_name, user?.last_name, user?.email)}
+                hoverText={user?.first_name || user?.email} avatarUrl={user?.avatar_url} />
+            <NameTag firstName={rootRun.user?.first_name} lastName={rootRun.user?.last_name} />
+        </>;
+    }, [rootRun]);
 
     const resolverKind = useMemo(() => {
         if (!resolution) {

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/columnDefinition.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/columnDefinition.tsx
@@ -3,11 +3,11 @@ import { ColumnHelper } from "@tanstack/react-table";
 import { parseJSON } from "date-fns";
 import { Run } from "src/Models";
 import { DateTimeLongConcise } from "src/component/DateTime";
-import NameTag from "src/component/NameTag";
 import { RunReference } from "src/component/RunReference";
 import RunStatusColumn from "src/pages/RunSearch/RunStatusColumn";
 import NameColumn from "src/pages/RunTableCommon/NameColumn";
 import TagsColumn from "src/pages/RunTableCommon/TagsColumn";
+import OwnerColumn from "src/pages/RunTableCommon/ownerColumn";
 import theme from "src/theme/new";
 
 
@@ -66,10 +66,7 @@ export const TagsColumnDef = (columnHelper: ColumnHelper<Run>) =>
     });
 
 export const OwnerColumnDef = (columnHelper: ColumnHelper<Run>) =>
-    columnHelper.accessor(data => ({
-        firstName: data.user?.first_name,
-        lastName: data.user?.last_name
-    }), {
+    columnHelper.accessor(data => data.user, {
         meta: {
             columnStyles: {
                 width: "8.39092%", // this is the minWidth (100px) divided by the sum of the minWidths of all other columns.
@@ -77,7 +74,7 @@ export const OwnerColumnDef = (columnHelper: ColumnHelper<Run>) =>
             }
         },
         header: "Owner",
-        cell: info => <NameTag {...info.getValue()} />,
+        cell: info => <OwnerColumn user={info.getValue()} />,
     });
 
 export const StatusColumnDef = (columnHelper: ColumnHelper<Run>) =>

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/ownerColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/ownerColumn.tsx
@@ -1,0 +1,29 @@
+import { User } from "src/Models";
+import NameTag from "src/component/NameTag";
+import UserAvatar from "src/component/UserAvatar";
+import { getUserInitials } from "src/utils/string";
+import styled from "@emotion/styled";
+import theme from "src/theme/new";
+
+const StyledContainer = styled.div`
+    display: inline-flex;
+    & > :first-of-type {
+        margin-right: ${theme.spacing(1)};
+    }
+`;
+
+interface OwnerColumnProps {
+    user: User | null;
+}
+
+export default function OwnerColumn(props: OwnerColumnProps) {
+    const { user } = props;
+
+    if (!user) return null;
+
+    return <StyledContainer>
+        <UserAvatar initials={getUserInitials(user?.first_name, user?.last_name, user?.email)}
+            hoverText={user?.first_name || user?.email} avatarUrl={user?.avatar_url} />
+        <NameTag firstName={user.first_name} lastName={user.last_name} />
+    </StyledContainer>;
+}

--- a/sematic/ui/packages/common/src/utils/color.ts
+++ b/sematic/ui/packages/common/src/utils/color.ts
@@ -10,3 +10,50 @@ const CHART_COLORS = [
 export function getChartColor(index: number): string {
     return CHART_COLORS[index % CHART_COLORS.length];
 }
+
+export const TAG_COLORS = [
+    {
+        color: "rgb(65, 36, 84)",
+        backgroundColor: "rgb(232, 222, 238)"
+    }, // purple
+    {
+        color: "rgb(24, 51, 71)",
+        backgroundColor: "rgb(91, 151, 189)"
+    }, // blue
+    {
+        color: "rgb(93, 23, 21)",
+        backgroundColor: "rgb(255, 226, 221)"
+    }, // pink
+    {
+        color: "rgb(93, 23, 21)",
+        backgroundColor: "rgba(238, 224, 218)"
+    }, // brown
+    {
+        color: "rgb(64, 44, 27)",
+        backgroundColor: "rgb(253, 236, 200)"
+    }, // yellow
+    {
+        color: "rgb(50, 48, 44)",
+        backgroundColor: "rgba(227, 226, 224, 0.5)"
+    }, // default
+    {
+        color: "rgb(145, 145, 142)",
+        backgroundColor: "rgb(227, 226, 224)"
+    }, // gray
+    {
+        color: "rgb(28, 56, 41)",
+        backgroundColor: "rgb(219, 237, 219)"
+    }, // green
+    {
+        color: "rgb(93, 23, 21)",
+        backgroundColor: "rgb(225, 111, 100)"
+    }, // red
+    {
+        color: "rgb(73, 41, 14)",
+        backgroundColor: "rgb(250, 222, 201)"
+    } // orange
+];
+
+export function getTagColor(anyNumber: number): typeof TAG_COLORS[0] {
+    return TAG_COLORS[anyNumber % TAG_COLORS.length];
+}

--- a/sematic/ui/packages/common/src/utils/string.ts
+++ b/sematic/ui/packages/common/src/utils/string.ts
@@ -1,0 +1,4 @@
+export function getUserInitials(firstName: string | undefined | null,
+    lastName: string | undefined | null, email: string | undefined | null) {
+    return firstName ? `${firstName[0]}${lastName?.[0] || ""}` : email?.[0];
+}


### PR DESCRIPTION
Preview:

1. Style for the case when users have pre-defined profile images.
<img width="1607" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/06999e35-2e54-4199-9bbc-171a81da415f">

2. Style for the case when users do not have profile images pre-defined.
<img width="1608" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/550ba925-3b06-40b6-aa65-77eb1ba56a80">
