### PR TITLE
Docker Build provide no-cache option

### DIFF
--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -117,7 +117,7 @@ Options:
                         the pipeline, using the configured build plugin.
                         Defaults to `False`. If not set, the pipeline will be
                         run locally in the current environment.
-  -c, --clean           When `--build` is specified, builds the image from
+  -n, --no_cache        When `--build` is specified, builds the image from
                         scratch, ignoring previous versions. Defaults to
                         `False`.
   -l, --log-level TEXT  The log level to use for building and launching the
@@ -153,10 +153,10 @@ makes sense in this context.
 Building the image uses layer caching for temporal and spatial optimization. If
 you find that you have an image with stale layers that, for example, have an
 older version of a library installed, then you can deactivate the caching and
-force a complete rebuild of the image by passing the `--clean` flag:
+force a complete rebuild of the image by passing the `--no_cache` flag:
 
 ```bash
-$ sematic run --build --clean path/to/my/hello_world.py
+$ sematic run --build --no_cache path/to/my/hello_world.py
 ```
 
 {% hint style="warning" %}

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -117,6 +117,9 @@ Options:
                         the pipeline, using the configured build plugin.
                         Defaults to `False`. If not set, the pipeline will be
                         run locally in the current environment.
+  -c, --clean           When `--build` is specified, builds the image from
+                        scratch, ignoring previous versions. Defaults to
+                        `False`.
   -l, --log-level TEXT  The log level to use for building and launching the
                         pipeline. Defaults to `INFO`.
   --help                Show this message and exit.
@@ -146,6 +149,15 @@ Omitting the `--build` flag results in skipping the entire build process, with
 the entire pipeline being executed locally. Only using
 [LocalRunner or SilentRunner](https://docs.sematic.dev/diving-deeper/concepts#runners)
 makes sense in this context.
+
+Building the image uses layer caching for temporal and spatial optimization. If
+you find that you have an image with stale layers that, for example, have an
+older version of a library installed, then you can deactivate the caching and
+force a complete rebuild of the image by passing the `--clean` flag:
+
+```bash
+$ sematic run --build --clean path/to/my/hello_world.py
+```
 
 {% hint style="warning" %}
 The launch script is executed locally, using the local Python installation.

--- a/sematic/cli/run.py
+++ b/sematic/cli/run.py
@@ -69,6 +69,16 @@ def _run_example(example_path: str):
     is_flag=True,
 )
 @click.option(
+    "-c",
+    "--clean",
+    help=(
+        "When `--build` is specified, builds the image from scratch, "
+        "ignoring previous versions. Defaults to `False`."
+    ),
+    default=False,
+    is_flag=True,
+)
+@click.option(
     "-l",
     "--log-level",
     help=(
@@ -79,7 +89,17 @@ def _run_example(example_path: str):
 )
 @click.argument("script_path", type=click.STRING)
 @click.argument("script_arguments", nargs=-1, type=click.STRING)
-def run(build: bool, log_level: str, script_path: str, script_arguments: Tuple[str]):
+def run(
+    build: bool,
+    clean: bool,
+    log_level: str,
+    script_path: str,
+    script_arguments: Tuple[str],
+):
+    # custom option validation
+    if clean and not build:
+        click.echo("Can only pass `--clean` together with `--build`.")
+        sys.exit(1)
 
     # ensure the client is pointing to the intended server
     switch_env("user")
@@ -108,7 +128,7 @@ def run(build: bool, log_level: str, script_path: str, script_arguments: Tuple[s
         return
 
     builder_class = get_builder_plugin(default=DockerBuilder)
-    builder = builder_class()
+    builder = builder_class(clean=clean)
 
     click.echo(f"Building image and launching: {pseudo_command}")
     start_time = time.time()

--- a/sematic/cli/run.py
+++ b/sematic/cli/run.py
@@ -69,8 +69,8 @@ def _run_example(example_path: str):
     is_flag=True,
 )
 @click.option(
-    "-c",
-    "--clean",
+    "-n",
+    "--no-cache",
     help=(
         "When `--build` is specified, builds the image from scratch, "
         "ignoring previous versions. Defaults to `False`."
@@ -91,14 +91,14 @@ def _run_example(example_path: str):
 @click.argument("script_arguments", nargs=-1, type=click.STRING)
 def run(
     build: bool,
-    clean: bool,
+    no_cache: bool,
     log_level: str,
     script_path: str,
     script_arguments: Tuple[str],
 ):
     # custom option validation
-    if clean and not build:
-        click.echo("Can only pass `--clean` together with `--build`.")
+    if no_cache and not build:
+        click.echo("Can only pass `--no-cache` together with `--build`.")
         sys.exit(1)
 
     # ensure the client is pointing to the intended server
@@ -128,7 +128,7 @@ def run(
         return
 
     builder_class = get_builder_plugin(default=DockerBuilder)
-    builder = builder_class(clean=clean)
+    builder = builder_class(no_cache=no_cache)
 
     click.echo(f"Building image and launching: {pseudo_command}")
     start_time = time.time()

--- a/sematic/plugins/abstract_builder.py
+++ b/sematic/plugins/abstract_builder.py
@@ -36,6 +36,9 @@ class AbstractBuilder(AbstractPlugin):
     Abstract base class to represent a container image builder and launcher.
     """
 
+    def __init__(self, **_):
+        super().__init__()
+
     @abc.abstractmethod
     def build_and_launch(self, target: str, run_command: Optional[str]) -> None:
         """

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -445,7 +445,6 @@ def _build_from_dockerfile(
                 path=os.getcwd(),
                 tag=built_image_name,
                 decode=True,
-                pull=True,
                 **optional_kwargs,
             )
 

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -131,13 +131,13 @@ class DockerBuilder(AbstractBuilder):
 
     Parameters
     ----------
-    clean: bool
+    no_cache: bool
         When set, builds the image from scratch, ignoring previous versions.
         Defaults to `False`.
     """
 
-    def __init__(self, clean: bool = False, **_):
-        self.clean = clean
+    def __init__(self, no_cache: bool = False, **_):
+        self.no_cache = no_cache
         super().__init__()
 
     @staticmethod
@@ -170,7 +170,7 @@ class DockerBuilder(AbstractBuilder):
         SystemExit:
             A subprocess exited with an unexpected code.
         """
-        image_uri, build_config = _build(target=target, clean=self.clean)
+        image_uri, build_config = _build(target=target, no_cache=self.no_cache)
         _launch(
             target=target,
             run_command=run_command,
@@ -179,7 +179,7 @@ class DockerBuilder(AbstractBuilder):
         )
 
 
-def _build(target: str, clean: bool = False) -> Tuple[ImageURI, BuildConfig]:
+def _build(target: str, no_cache: bool = False) -> Tuple[ImageURI, BuildConfig]:
     """
     Builds the container image, returning the image URI that can be used to launch
     executions, and the build configuration object used to build the image.
@@ -196,7 +196,7 @@ def _build(target: str, clean: bool = False) -> Tuple[ImageURI, BuildConfig]:
         target=target,
         build_config=build_config,
         docker_client=docker_client,
-        clean=clean,
+        no_cache=no_cache,
     )
     logger.debug("Built local image: %s", repr(image_uri))
 
@@ -259,7 +259,7 @@ def _build_image(
     target: str,
     build_config: BuildConfig,
     docker_client: docker.DockerClient,  # type: ignore
-    clean: bool = False,
+    no_cache: bool = False,
 ) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use, according to the build configuration, and returns
@@ -274,7 +274,7 @@ def _build_image(
         The configuration that controls the image build.
     docker_client: docker.DockerClient
         The client to use for executing the operations.
-    clean: bool
+    no_cache: bool
         When set, builds the image from scratch, ignoring previous versions.
         Defaults to `False`.
 
@@ -311,7 +311,7 @@ def _build_image(
     # A: Because that feature requires the `BUILDKIT_INLINE_CACHE` flag be set on the
     # image while building, and this seems to require the image to already exist locally,
     # which makes first building an image impossible.
-    if not clean:
+    if not no_cache:
         _pull_existing_layers(
             push_config=build_config.push,
             platform=platform,
@@ -324,7 +324,7 @@ def _build_image(
         build_config=build_config,
         platform=platform,
         docker_client=docker_client,
-        clean=clean,
+        no_cache=no_cache,
     )
 
 
@@ -389,7 +389,7 @@ def _build_image_from_base(
     build_config: BuildConfig,
     platform: Optional[str],
     docker_client: docker.DockerClient,  # type: ignore
-    clean: bool = False,
+    no_cache: bool = False,
 ) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use by adding layers to an existing base image.
@@ -413,7 +413,7 @@ def _build_image_from_base(
         dockerfile_contents=dockerfile_contents,
         platform=platform,
         docker_client=docker_client,
-        clean=clean,
+        no_cache=no_cache,
     )
 
     if status_updates is None:
@@ -439,7 +439,7 @@ def _build_from_dockerfile(
     dockerfile_contents: str,
     platform: Optional[str],
     docker_client: docker.DockerClient,  # type: ignore
-    clean: bool = False,
+    no_cache: bool = False,
 ) -> Generator[Dict[str, Any], None, None]:
     """
     Builds a Docker image starting from Dockerfile contents.
@@ -467,7 +467,7 @@ def _build_from_dockerfile(
                 path=os.getcwd(),
                 tag=built_image_name,
                 decode=True,
-                nocache=clean,
+                nocache=no_cache,
                 **optional_kwargs,
             )
 

--- a/sematic/plugins/building/docker_builder.py
+++ b/sematic/plugins/building/docker_builder.py
@@ -128,7 +128,17 @@ class DockerBuilder(AbstractBuilder):
 
     It then launches the target Pipeline by submitting its execution to Sematic Server,
     using the build image to execute `@func`s in the cloud.
+
+    Parameters
+    ----------
+    clean: bool
+        When set, builds the image from scratch, ignoring previous versions.
+        Defaults to `False`.
     """
+
+    def __init__(self, clean: bool = False, **_):
+        self.clean = clean
+        super().__init__()
 
     @staticmethod
     def get_author() -> str:
@@ -160,7 +170,7 @@ class DockerBuilder(AbstractBuilder):
         SystemExit:
             A subprocess exited with an unexpected code.
         """
-        image_uri, build_config = _build(target=target)
+        image_uri, build_config = _build(target=target, clean=self.clean)
         _launch(
             target=target,
             run_command=run_command,
@@ -169,7 +179,7 @@ class DockerBuilder(AbstractBuilder):
         )
 
 
-def _build(target: str) -> Tuple[ImageURI, BuildConfig]:
+def _build(target: str, clean: bool = False) -> Tuple[ImageURI, BuildConfig]:
     """
     Builds the container image, returning the image URI that can be used to launch
     executions, and the build configuration object used to build the image.
@@ -183,7 +193,10 @@ def _build(target: str) -> Tuple[ImageURI, BuildConfig]:
     )
 
     image, image_uri = _build_image(
-        target=target, build_config=build_config, docker_client=docker_client
+        target=target,
+        build_config=build_config,
+        docker_client=docker_client,
+        clean=clean,
     )
     logger.debug("Built local image: %s", repr(image_uri))
 
@@ -246,6 +259,7 @@ def _build_image(
     target: str,
     build_config: BuildConfig,
     docker_client: docker.DockerClient,  # type: ignore
+    clean: bool = False,
 ) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use, according to the build configuration, and returns
@@ -260,6 +274,9 @@ def _build_image(
         The configuration that controls the image build.
     docker_client: docker.DockerClient
         The client to use for executing the operations.
+    clean: bool
+        When set, builds the image from scratch, ignoring previous versions.
+        Defaults to `False`.
 
     Returns
     -------
@@ -294,11 +311,12 @@ def _build_image(
     # A: Because that feature requires the `BUILDKIT_INLINE_CACHE` flag be set on the
     # image while building, and this seems to require the image to already exist locally,
     # which makes first building an image impossible.
-    _pull_existing_layers(
-        push_config=build_config.push,
-        platform=platform,
-        docker_client=docker_client,
-    )
+    if not clean:
+        _pull_existing_layers(
+            push_config=build_config.push,
+            platform=platform,
+            docker_client=docker_client,
+        )
 
     return _build_image_from_base(
         target=target,
@@ -306,6 +324,7 @@ def _build_image(
         build_config=build_config,
         platform=platform,
         docker_client=docker_client,
+        clean=clean,
     )
 
 
@@ -370,6 +389,7 @@ def _build_image_from_base(
     build_config: BuildConfig,
     platform: Optional[str],
     docker_client: docker.DockerClient,  # type: ignore
+    clean: bool = False,
 ) -> Tuple[Image, ImageURI]:
     """
     Builds the container image to use by adding layers to an existing base image.
@@ -393,6 +413,7 @@ def _build_image_from_base(
         dockerfile_contents=dockerfile_contents,
         platform=platform,
         docker_client=docker_client,
+        clean=clean,
     )
 
     if status_updates is None:
@@ -418,6 +439,7 @@ def _build_from_dockerfile(
     dockerfile_contents: str,
     platform: Optional[str],
     docker_client: docker.DockerClient,  # type: ignore
+    clean: bool = False,
 ) -> Generator[Dict[str, Any], None, None]:
     """
     Builds a Docker image starting from Dockerfile contents.
@@ -445,6 +467,7 @@ def _build_from_dockerfile(
                 path=os.getcwd(),
                 tag=built_image_name,
                 decode=True,
+                nocache=clean,
                 **optional_kwargs,
             )
 

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -173,7 +173,7 @@ def test_build_image_base_uri(
         build_config=mock_build_config,
         platform=mock_build_config.build.platform,
         docker_client=mock_docker_client,
-        clean=False,
+        no_cache=False,
     )
 
 
@@ -207,7 +207,7 @@ def test_build_image_build_script(
         build_config=mock_build_config,
         platform=None,
         docker_client=mock_docker_client,
-        clean=False,
+        no_cache=False,
     )
 
 

--- a/sematic/plugins/building/tests/test_docker_builder.py
+++ b/sematic/plugins/building/tests/test_docker_builder.py
@@ -173,6 +173,7 @@ def test_build_image_base_uri(
         build_config=mock_build_config,
         platform=mock_build_config.build.platform,
         docker_client=mock_docker_client,
+        clean=False,
     )
 
 
@@ -206,6 +207,7 @@ def test_build_image_build_script(
         build_config=mock_build_config,
         platform=None,
         docker_client=mock_docker_client,
+        clean=False,
     )
 
 


### PR DESCRIPTION
The Docker Build System uses layer caching, which can result in older versions of libraries being used instead of the new ones. After a new version of Sematic is released, this can result in incompatibilities between the client bundled in an older pipeline image layer, and the backend Server:

Client:

```bash
$ sematic version
Sematic server v0.32.0 is installed.
Client versions >= v0.30.0 are supported.
Python v3.8.14 is running this binary.
$ sematic run --build intermediate/main.py -- /intermediate/data/message.txt
[...]
2023-07-19 06:27:56,503  [INFO] sematic.plugins.building.docker_builder: Launching target: 'intermediate/main.py'
41c30e6ae8904535ba0a28c8944321d0
Built and launched 'intermediate/main.py' in 24.77s
```

Server:

```bash
$ kubectl exec -it sematic-driver-41c30e6ae8904535ba0a28c8944321d0-2nlth /bin/bash
[...]
root@sematic-driver-41c30e6ae8904535ba0a28c8944321d0-2nlth:/# sematic version
Sematic server v0.30.0 is installed.
Client versions >= v0.24.1 are supported.
Python v3.9.16 is running this binary.
```

```bash
$ kubectl logs -f sematic-driver-41c30e6ae8904535ba0a28c8944321d0-2nlth
[...]
2023-07-19 13:27:44,078 - INFO - sematic.resolvers.state_machine_resolver: Starting resolution 41c30e6ae8904535ba0a28c8944321d0
2023-07-19 13:27:44,395 - ERROR - sematic.api_client: Server returned 400 for PUT http://sematic-server/api/v1/resolutions/41c30e6ae8904535ba0a28c8944321d0: {"error": "Cannot update run_command of resolution 41c30e6ae8904535ba0a28c8944321d0 after it has been created. Original value: '/Users/tudorscurtu/.pyenv/versions/3.8.14/envs/3.8.14-testing/bin/sematic run --build intermediate/main.py -- /intermediate/data/message.txt', new value: 'None' (will not be used)"}
[...]
```

<img width="646" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/c1e5f5da-10a2-4f03-acbd-fceeee2875dd">

As a work-around, users have to either rename their pipeline images, or delete both their local and remote images, which are both very inconvenient options, each with other ramifications.

This PR introduces a CLI option to force the Build System to ignore the layer caching.

## Testing

Passing the new `--clean` option results in a complete rebuild (~minutes of build time), and in a successful execution:

```bash
$ time sematic run --build --clean intermediate/main.py -- /intermediate/data/message.txt
Building image and launching: intermediate/main.py /intermediate/data/message.txt
2023-07-19 07:47:25,171  [INFO] sematic.plugins.building.docker_builder: Building image 'intermediate:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
[...]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 26.3 MB/s eta 0:00:00
[...]
Step 12/14 : COPY intermediate/__init__.py intermediate/__init__.py
---> e33422dae5cf
Step 13/14 : COPY intermediate/main.py intermediate/main.py
---> d053c2a850a0
Step 14/14 : COPY intermediate/pipeline.py intermediate/pipeline.py
---> fe1cc9787e2f
{'ID': 'sha256:fe1cc9787e2f99dbb557f698615ebdb05f5392aaf13ae2b8aaca97c9deef99ca'}
Successfully built fe1cc9787e2f
Successfully tagged intermediate:default_example_docker_intermediate
[...]
215315989} Pushing
2023-07-19 07:50:12,583  [INFO] sematic.plugins.building.docker_builder: Launching target: 'intermediate/main.py'':
[...]
dd2937225788 Layer already exists
34200e553ba3 Layer already exists
69e041190553 Layer already exists
af4418d96ca6 Layer already exists
e59fc9495612 Layer already exists
default_example_docker_intermediate: digest: sha256:41f1dc88bac693bf2f9a946928137fdd7e0f9bc7487d428eceea5da9d5c47128
size: 4922
{'Tag': 'default_example_docker_intermediate', 'Digest':
'sha256:41f1dc88bac693bf2f9a946928137fdd7e0f9bc7487d428eceea5da9d5c47128', 'Size': 4922}

real	2m55.975s
user	0m5.602s
sys	0m5.047s
```

<img width="1110" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/d14785b2-16de-460d-95c1-f5952e375dee">

Then re-running without the `--clean` flag results in a cached build:

```bash
$ time sematic run --build intermediate/main.py -- /intermediate/data/message.txt
Building image and launching: intermediate/main.py /intermediate/data/message.txt
2023-07-19 07:51:03,697  [INFO] sematic.plugins.building.docker_builder: Pulling existing layers from repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_intermediate'
2023-07-19 07:51:06,883  [INFO] sematic.plugins.building.docker_builder: Building image 'intermediate:default_example_docker_intermediate' starting from base: sematicai/sematic-worker-base:latest
default_example_docker_intermediate Pulling from sematic-dev
Digest: sha256:41f1dc88bac693bf2f9a946928137fdd7e0f9bc7487d428eceea5da9d5c47128
Status: Image is up to date for 558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-
dev:default_example_docker_intermediate
2023-07-19 07:51:10,263  [INFO] sematic.plugins.building.docker_builder: Tagged image 'intermediate:default_example_docker_intermediate' in repository '558717131297.dkr.ecr.us-west-2.amazonaws.com/sematic-dev' with tag 'default_example_docker_intermediate'
[...]
Step 13/14 : COPY intermediate/main.py intermediate/main.py
---> Using cache
---> d053c2a850a0
Step 14/14 : COPY intermediate/pipeline.py intermediate/pipeline.py
---> Using cache
---> fe1cc9787e2f
{'ID': 'sha256:fe1cc9787e2f99dbb557f698615ebdb05f5392aaf13ae2b8aaca97c9deef99ca'}
Successfully built fe1cc9787e2f
Successfully tagged intermediate:default_example_docker_intermediate
2023-07-19 07:51:17,320  [INFO] sematic.plugins.building.docker_builder: Launching target: 'intermediate/main.py'
f78682bedb9440e5a1878db9efbe676d
Built and launched 'intermediate/main.py' in 19.16s
[...]
34200e553ba3 Layer already exists
26aa9c02e99e Layer already exists
69e041190553 Layer already exists
e59fc9495612 Layer already exists
af4418d96ca6 Layer already exists
default_example_docker_intermediate: digest: sha256:41f1dc88bac693bf2f9a946928137fdd7e0f9bc7487d428eceea5da9d5c47128
size: 4922
{'Tag': 'default_example_docker_intermediate', 'Digest':
'sha256:41f1dc88bac693bf2f9a946928137fdd7e0f9bc7487d428eceea5da9d5c47128', 'Size': 4922}

real	0m22.142s
user	0m7.713s
sys	0m6.525s
```

Notice the must lower build time (22 seconds), and the log line saying that pulling of the image from remote before building is executed.
