### PR TITLE
Fix DB migration script for PostgreSQL

### DIFF
--- a/sematic/db/migrations/20230712121255_add_organizations_associations.py
+++ b/sematic/db/migrations/20230712121255_add_organizations_associations.py
@@ -206,10 +206,10 @@ def up_postgres():
     with db().get_engine().begin() as conn:
         conn.execute(
             """
-            ALTER TABLE resolutions ADD COLUMN organization_id REFERENCES organizations(id);
-            ALTER TABLE runs ADD COLUMN organization_id REFERENCES organizations(id);
-            ALTER TABLE metric_labels ADD COLUMN organization_id REFERENCES organizations(id);
-            ALTER TABLE artifacts ADD COLUMN organization_id REFERENCES organizations(id);
+            ALTER TABLE resolutions ADD COLUMN organization_id character(32) REFERENCES organizations(id);
+            ALTER TABLE runs ADD COLUMN organization_id character(32) REFERENCES organizations(id);
+            ALTER TABLE metric_labels ADD COLUMN organization_id character(32) REFERENCES organizations(id);
+            ALTER TABLE artifacts ADD COLUMN organization_id character(32) REFERENCES organizations(id);
             """
         )
 


### PR DESCRIPTION
A DB migration script has incorrect syntax for PostgreSQL.
