### PR TITLE
Propagate Testing Pipeline raise retry probability to func

### DIFF
--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -538,7 +538,7 @@ def testing_pipeline(
         futures.append(do_raise(initial_future))
 
     if raise_retry_probability:
-        futures.append(do_retry(initial_future))
+        futures.append(do_retry(initial_future, raise_retry_probability))
 
     if timeout_settings and timeout_settings[0] > 0:
         futures.append(


### PR DESCRIPTION
The Testing Pipeline function that raises and retries takes a raising probability parameter that can be specified in the CLI. This parameter isn't actually passed to the func, instead always using the default value of `0.5`.