### PR TITLE
Avoid Docker Build name collision with public repos

### DIFF
--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -445,7 +445,6 @@ def _build_from_dockerfile(
                 path=os.getcwd(),
                 tag=built_image_name,
                 decode=True,
-                pull=True,
                 **optional_kwargs,
             )
 


### PR DESCRIPTION
Fixes #995.

If the local name chosen when producing an image collides with a public Dockerhub repo, then building the image will result in an error:

```bash
$ sematic run --log-level debug --build advanced/main.py -- /advanced/data/message.txt
[...]
2023-07-14 04:54:10,978  [INFO] sematic.plugins.building.docker_builder: Building image 'advanced:default_example_docker_advanced' starting from base: example_docker:default_advanced
Step 1/8 : FROM example_docker:default_advanced
2023-07-14 04:54:21,929  [ERROR] sematic.plugins.building.docker_builder: Image build error details: '{'message': "pull access denied for example_docker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}'
Traceback (most recent call last):
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/bin/sematic", line 8, in <module>
    sys.exit(cli())
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/sematic/cli/run.py", line 115, in run
    builder.build_and_launch(target=script_path, run_command=run_command)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/sematic/plugins/building/docker_builder.py", line 163, in build_and_launch
    image_uri, build_config = _build(target=target)
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/sematic/plugins/building/docker_builder.py", line 185, in _build
    image, image_uri = _build_image(
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/sematic/plugins/building/docker_builder.py", line 303, in _build_image
    return _build_image_from_base(
  File "/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/lib/python3.8/site-packages/sematic/plugins/building/docker_builder.py", line 408, in _build_image_from_base
    raise BuildError(
sematic.plugins.abstract_builder.BuildError: Unable to build image 'advanced:default_example_docker_advanced': pull access denied for example_docker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

The fix is to avoid pulling from upstream when building the image locally, which had been put in place to refresh the image before building. This way pulling from an incorrect remote repo is avoided.

Refreshing the image is still done in a dedicated previous step which logs, but ignores errors.
