### PR TITLE
Improve CI retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,21 +67,9 @@ commands:
       # Pre-build Sematic so we can retry if there are errors due to downloading deps
       - run:
           name: Pre-build Sematic
-          command: bazel build --experimental_repository_downloader_retries=5 //sematic/...
-      - run:
-          # Unfortunately this is the best way to retry in Circle CI
-          # https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-
-          name: Pre-build Sematic (2)
-          command: bazel build --experimental_repository_downloader_retries=5 //sematic/...
-          when: on_fail
-      - run:
-          name: Pre-build Sematic (3)
-          command: bazel build --experimental_repository_downloader_retries=5 //sematic/...
-          when: on_fail
-      - run:
-          name: Pre-build Sematic (4)
-          command: bazel build --experimental_repository_downloader_retries=5 //sematic/...
-          when: on_fail
+          command: |
+            PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.circleci/"
+            retry 5 bazel build --experimental_repository_downloader_retries=5 //sematic/...
       - run:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,20 +80,9 @@ commands:
     steps:
       - run:
           name: Build wheel
-          command: make wheel
-      - run:
-          # The wheel building can be flaky due to lib download issues
-          name: Build wheel (2)
-          command: make wheel
-          when: on_fail
-      - run:
-          name: Build wheel (3)
-          command: make wheel
-          when: on_fail
-      - run:
-          name: Build wheel (4)
-          command: make wheel
-          when: on_fail
+          command: |
+            PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.circleci/"
+            retry 5 make wheel
       - run:
           name: Test pip install
           command: bazel run //sematic/tests/integration:test_pip_install

--- a/.circleci/retry
+++ b/.circleci/retry
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Script source: https://stackoverflow.com/questions/7449772/how-to-retry-a-command-in-bash
+ 
+# Retries a command on failure.
+# $1 - the max number of attempts
+# $2... - the command to run
+
+retry() {
+    local -r -i max_attempts="$1"; shift
+    local -i attempt_num=1
+    until "$@"
+    do
+        if ((attempt_num==max_attempts))
+        then
+            echo "Attempt $attempt_num failed and there are no more attempts left!"
+            return 1
+        else
+            echo "Attempt $attempt_num failed! Trying again in $attempt_num seconds..."
+            sleep $((attempt_num++))
+        fi
+    done
+}

--- a/.circleci/retry
+++ b/.circleci/retry
@@ -20,3 +20,5 @@ retry() {
         fi
     done
 }
+
+retry "$@"


### PR DESCRIPTION
It turns out [these docs](https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-) from Circle only tell you how to ensure a step gets tried again, but will NOT stop the overall job from failing. So this PR switches us to use a bash script to do retries.