### PR TITLE
Fixes an issue that local deployment cannot switch UI

### DIFF
--- a/sematic/ui/packages/common/src/component/SettingsMenu.tsx
+++ b/sematic/ui/packages/common/src/component/SettingsMenu.tsx
@@ -1,0 +1,115 @@
+import { css } from "@emotion/css";
+import styled from "@emotion/styled";
+import Link from "@mui/material/Link";
+import Popover from "@mui/material/Popover";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TrackingNoticeButton, TrackingNoticeDialogRefType } from "src/component/TrackingNotice";
+import theme from "src/theme/new";
+
+const ANCHOR_OFFSET = { x: 5, y: 0 };
+
+const Container = styled.div`
+    min-width: 300px;
+    border: 1px solid ${theme.palette.p3border.main};
+    border-radius: 0px 0px 3px 3px;
+`;
+
+export const SectionWithBorder = styled.section`
+    padding: ${theme.spacing(5)};
+    border-bottom: 1px solid ${theme.palette.p3border.main};
+`;
+
+const PaperStyleOverride = css`
+    box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.35)!important;
+`;
+
+export function SwitchUICommand() {
+    const switchToOldUI = useCallback(() => {
+        window.localStorage.removeItem("sematic-feature-flag-newui");
+        window.location.reload();
+    }, []);
+
+    return <SectionWithBorder>
+        <Link style={{ cursor: "pointer" }} onClick={switchToOldUI}>
+        Switch to old UI
+        </Link>
+    </SectionWithBorder>
+}
+
+export function PrivacySettingsCommand() {
+    const privacySettingsControl = useRef<TrackingNoticeDialogRefType>(null);
+
+    return <SectionWithBorder>
+        <TrackingNoticeButton ref={privacySettingsControl}>
+            <Link style={{ cursor: "pointer" }} onClick={() => privacySettingsControl.current?.setOpen(true)}>
+            Privacy Settings
+            </Link>
+        </TrackingNoticeButton>
+    </SectionWithBorder>
+};
+
+interface CommonMenuProps {
+    anchorEl: HTMLElement | null;
+    children?: React.ReactNode;
+}
+
+export function CommonMenu(props: CommonMenuProps) {
+    const { anchorEl: anchorElProp, children } = props;
+
+    const [open, setOpen] = useState(false);
+    const [anchorEl, setAnchorElement] = useState<HTMLElement>();
+
+    const buttonClickEvent = useCallback(() => {
+        setOpen((open) => !open);
+    }, [setOpen]);
+
+    const virtualAnchorElement = useMemo(() => ({
+        nodeType: 1,
+        getBoundingClientRect: () => {
+            const rect = anchorEl?.getBoundingClientRect() ?? { x: 0, y: 0 };
+            const newReact = DOMRect.fromRect(rect);
+            newReact.x += ANCHOR_OFFSET.x;
+            newReact.y += ANCHOR_OFFSET.y;
+            return newReact;
+        }
+    }), [anchorEl]);
+
+    useEffect(() => {
+        if (anchorElProp) {
+            setAnchorElement(anchorElProp);
+            anchorElProp.addEventListener("click", buttonClickEvent);
+
+            return () => {
+                anchorElProp.removeEventListener("click", buttonClickEvent);
+            }
+        }
+    }, [anchorElProp, buttonClickEvent]);
+
+    return <Popover
+        anchorEl={virtualAnchorElement as any}
+        open={open}
+        anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "right",
+        }}
+        transformOrigin={{
+            vertical: "top",
+            horizontal: "right",
+        }}
+        onClose={() => setOpen(false)}
+        PaperProps={{ className: PaperStyleOverride }}
+    >
+        <Container>
+            {children}
+        </Container>
+    </Popover >;
+}
+
+function SettingsMenu(props: CommonMenuProps) {
+    return <CommonMenu {...props} >
+        <SwitchUICommand />
+        <PrivacySettingsCommand />
+    </CommonMenu>;
+}
+
+export default SettingsMenu;

--- a/sematic/ui/packages/common/src/component/UserMenu.tsx
+++ b/sematic/ui/packages/common/src/component/UserMenu.tsx
@@ -1,37 +1,17 @@
-import { css } from "@emotion/css";
 import styled from "@emotion/styled";
 import Button from "@mui/material/Button";
-import Popover from "@mui/material/Popover";
 import Typography from "@mui/material/Typography";
-import { useCallback, useContext, useEffect, useMemo, useState, useRef } from "react";
+import { useContext } from "react";
 import NameTag from "src/component/NameTag";
+import { CommonMenu, PrivacySettingsCommand, SectionWithBorder, SwitchUICommand } from "src/component/SettingsMenu";
 import UserContext from "src/context/UserContext";
 import theme from "src/theme/new";
-import Link from "@mui/material/Link";
-import { TrackingNoticeButton, TrackingNoticeDialogRefType } from "src/component/TrackingNotice";
-
-const ANCHOR_OFFSET = { x: 5, y: 0 };
-
-const Container = styled.div`
-    min-width: 300px;
-    border: 1px solid ${theme.palette.p3border.main};
-    border-radius: 0px 0px 3px 3px;
-`;
-
-const SectionWithBorder = styled.section`
-    padding: ${theme.spacing(5)};
-    border-bottom: 1px solid ${theme.palette.p3border.main};
-`;
 
 const StyledNameTag = styled(NameTag)`
     font-size: ${theme.typography.fontSize}px;
     font-weight: ${theme.typography.fontWeightBold};
     margin-bottom: ${theme.spacing(2)};
     display: inline-block;
-`;
-
-const PaperStyleOverride = css`
-    box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.35)!important;
 `;
 
 const StyledButton = styled(Button)`
@@ -44,92 +24,30 @@ const StyledButton = styled(Button)`
     font-weight: ${theme.typography.fontWeightBold};
 `;
 
+
 interface UserMenuProps {
     anchorEl: HTMLElement | null;
 }
 
 function UserMenu(props: UserMenuProps) {
-    const { anchorEl: anchorElProp } = props;
-
-    const [open, setOpen] = useState(false);
-    const [anchorEl, setAnchorElement] = useState<HTMLElement>();
-
-    const privacySettingsControl = useRef<TrackingNoticeDialogRefType>(null);
-
     const { user, signOut } = useContext(UserContext);
 
-    const buttonClickEvent = useCallback(() => {
-        setOpen((open) => !open);
-    }, [setOpen]);
-
-    const switchToOldUI = useCallback(() => {
-        window.localStorage.removeItem("sematic-feature-flag-newui");
-        window.location.reload();
-    }, []);
-
-    const virtualAnchorElement = useMemo(() => ({
-        nodeType: 1,
-        getBoundingClientRect: () => {
-            const rect = anchorEl?.getBoundingClientRect() ?? { x: 0, y: 0 };
-            const newReact = DOMRect.fromRect(rect);
-            newReact.x += ANCHOR_OFFSET.x;
-            newReact.y += ANCHOR_OFFSET.y;
-            return newReact;
-        }
-    }), [anchorEl]);
-
-    useEffect(() => {
-        if (anchorElProp && user) {
-            setAnchorElement(anchorElProp);
-            anchorElProp.addEventListener("click", buttonClickEvent);
-
-            return () => {
-                anchorElProp.removeEventListener("click", buttonClickEvent);
-            }
-        }
-    }, [anchorElProp, user, buttonClickEvent]);
-
-    return <Popover
-        anchorEl={virtualAnchorElement as any}
-        open={open}
-        anchorOrigin={{
-            vertical: "bottom",
-            horizontal: "right",
-        }}
-        transformOrigin={{
-            vertical: "top",
-            horizontal: "right",
-        }}
-        onClose={() => setOpen(false)}
-        PaperProps={{ className: PaperStyleOverride }}
-    >
-        <Container>
-            <SectionWithBorder>
-                <StyledNameTag firstName={user?.first_name} lastName={user?.last_name} variant={"inherit"} />
-                <Typography color="GrayText">
+    return <CommonMenu {...props}>
+        <SectionWithBorder>
+            <StyledNameTag firstName={user?.first_name} lastName={user?.last_name} variant={"inherit"} />
+            <Typography color="GrayText">
                     API key: <code>{user?.api_key}</code>
-                </Typography>
-            </SectionWithBorder>
-            <SectionWithBorder>
-                <Link style={{ cursor: "pointer" }} onClick={switchToOldUI}>
-                    Switch to old UI
-                </Link>
-            </SectionWithBorder>
-            <SectionWithBorder>
-                <TrackingNoticeButton ref={privacySettingsControl}>
-                    <Link style={{ cursor: "pointer" }} onClick={() => privacySettingsControl.current?.setOpen(true)}>
-                        Privacy Settings
-                    </Link>
-                </TrackingNoticeButton>
-            </SectionWithBorder>
-            {/* Hide for now, will re-enable when we have organization support */}
-            {/* <SectionWithBorder>
+            </Typography>
+        </SectionWithBorder>
+        <SwitchUICommand />
+        <PrivacySettingsCommand />
+        {/* Hide for now, will re-enable when we have organization support */}
+        {/* <SectionWithBorder>
                 <Headline>Organization</Headline>
                 <Typography variant={"bold"}>Unset</Typography>
             </SectionWithBorder> */}
-            <StyledButton onClick={signOut!}>Sign out</StyledButton>
-        </Container>
-    </Popover >;
+        <StyledButton onClick={signOut!}>Sign out</StyledButton>
+    </CommonMenu >;
 }
 
 export default UserMenu;

--- a/sematic/ui/packages/common/src/component/menu.tsx
+++ b/sematic/ui/packages/common/src/component/menu.tsx
@@ -4,7 +4,7 @@ import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
 import { SimplePaletteColorOptions } from "@mui/material/styles";
 import useTheme from "@mui/material/styles/useTheme";
-import { useContext, useRef, useEffect } from "react";
+import { useContext, useRef, useEffect, useMemo } from "react";
 import MuiRouterLink from "src/component/MuiRouterLink";
 import NameTag from "src/component/NameTag";
 import UserMenu from "src/component/UserMenu";
@@ -16,6 +16,7 @@ import useCounter from "react-use/lib/useCounter";
 import UserAvatar from "src/component/UserAvatar";
 import { getUserInitials } from "src/utils/string";
 import theme from "src/theme/new";
+import SettingsMenu from "src/component/SettingsMenu";
 
 const StyledGridContainer = styled(Grid)`
     border-bottom: 1px solid ${() => (palette.p3border as SimplePaletteColorOptions).main};
@@ -49,6 +50,27 @@ const HeaderMenu = (props: HeaderMenuProps) => {
 
     const latestAnchor = useLatest(contextMenuAnchor.current);
 
+    const profileMenuLabel = useMemo(() => {
+        if (!user) {
+            return "Settings";
+        }
+
+        return <>
+            <UserAvatar initials={getUserInitials(user?.first_name, user?.last_name, user?.email)} 
+                hoverText={user?.first_name || user?.email} avatarUrl={user?.avatar_url} size={"medium"}/>
+            <NameTag firstName={user?.first_name} lastName={undefined} variant={"inherit"} />
+        </>
+    }, [user]);
+
+    const profileMenu = useMemo(() => {
+        if (!user) {
+            return <SettingsMenu anchorEl={contextMenuAnchor.current} />;
+        }
+
+        return <UserMenu anchorEl={contextMenuAnchor.current} />
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [user, renderTimes]);
+
     useEffect(() => {
         // re-render until the context menu anchor is set
         if (latestAnchor.current === null) {
@@ -80,11 +102,9 @@ const HeaderMenu = (props: HeaderMenuProps) => {
             <MuiRouterLink href={"https://docs.sematic.dev"} variant="subtitle1" type='menu'>Docs</MuiRouterLink>
             <MuiRouterLink href={"https://discord.gg/4KZJ6kYVax"} variant="subtitle1" type='menu'>Discord</MuiRouterLink>
             <StyledLink variant="subtitle1" type='menu' ref={contextMenuAnchor}>
-                {!!user && <UserAvatar initials={getUserInitials(user?.first_name, user?.last_name, user?.email)} 
-                    hoverText={user?.first_name || user?.email} avatarUrl={user?.avatar_url} size={"medium"}/>}
-                <NameTag firstName={user?.first_name} lastName={undefined} variant={"inherit"} />
+                {profileMenuLabel}
             </StyledLink>
-            <UserMenu anchorEl={contextMenuAnchor.current} />
+            { profileMenu }
         </Box>
     </StyledGridContainer>;
 };

--- a/sematic/ui/packages/main/src/components/SideBar.tsx
+++ b/sematic/ui/packages/main/src/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import { Logout, PlayCircle, Timeline } from "@mui/icons-material";
+import { Logout, PlayCircle, Timeline, NewReleases } from "@mui/icons-material";
 import {
     Box,
     ButtonBase,
@@ -15,10 +15,15 @@ import Link from "@mui/material/Link";
 import { useTheme } from "@mui/material/styles";
 import MuiRouterLink from "@sematic/common/src/component/MuiRouterLink";
 import UserContext from "@sematic/common/src/context/UserContext";
-import { useCallback, useContext, useState } from "react";
+import { useContext, useState } from "react";
 import { SiDiscord, SiReadthedocs } from "react-icons/si";
 import logo from "../Fox.png";
 import UserAvatar from "./UserAvatar";
+
+const switchToNewUI = () => {
+    window.localStorage.setItem("sematic-feature-flag-newui", "true");
+    window.location.reload();
+};
 
 export default function SideBar() {
     const theme = useTheme();
@@ -112,11 +117,6 @@ function UserMenu() {
         setAnchorEl(null);
     };
     
-    const switchToNewUI = useCallback(() => {
-        window.localStorage.setItem("sematic-feature-flag-newui", "true");
-        window.location.reload();
-    }, []);
-
     return user && signOut ? (
         <>
             <Box>
@@ -189,6 +189,14 @@ function UserMenu() {
             </Menu>
         </>
     ) : (
-        <></>
+        <>
+            <Box sx={{display: "flex", marginTop: "0!important", justifyContent: "center"}}>
+                <IconButton onClick={switchToNewUI} sx={{ color: "rgba(255, 255, 255, 0.5)", 
+                    display: "flex", flexDirection: "column" }}>
+                    <NewReleases />
+                    <Typography fontSize={10}>new UI</Typography>
+                </IconButton>
+            </Box>
+        </>
     );
 }


### PR DESCRIPTION
1. For local deployment, which does not have authentication enabled, instead of showing the user profile menu, show a "Settings" menu instead.
2. The settings menu has a minimized command list that only supports "switch UI" + "Privacy settings" menu items. Because "user API key" and "Sign out" isn't applicable for user-less deployments.
3. Also added a placeholder entry point on the old UI to switch to the new UI, instead of relying on the user profile menu to switch to the new UI because the user profile menu does not display for the local deployment without authentication enabled.  
4. The experience for deployments with authentication doesn't change.


Preview:
![capture1](https://github.com/sematic-ai/sematic/assets/133257643/bc88f330-2d25-4458-9027-47d3bc737929)

Closes #985 
Closes #986 
