### PR TITLE
Make Failed a terminal state for Run

### DIFF
--- a/sematic/abstract_future.py
+++ b/sematic/abstract_future.py
@@ -102,7 +102,6 @@ _ALLOWED_TRANSITIONS = {
             FutureState.RETRYING,
             FutureState.CANCELED,
             FutureState.RESOLVED,
-            # TODO: remove (See https://github.com/sematic-ai/sematic/issues/609)
             FutureState.FAILED,
         }
     ),
@@ -112,12 +111,7 @@ _ALLOWED_TRANSITIONS = {
     FutureState.RETRYING: frozenset(
         {FutureState.FAILED, FutureState.SCHEDULED, FutureState.CANCELED}
     ),
-    FutureState.FAILED: frozenset(
-        {
-            # TODO: remove (See https://github.com/sematic-ai/sematic/issues/609)
-            FutureState.RETRYING
-        }
-    ),
+    FutureState.FAILED: frozenset(),
     FutureState.NESTED_FAILED: frozenset(),
     FutureState.CANCELED: frozenset(),
     FutureState.RESOLVED: frozenset(),


### PR DESCRIPTION
Fixes #609.

Removes the FAILED -> RETRYING transition.

The other SCHEDULED -> FAILED transition cannot be removed, as Runs that do not have retries configured, and Runs that are on their last try will go through SCHEDULED -> FAILED.

## Testing

Validated using the Testing Pipeline, while watching the logs that the Runs are actually failing.

```bash
$ bazel run sematic/examples/testing_pipeline:__main__ -- --cloud --raise-retry 0.9
```
