### PR TITLE
Fix Slack generated URL

### DIFF
--- a/sematic/plugins/publishing/slack.py
+++ b/sematic/plugins/publishing/slack.py
@@ -31,9 +31,7 @@ _SLACK_URL_TEMPLATE = "https://hooks.slack.com/services/{webhook_token}"
 # TODO: implement server-side dedicated components that build urls that point to specific
 #  resources - e.g. have resolutions.py build this url for us
 # currently, this needs to be updated here whenever the endpoints change
-_RESOLUTION_URL_TEMPLATE = (
-    "{external_url}/pipelines/{pipeline_import_path}/{resolution_id}#tab=logs"
-)
+_RESOLUTION_URL_TEMPLATE = "{external_url}/runs/{resolution_id}#tab=logs"
 _MESSAGE_TEMPLATE = (
     ":red_circle: {resolution_name} run "
     "<{resolution_url}|{short_resolution_id}> has failed."
@@ -90,7 +88,6 @@ class SlackPublisher(AbstractPublisher, AbstractPlugin):
         #  redirect to the full url path
         resolution_url = _RESOLUTION_URL_TEMPLATE.format(
             external_url=external_url,
-            pipeline_import_path=root_run.function_path,
             resolution_id=resolution.root_id,
         )
 

--- a/sematic/plugins/publishing/tests/test_slack.py
+++ b/sematic/plugins/publishing/tests/test_slack.py
@@ -53,7 +53,7 @@ def test_publish_happy(
 
     expected_message = (
         f":red_circle: test_run run "
-        f"<https://my.sematic/pipelines/path.to.test_run/{id}#tab=logs|{id[0:6]}> "
+        f"<https://my.sematic/runs/{id}#tab=logs|{id[0:6]}> "
         f"has failed."
     )
 


### PR DESCRIPTION
We changed the formatting of URL links to runs, but never updated the slack plugin to account for that. This PR does that.

Testing
-------

Launched a run on dev1 that I intentionally failed, confirmed that the new link posted in slack took me to the relevant run.