### PR TITLE
Display cloned state icon for cloned runs

### DIFF
--- a/sematic/ui/packages/common/src/component/RunStateText.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateText.tsx
@@ -1,17 +1,37 @@
 import { parseJSON } from "date-fns";
+import { ReactNode } from "react";
 import { DurationShort } from "src/component/DateTime";
+import { RunReferenceLink } from "src/component/RunReference";
+import styled from "@emotion/styled";
+import theme from "src/theme/new";
+
+const StyledRunReferenceLink = styled(RunReferenceLink)`
+    color: ${theme.palette.lightGrey.main};
+`;
+
 
 export enum DateFormats {
     SHORT,
     LONG,
 }
 
-export function getRunStateText(futureState: string,
+interface GetRunStateTextOptions {
+    short?: boolean;
+}
+
+export function getRunStateText(futureState: string, originalRunId: string | null,
     timestamps: {
         createdAt: string, resolvedAt?: string, failedAt?: string, endedAt?: string
-    }, dateFormat: DateFormats = DateFormats.SHORT) {
+    }, options: GetRunStateTextOptions = {}): ReactNode {
     const { createdAt, resolvedAt, failedAt, endedAt } = timestamps;
+    const { short = false } = options;
 
+    if (originalRunId) {
+        return short ? "Cached" : <>
+            {"Cached from"}
+            <StyledRunReferenceLink runId={originalRunId} variant="code" />
+        </>;
+    }
 
     if (["RESOLVED", "SUCCEEDED"].includes(futureState)) {
         if (!resolvedAt) {

--- a/sematic/ui/packages/common/src/component/RunTree.tsx
+++ b/sematic/ui/packages/common/src/component/RunTree.tsx
@@ -5,7 +5,7 @@ import ListItemButton, { listItemButtonClasses } from "@mui/material/ListItemBut
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import { Fragment } from "react";
-import { getRunStateChipByState } from "src/component/RunStateChips";
+import RunStateChip from "src/component/RunStateChips";
 import { RunTreeNode } from "src/interfaces/graph";
 import theme from "src/theme/new";
 import range from "lodash/range";
@@ -45,7 +45,8 @@ const RunTree = (props: RunTreeProps) => {
                 <ListItemButton className={selectedRunId === run.id ? "selected" : ""}
                     onClick={() => onSelect?.(run.id)}>
                     <ListItemIcon sx={{ minWidth: "20px" }}>
-                        {getRunStateChipByState(run.future_state, "small")}
+                        <RunStateChip futureState={run.future_state} 
+                            orignalRunId={run.original_run_id} size={"small"} />
                     </ListItemIcon>
                     <ListItemText >{run.name}</ListItemText>
                 </ListItemButton>

--- a/sematic/ui/packages/common/src/component/RunsDropdown.tsx
+++ b/sematic/ui/packages/common/src/component/RunsDropdown.tsx
@@ -9,7 +9,7 @@ import isEmpty from "lodash/isEmpty";
 import keyBy from "lodash/keyBy";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Run } from "src/Models";
-import { getRunStateChipByState } from "src/component/RunStateChips";
+import RunStateChip from "src/component/RunStateChips";
 import TimeAgo from "src/component/TimeAgo";
 import theme from "src/theme/new";
 
@@ -48,7 +48,8 @@ interface ValuePresentationProps {
 }
 const ValuePresentation = (props: ValuePresentationProps) => {
     const { run } = props;
-    const stateChip = useMemo(() => getRunStateChipByState(run.future_state, "large"), [run.future_state]);
+    const stateChip = useMemo(() => <RunStateChip futureState={run.future_state} 
+        orignalRunId={run.original_run_id} size={"large"} />, [run.future_state, run.original_run_id]);
     return <StyledBox {...props}>
         {stateChip}
         <Typography variant="code">{run.id.substring(0, 7)}</Typography>

--- a/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/PipelineList/LatestRunsColumn.tsx
@@ -4,7 +4,7 @@ import { TableMeta } from "@tanstack/react-table";
 import { useEffect, useMemo } from "react";
 import { Run } from "src/Models";
 import MuiRouterLink from "src/component/MuiRouterLink";
-import { getRunStateChipByState } from "src/component/RunStateChips";
+import RunStateChip from "src/component/RunStateChips";
 import { getRunUrlPattern, useFetchRuns } from "src/hooks/runHooks";
 import { ExtendedRunMetadata } from "src/pages/PipelineList/common";
 
@@ -21,7 +21,8 @@ const StyledChipContainer = styled.span`
 function StatusChips({ runs }: { runs: Run[] }) {
     return <>{runs.map((run, index) => <MuiRouterLink key={index} href={getRunUrlPattern(run.id)}>
         <StyledChipContainer key={`${run.id}---${run.future_state}`}>
-            {getRunStateChipByState(run.future_state)}
+            <RunStateChip futureState={run.future_state} 
+                orignalRunId={run.original_run_id} size={"large"} />
         </StyledChipContainer></MuiRouterLink>)}
     </>;
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -2,15 +2,15 @@ import styled from "@emotion/styled";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import parseJSON from "date-fns/parseJSON";
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DateTimeLong } from "src/component/DateTime";
 import Headline from "src/component/Headline";
 import ImportPath from "src/component/ImportPath";
 import MoreVertButton from "src/component/MoreVertButton";
 import PipelineTitle from "src/component/PipelineTitle";
 import { RunReferenceLink } from "src/component/RunReference";
-import { getRunStateChipByState } from "src/component/RunStateChips";
-import getRunStateText, { DateFormats } from "src/component/RunStateText";
+import RunStateChip from "src/component/RunStateChips";
+import getRunStateText from "src/component/RunStateText";
 import Section from "src/component/Section";
 import TagsList from "src/component/TagsList";
 import { useRootRunContext } from "src/context/RootRunContext";
@@ -112,11 +112,13 @@ const FunctionSection = () => {
             return null;
         }
 
-        const runDuration = getRunStateText(selectedRun.future_state, {
-            createdAt: selectedRun.created_at as unknown as string,
-            failedAt: selectedRun.failed_at as unknown as string,
-            resolvedAt: selectedRun.resolved_at as unknown as string
-        }, DateFormats.LONG);
+        const runDuration = getRunStateText(
+            selectedRun.future_state, 
+            selectedRun.original_run_id, {
+                createdAt: selectedRun.created_at as unknown as string,
+                failedAt: selectedRun.failed_at as unknown as string,
+                resolvedAt: selectedRun.resolved_at as unknown as string
+            });
 
         if (!(selectedRun.resolved_at || selectedRun.failed_at|| selectedRun.ended_at)){
             return runDuration;
@@ -140,7 +142,8 @@ const FunctionSection = () => {
         <Headline>Function Run</Headline>
         <BoxContainer>
             <RunStateContainer>
-                {!isGraphLoaded ? <SmallPlaceholderSkeleton /> : getRunStateChipByState(selectedRun!.future_state)}
+                {!isGraphLoaded ? <SmallPlaceholderSkeleton /> : 
+                    <RunStateChip futureState={selectedRun!.future_state}  orignalRunId={selectedRun!.original_run_id} />}
             </RunStateContainer>
             <div className='Info'>
                 <FunctionName>

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
@@ -4,7 +4,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import IconButton from "@mui/material/IconButton";
 import { useCallback, useContext, useMemo } from "react";
 import { NodeProps, Position } from "reactflow";
-import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
+import RunStateChip, { getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming, useNodeExpandStateToggle } from "src/hooks/dagHooks";
 import { DagViewServiceContext, StyledHandleBottom, StyledHandleTop } from "src/pages/RunDetails/dag/common";
 import theme from "src/theme/new";
@@ -65,8 +65,8 @@ function CompoundNode(props: NodeProps) {
 
     const hasIncoming = useHasIncoming();
 
-    const stateChip = useMemo(() => getRunStateChipByState(run.future_state), [run.future_state]);
-    const color = useMemo(() => getRunStateColorByState(run.future_state), [run.future_state]);
+    const color = useMemo(() => getRunStateColorByState(run.future_state, run.original_run_id), 
+        [run.future_state, run.original_run_id]);
 
     const { onNodeClick } = useContext(DagViewServiceContext)
 
@@ -78,7 +78,7 @@ function CompoundNode(props: NodeProps) {
         style={{ width: `${data.width}px`, height: `${data.height}px` }}>
         {hasIncoming && <StyledHandleTop type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
-            {stateChip}
+            <RunStateChip futureState={run.future_state} orignalRunId={run.original_run_id} />
             <label style={{ flexGrow: 1 }}>{data.label}</label>
             <StyledIconButton onClick={toggleExpanded} >
                 {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { useMemo, useCallback, useContext } from "react";
 import { NodeProps, Position } from "reactflow";
-import { getRunStateChipByState, getRunStateColorByState } from "src/component/RunStateChips";
+import RunStateChip, { getRunStateColorByState } from "src/component/RunStateChips";
 import { useHasIncoming } from "src/hooks/dagHooks";
 import { DagViewServiceContext, LEFT_NODE_MAX_WIDTH, StyledHandleTop, StyledHandleBottom } from "src/pages/RunDetails/dag/common";
 import { SPACING } from "src/pages/RunDetails/dag/dagLayout";
@@ -45,8 +45,8 @@ export const LabelContainer = styled.div`
 function LeafNode(props: NodeProps) {
     const { data } = props;
     const { run, selected } = data;
-    const stateChip = useMemo(() => getRunStateChipByState(run.future_state), [run.future_state]);
-    const color = useMemo(() => getRunStateColorByState(run.future_state), [run.future_state]);
+    const color = useMemo(() => getRunStateColorByState(run.future_state, run.original_run_id), 
+        [run.future_state, run.original_run_id]);
     const hasIncoming = useHasIncoming();
 
     const { onNodeClick } = useContext(DagViewServiceContext)
@@ -61,7 +61,7 @@ function LeafNode(props: NodeProps) {
         {hasIncoming && <StyledHandleTop type="target" position={Position.Top} isConnectable={false}
             id={"t"} color={color} />}
         <LabelContainer>
-            {stateChip}
+            <RunStateChip futureState={run.future_state} orignalRunId={run.original_run_id} />
             <label >{data.label}</label>
         </LabelContainer>
         <StyledHandleBottom

--- a/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
+++ b/sematic/ui/packages/common/src/pages/RunSearch/RunStatusColumn.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { useMemo } from "react";
 import ErrorBoundary from "src/component/ErrorBoundary";
-import { getRunStateChipByState } from "src/component/RunStateChips";
+import RunStateChip from "src/component/RunStateChips";
 import getRunStateText from "src/component/RunStateText";
 import theme from "src/theme/new";
 
@@ -17,6 +17,7 @@ const StyledContainer = styled.div`
 
 interface RunStatusColumnProps {
     futureState: string;
+    originalRunId: string | null;
     createdAt: string;
     failedAt?: string;
     resolvedAt?: string;
@@ -24,16 +25,17 @@ interface RunStatusColumnProps {
 }
 
 const RunStatusColumn = (props: RunStatusColumnProps) => {
-    const { futureState, createdAt, failedAt, resolvedAt, endedAt } = props;
-
-    const runStateChip = useMemo(() => getRunStateChipByState(futureState), [futureState]);
+    const { futureState, originalRunId, createdAt, failedAt, resolvedAt, endedAt } = props;
 
     const runStateText = useMemo(() => getRunStateText(
-        futureState,
-        {createdAt, failedAt, resolvedAt, endedAt}
-    ), [futureState, createdAt, failedAt, resolvedAt, endedAt]);
+        futureState, originalRunId,
+        {createdAt, failedAt, resolvedAt, endedAt},
+        { short: true }
+    ), [futureState, createdAt, failedAt, resolvedAt, endedAt, originalRunId]);
 
-    return <StyledContainer>{runStateChip} {runStateText}</StyledContainer>;
+    return <StyledContainer>
+        <RunStateChip futureState={futureState} orignalRunId={originalRunId} /> {runStateText}
+    </StyledContainer>;
 }
 
 const RunStatusColumnWithErrorBoundary = (props: RunStatusColumnProps) => {

--- a/sematic/ui/packages/common/src/pages/RunTableCommon/columnDefinition.tsx
+++ b/sematic/ui/packages/common/src/pages/RunTableCommon/columnDefinition.tsx
@@ -80,6 +80,7 @@ export const OwnerColumnDef = (columnHelper: ColumnHelper<Run>) =>
 export const StatusColumnDef = (columnHelper: ColumnHelper<Run>) =>
     columnHelper.accessor(data => ({
         futureState: data.future_state,
+        originalRunId: data.original_run_id,
         createdAt: data.created_at,
         failedAt: data.failed_at,
         resolvedAt: data.resolved_at


### PR DESCRIPTION
Snapshots for the new icon for cloned runs:

1. Run details page 
<img width="1179" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/f426b683-db39-4f5a-b25a-ae9ed2f3e78e">


2. Run list:
<img width="861" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/ba015f73-aec0-4bdf-86df-dc7d677ef6bc">


3. Graph:
<img width="1171" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/b5563aec-45de-4859-b4d8-58c020ac8b3e">

