### PR TITLE
Redact full DB URL from migration logs

### DIFF
--- a/sematic/config/config.py
+++ b/sematic/config/config.py
@@ -179,6 +179,10 @@ class Config:
     def __str__(self) -> str:
         return repr(self)
 
+    @property
+    def redacted_db_url(self):
+        return self._scrub_db_password(self.db_url)
+
     def _scrub_db_password(self, text: str) -> str:
         db_password = _get_db_password(self.db_url)
         if db_password is None:

--- a/sematic/db/migrate.py
+++ b/sematic/db/migrate.py
@@ -214,7 +214,7 @@ def migrate_up():
     """
     Migrate the DB to the latest version.
     """
-    logging.info("Running migrations on {}".format(get_config().db_url))
+    logging.info("Running migrations on {}".format(get_config().redacted_db_url))
 
     versions = _get_current_versions()
 


### PR DESCRIPTION
Closes #934

Removes the DB password from the DB URL logged to the migration logs.

Testing
-------

Deployed with helm and looked at the logs from the migration pod. Got:

```
INFO:root:Running migrations on postgresql://josh:<REDACTED>@dev-usw2-sematic0.cjwke8fboxes.us-west-2.rds.amazonaws.com:5432/josh
INFO:root:Already applied 20220424062956_create_runs_table.sql
INFO:root:Already applied 20220514015440_create_artifacts_table.sql
...
```

Note that the logs actually contain the string `<REDACTED>` in the location shown above, that's not a post-hoc modification.