### PR TITLE
Add promotion banner to switch to new dashboard in old UI

### DIFF
--- a/sematic/ui/packages/common/src/utils/FeatureFlagManager.ts
+++ b/sematic/ui/packages/common/src/utils/FeatureFlagManager.ts
@@ -1,4 +1,5 @@
 import memoize from "lodash/memoize";
+import { atomWithStorage } from "jotai/utils";
 
 function convertBooleanLikeValue(value: any) {
     if (value === "true" || value === "1") {
@@ -10,13 +11,15 @@ function convertBooleanLikeValue(value: any) {
     }
 }
 
+const fullyQualifiedFeatureFlagKey = (key: string) => `sematic-feature-flag-${key}`;
+
 export const getFeatureFlagValue = memoize(function getFeatureFlagValue(featureName: string) {
     const search = window.location.search;
 
     const strValue = (new URLSearchParams(search)).get(featureName)?.toLocaleLowerCase();
     const featureFlagUrlValue = convertBooleanLikeValue(strValue);
 
-    const localStorageName = `sematic-feature-flag-${featureName}`;
+    const localStorageName = fullyQualifiedFeatureFlagKey(featureName);
 
     const localStorageValue = window.localStorage.getItem(localStorageName);
 
@@ -34,3 +37,7 @@ export const getFeatureFlagValue = memoize(function getFeatureFlagValue(featureN
     }
     return undefined;
 });
+
+export const NewDashBoardPromotionOptoutAtom = atomWithStorage(
+    fullyQualifiedFeatureFlagKey("new-dashboard-promotion-optout"), 
+    getFeatureFlagValue("new-dashboard-promotion-optout") ?? false);

--- a/sematic/ui/packages/main/src/Home.tsx
+++ b/sematic/ui/packages/main/src/Home.tsx
@@ -66,7 +66,7 @@ export default function Home() {
     const h1 = user ? "Hi " + user.first_name : "Welcome to Sematic";
 
     return (
-        <Container sx={{ pt: 10, height: "100vh" }}>
+        <Container sx={{ pt: 10, height: "100%" }}>
             <Typography variant="h1">{h1}</Typography>
             <Box sx={{ mt: 15, mb: 10, minHeight: "1px" }}>
                 {!!error && (

--- a/sematic/ui/packages/main/src/components/PromotionBanner.tsx
+++ b/sematic/ui/packages/main/src/components/PromotionBanner.tsx
@@ -1,0 +1,53 @@
+import { css } from "@emotion/css";
+import CloseIcon from "@mui/icons-material/Close";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
+import { theme } from "@sematic/common/src/theme/mira";
+import { useCallback } from "react";
+
+const bannerStyle = css`
+    background-color: rgb(229, 246, 253);
+    padding: ${theme.spacing(2)};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 30px;
+    box-sizing: border-box;
+    flex-grow: 0;
+    flex-shrink: 0;
+
+`;
+
+const messageStyle = css`
+    margin-right: ${theme.spacing(2)}!important;
+    font-size: 16px!important;
+`;
+
+interface PromotionBannerProps {
+    onClose: () => void;
+}
+
+const PromotionBanner = (props: PromotionBannerProps) => {
+    const { onClose } = props;
+
+    const switchToNewUI = useCallback(() => {
+        window.localStorage.setItem("sematic-feature-flag-newui", "true");
+        window.location.reload();
+    }, []);
+
+    return (
+        <div className={bannerStyle}>
+            <Typography variant="body1" className={messageStyle}>
+                <Link style={{ cursor: "pointer" }} onClick={switchToNewUI}>
+                    Try our new dashboard UI!
+                </Link>
+            </Typography>
+            <IconButton size="small" aria-label="close" onClick={onClose} >
+                <CloseIcon fontSize="small" />
+            </IconButton>
+        </div>
+    );
+};
+
+export default PromotionBanner;

--- a/sematic/ui/packages/main/src/components/Shell.tsx
+++ b/sematic/ui/packages/main/src/components/Shell.tsx
@@ -3,13 +3,22 @@ import { ThemeProvider } from "@mui/material/styles";
 import UserContext from "@sematic/common/src/context/UserContext";
 import { useAppContext } from "@sematic/common/src/hooks/appHooks";
 import createTheme from "@sematic/common/src/theme/mira";
-import { useContext } from "react";
+import { NewDashBoardPromotionOptoutAtom } from "@sematic/common/src/utils/FeatureFlagManager";
+import { useAtom } from "jotai";
+import { useCallback, useContext } from "react";
 import { Navigate, Outlet } from "react-router-dom";
+import PromotionBanner from "src/components/PromotionBanner";
 import SideBar from "./SideBar";
 
 export default function Shell() {
     const { authenticationEnabled } = useAppContext()
     const { user } = useContext(UserContext);
+
+    const [newDashBoardPromotionOptout, setNewDashBoardPromotionOptout] = useAtom(NewDashBoardPromotionOptoutAtom);
+
+    const onCloseBanner = useCallback(() => {
+        setNewDashBoardPromotionOptout(true);
+    }, [setNewDashBoardPromotionOptout]);
 
     if (authenticationEnabled && !user) {
         return <Navigate to="/login" />;
@@ -17,21 +26,26 @@ export default function Shell() {
 
     return (
         <ThemeProvider theme={createTheme("LIGHT")}>
-            <Box
-                sx={{
-                    height: "100vh",
-                    display: "grid",
-                    gridTemplateColumns: "60px auto",
-                    gridTemplateRows: "1fr",
-                }}
-            >
-                <Box sx={{ gridColumn: 1, gridRow: 1 }}>
-                    <SideBar />
+            <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+                {!newDashBoardPromotionOptout && <PromotionBanner onClose={onCloseBanner} />}
+                <Box
+                    sx={{
+                        display: "grid",
+                        gridTemplateColumns: "60px auto",
+                        gridTemplateRows: "1fr",
+                        flexGrow: 1,
+                        flexShrink: 1,
+                    }}
+                >
+                    <Box sx={{ gridColumn: 1, gridRow: 1 }}>
+                        <SideBar />
+                    </Box>
+                    <Box sx={{ gridColumn: 2, overflowY: "scroll" }}>
+                        <Outlet />
+                    </Box>
                 </Box>
-                <Box sx={{ gridColumn: 2, overflowY: "scroll" }}>
-                    <Outlet />
-                </Box>
-            </Box>
+            </div>
+
         </ThemeProvider>
     );
 }

--- a/sematic/ui/packages/main/src/components/SideBar.tsx
+++ b/sematic/ui/packages/main/src/components/SideBar.tsx
@@ -32,7 +32,7 @@ export default function SideBar() {
                 backgroundColor: theme.palette.grey[800],
                 color: "rgba(255, 255, 255, 0.5)",
                 textAlign: "center",
-                height: "100vh",
+                height: "100%",
             }}
         >
             <Stack sx={{ gridRow: 1, spacing: 2, paddingTop: 3 }}>

--- a/sematic/ui/packages/main/src/pipelines/PipelineRunView.tsx
+++ b/sematic/ui/packages/main/src/pipelines/PipelineRunView.tsx
@@ -35,7 +35,7 @@ export function RunViewPresentation({
                     display: "grid",
                     gridTemplateColumns: "250px 1fr 350px",
                     gridTemplateRows: "70px 1fr",
-                    height: "100vh",
+                    height: "100%",
                 }}
             >
                 <PipelineBar />


### PR DESCRIPTION
Display a promotional banner in the old UI to encourage usage of the new dashboard.

Clicking the X button will opt out of seeing the banner. 

Preview:

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/bc6d6035-99bf-4385-9974-7c3031380cd1)
