### PR TITLE
Fixes DAG zoom issue

### DIFF
--- a/sematic/ui/packages/common/src/component/RunsDropdown.tsx
+++ b/sematic/ui/packages/common/src/component/RunsDropdown.tsx
@@ -96,7 +96,7 @@ const RunsDropdown = (prop: RunsDropdownProps) => {
 
     return <FormControl style={{ width: "100%" }} size="small">
         <StyledSelect value={value} renderValue={renderValue} onChange={onChange}>
-            {runs.map((run) => <StyledMenuItem key={run.id} value={run.id}>
+            {runs.map((run) => <StyledMenuItem key={`${run.id}--${run.future_state}`} value={run.id}>
                 <ValuePresentation run={run} />
             </StyledMenuItem>)}
         </StyledSelect>

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Headline from "src/component/Headline";
 import MoreVertButton from "src/component/MoreVertButton";
@@ -38,7 +38,7 @@ const RunSection = () => {
     const theme = useTheme();
     const navigate = useNavigate();
 
-    const { rootRun, resolution } = useRootRunContext() as RemoveUndefined<ExtractContextType<typeof RootRunContext>>;
+    const { rootRun, resolution, isGraphLoading } = useRootRunContext() as RemoveUndefined<ExtractContextType<typeof RootRunContext>>;
 
     const runFilters = useMemo(
         () => ({
@@ -79,6 +79,13 @@ const RunSection = () => {
     usePipelineSocketMonitor(rootRun.function_path, useMemo(() => ({
         onCancel: reloadRuns
     }), [reloadRuns]));
+
+    useEffect(() => {
+        if (isGraphLoading) {
+            return;
+        }
+        reloadRuns();
+    }, [isGraphLoading, reloadRuns])
 
     return (
         <StyledSection>

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
@@ -6,13 +6,15 @@ import { useCallback, useContext, useMemo } from "react";
 import { NodeProps, Position } from "reactflow";
 import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming, useNodeExpandStateToggle } from "src/hooks/dagHooks";
-import { DagViewServiceContext, StyledHandleTop, StyledHandleBottom } from "src/pages/RunDetails/dag/common";
+import { DagViewServiceContext, StyledHandleBottom, StyledHandleTop } from "src/pages/RunDetails/dag/common";
 import theme from "src/theme/new";
+import includes from "lodash/includes";
 
 const CompoundNodeContainer = styled("div", {
-    shouldForwardProp: (prop) => prop !== "selected"
+    shouldForwardProp: (prop) => !includes(["selected", "color"], prop)
 }) <{
     selected?: boolean;
+    color: string;
 }>`
     width: min-content;
     display: flex;
@@ -20,6 +22,12 @@ const CompoundNodeContainer = styled("div", {
     border-width: ${({ selected }) => selected ? 2 : 1}px;
     border-style: solid;
     border-radius: 4px;
+    border-color: ${({ color }) => color};
+    cursor: pointer;
+
+    label {
+        cursor: pointer;
+    }
 `;
 
 export const LabelContainer = styled.div`
@@ -66,8 +74,8 @@ function CompoundNode(props: NodeProps) {
         onNodeClick(run.id);
     }, [onNodeClick, run]);
 
-    return <CompoundNodeContainer selected={selected} onClick={onClick}
-        style={{ width: `${data.width}px`, height: `${data.height}px`, borderColor: color }}>
+    return <CompoundNodeContainer selected={selected} onClick={onClick} color={color}
+        style={{ width: `${data.width}px`, height: `${data.height}px` }}>
         {hasIncoming && <StyledHandleTop type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
             {stateChip}
@@ -80,9 +88,9 @@ function CompoundNode(props: NodeProps) {
             type="source"
             position={Position.Bottom}
             id="sb"
-            isConnectable={false}
+            isConnectable={false} color={color} 
         />
-        <StyledHandleBottom type="target" position={Position.Bottom} isConnectable={false} id={"tb"} />
+        <StyledHandleBottom type="target" position={Position.Bottom} isConnectable={false} id={"tb"} color={color} />
     </CompoundNodeContainer>
 }
 

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
@@ -6,11 +6,13 @@ import { useHasIncoming } from "src/hooks/dagHooks";
 import { DagViewServiceContext, LEFT_NODE_MAX_WIDTH, StyledHandleTop, StyledHandleBottom } from "src/pages/RunDetails/dag/common";
 import { SPACING } from "src/pages/RunDetails/dag/dagLayout";
 import theme from "src/theme/new";
+import includes from "lodash/includes";
 
 const LeafNodeContainer = styled("div", {
-    shouldForwardProp: (prop) => prop !== "selected"
+    shouldForwardProp: (prop) => !includes(["selected", "color"], prop)
 }) <{
     selected?: boolean;
+    color: string;
 }>`
     width: max-content;
     max-width: ${LEFT_NODE_MAX_WIDTH}px;
@@ -19,6 +21,12 @@ const LeafNodeContainer = styled("div", {
     align-items: center;
     border: ${({ selected }) => selected ? 2 : 1}px solid #ccc;
     border-radius: 4px;
+    border-color: ${({ color }) => color};
+    cursor: pointer;
+
+    label {
+        cursor: pointer;
+    }
 `;
 
 export const LabelContainer = styled.div`
@@ -47,10 +55,11 @@ function LeafNode(props: NodeProps) {
         onNodeClick(run.id);
     }, [onNodeClick, run]);
 
-    return <LeafNodeContainer selected={selected} style={{ paddingRight: `${SPACING}px`, borderColor: color }}
+    return <LeafNodeContainer selected={selected} color={color} style={{ paddingRight: `${SPACING}px` }}
         onClick={onClick}
     >
-        {hasIncoming && <StyledHandleTop type="target" position={Position.Top} isConnectable={false} id={"t"} />}
+        {hasIncoming && <StyledHandleTop type="target" position={Position.Top} isConnectable={false}
+            id={"t"} color={color} />}
         <LabelContainer>
             {stateChip}
             <label >{data.label}</label>
@@ -60,6 +69,7 @@ function LeafNode(props: NodeProps) {
             position={Position.Bottom}
             id="sb"
             isConnectable={false}
+            color={color}
         />
     </LeafNodeContainer>
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/ReactFlowDag.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/ReactFlowDag.tsx
@@ -74,11 +74,11 @@ function ReactFlowDagStaging() {
     }, [setLayoutDone, edges, incVersion]);
 
     const onNodeSelectionChange = useCallback((nodeId: string) => {
+        setSelectedPanel(RESET);
         if (nodeId === selectedRun?.id) {
             return;
         }
         setSelectedRunId(nodeId);
-        setSelectedPanel(RESET)
     }, [selectedRun, setSelectedRunId, setSelectedPanel]);
 
     useEffect(() => {
@@ -134,7 +134,9 @@ function ReactFlowDag(props: ReactFlowDagProps) {
     useEffect(() => {
         setNodes([..._nodes]);
         setEdges([..._edges]);
-        reactFlowRef.current?.fitView();
+        reactFlowRef.current?.fitView({
+            maxZoom: 1,
+        });
     }, [_nodes, _edges, setNodes, setEdges]);
 
     return <div style={{ width: "100%", height: "100%" }}>
@@ -144,8 +146,9 @@ function ReactFlowDag(props: ReactFlowDagProps) {
             nodeTypes={nodeTypes}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
-            fitView
             onInit={reactFlow => reactFlowRef.current = reactFlow}
+            fitView
+            fitViewOptions={{maxZoom: 1}}
         />
     </div>;
 }


### PR DESCRIPTION
1. Ensure the DAG view will not be over-zoomed during viewport initialization to prevent it from being too big. 
2. Ensure that the DAG node handles have the same color as the border of the nodes.
3. Ensure that DAG nodes should have pointer on mouse hover
4. Fixes a bug that the runs dropdown list does not update the state chip when the DAG is updated. 

Preview
![capture1](https://github.com/sematic-ai/sematic/assets/133257643/0fea9640-3eb1-416a-8d72-83974d84d4b2)
