### PR TITLE
Breathing style for running state icon on the DAG view

### DIFF
--- a/sematic/ui/packages/common/src/component/RunStateChips.tsx
+++ b/sematic/ui/packages/common/src/component/RunStateChips.tsx
@@ -7,8 +7,26 @@ import DoneOutline from "@mui/icons-material/DoneOutline";
 import { useMemo } from "react";
 import theme from "src/theme/new";
 import { SvgIconTypeMap } from "@mui/material/SvgIcon";
+import { css } from "@emotion/css";
+
+const AnimatedChip = css`
+    @keyframes svg-gaussian-blur {
+        0%   {filter: url(#gaussian-blur-1); transform: scale(1.3); }
+        25%  {filter: url(#gaussian-blur-0.5); }
+        50%  {filter: url(#gaussian-blur-0); transform: scale(1);}
+        75%  {filter: url(#gaussian-blur-0.5); }
+        100%  {filter: url(#gaussian-blur-1); transform: scale(1.3);}
+    }
+
+    animation-name: svg-gaussian-blur;
+    animation-duration: 1.5s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+`;
+
 interface StateChipBaseProps {
     size?: "small" | "medium" | "large";
+    animated?: boolean;
 }
 
 const useStylesHook = (props: StateChipBaseProps) => {
@@ -47,10 +65,10 @@ export const FailedStateChip = (props: StateChipBaseProps) => {
 }
 
 export const RunningStateChip = (props: StateChipBaseProps) => {
-    const { size } = props;
+    const { size, animated = false } = props;
     const styles = useStylesHook({ size });
     const color = RunStateColorMap.get(RunningStateChip)!.color;
-    return <BoltIcon color={color} style={styles} />;
+    return <BoltIcon color={color} style={styles} className={animated ? AnimatedChip : undefined} />;
 }
 
 export const CanceledStateChip = (props: StateChipBaseProps) => {
@@ -120,19 +138,18 @@ export function getRunStateColorByState(futureState: string, orignalRunId: strin
     return (theme.palette as any)[color].main;
 }
 
-interface RunStateChipProps {
+interface RunStateChipProps extends StateChipBaseProps{
     futureState: string;
     orignalRunId: string | null;
-    size?: StateChipBaseProps["size"];
 }
 
 export default function RunStateChip(props: RunStateChipProps) {
-    const { futureState, orignalRunId, size = "large" } = props;
+    const { futureState, orignalRunId, size = "large", animated } = props;
 
     const Component = useMemo(
         () => getRunStateChipComponentByState(futureState, orignalRunId), [futureState, orignalRunId]);
     if (!Component) {
         return null;
     }
-    return <Component size={size} />;
+    return <Component size={size} animated={animated} />;
 }

--- a/sematic/ui/packages/common/src/layout/Shell.tsx
+++ b/sematic/ui/packages/common/src/layout/Shell.tsx
@@ -10,6 +10,7 @@ import HeaderMenu from "src/component/menu";
 import SnackBarProvider from "src/context/SnackBarProvider";
 import UserContext from "src/context/UserContext";
 import theme from "src/theme/new/index";
+import SvgFilters from "src/theme/new/svgfilters";
 
 const StyledGrid = styled(Grid)`
   height: 100vh;
@@ -39,6 +40,7 @@ const Shell = () => {
     return <SnackBarProvider>
         <ThemeProvider theme={theme}>
             <CssBaseline />
+            <SvgFilters />
             <StyledGrid container spacing={0} direction={"column"} >
                 <Grid style={{ flexShrink: 0, flexGrow: 0 }}>
                     <HeaderMenu selectedKey={selectionKey} />

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/CompoundNode.tsx
@@ -78,7 +78,7 @@ function CompoundNode(props: NodeProps) {
         style={{ width: `${data.width}px`, height: `${data.height}px` }}>
         {hasIncoming && <StyledHandleTop type="target" color={color} position={Position.Top} isConnectable={false} id={"t"} />}
         <LabelContainer>
-            <RunStateChip futureState={run.future_state} orignalRunId={run.original_run_id} />
+            <RunStateChip animated={true} futureState={run.future_state} orignalRunId={run.original_run_id} />
             <label style={{ flexGrow: 1 }}>{data.label}</label>
             <StyledIconButton onClick={toggleExpanded} >
                 {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/LeafNode.tsx
@@ -61,7 +61,7 @@ function LeafNode(props: NodeProps) {
         {hasIncoming && <StyledHandleTop type="target" position={Position.Top} isConnectable={false}
             id={"t"} color={color} />}
         <LabelContainer>
-            <RunStateChip futureState={run.future_state} orignalRunId={run.original_run_id} />
+            <RunStateChip futureState={run.future_state} animated={true} orignalRunId={run.original_run_id} />
             <label >{data.label}</label>
         </LabelContainer>
         <StyledHandleBottom

--- a/sematic/ui/packages/common/src/theme/new/svgfilters.tsx
+++ b/sematic/ui/packages/common/src/theme/new/svgfilters.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function SvgFilters() {
+    return <svg version="1.1" width="0" height="0">
+        <filter id="gaussian-blur-0.5">
+            <feGaussianBlur stdDeviation="0.4" />
+        </filter>
+        <filter id="gaussian-blur-1">
+            <feGaussianBlur stdDeviation="0.8" />
+        </filter>
+        <filter id="gaussian-blur-0">
+            <feGaussianBlur stdDeviation="0" />
+        </filter>
+    </svg>
+}


### PR DESCRIPTION
Applies a breathing style for running state icon on the DAG view. It is DAG view only for now.

Preview:

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/35a0f6bc-7268-4b7a-bcea-2fa498211a33)
