### PR TITLE
Add GCS Storage implementation

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
   AWS_S3_REGION: {{ .Values.aws.bucket_region | quote }}
   STORAGE: "sematic.plugins.storage.s3_storage.S3Storage"
 {{ end }}
+{{ if .Values.gcp.enabled }}
+  GCP_GCS_BUCKET: {{ .Values.gcp.storage_bucket | quote }}
+  STORAGE: "sematic.plugins.storage.gcs_storage.GcsStorage"
+{{ end }}
 {{ if .Values.local_storage.enabled }}
   STORAGE: "sematic.plugins.storage.local_storage.LocalStorage"
 {{ if .Values.local_storage.local_storage_path }}

--- a/helm/sematic-server/templates/deployment.yaml
+++ b/helm/sematic-server/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           env:
           - name: SEMATIC_WSGI_WORKERS_COUNT
             value: "{{ .Values.deployment.worker_count }}"
+          {{- if .Values.gcp.sa_secret.use }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: "/gcp/secrets/{{ .Values.gcp.sa_secret.file }}"
+          {{- end }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}
@@ -60,6 +64,12 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.gcp.sa_secret.use }}
+          volumeMounts:
+          - name: gcp-sa-secret
+            mountPath: /gcp/secrets
+            readOnly: true
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.deployment.liveness_probe | nindent 12 }}
           readinessProbe:
@@ -68,6 +78,12 @@ spec:
             {{- toYaml .Values.deployment.startup_probe | nindent 12 }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+      {{- if .Values.gcp.sa_secret.use }}
+      volumes:
+        - name: gcp-sa-secret
+          secret:
+            secretName: {{ .Values.gcp.sa_secret.name }}
+      {{- end }}
       {{- with .Values.deployment.node_selector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -8,6 +8,14 @@ aws:
   storage_bucket: my-s3-bucket # REPLACE ME
   bucket_region: my-s3-region # REPLACE ME
 
+gcp:
+  enabled: false
+  storage_bucket: my-bucket # REPLACE ME
+  sa_secret:
+    use: false
+    name: gcp-sa # REPLACE ME
+    file: the-key.json # REPLACE ME
+
 local_storage:
   enabled: false
   local_storage_path: /path/to/storage # REPLACE ME. Optional, defaults to ~/.sematic/data

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -76,6 +76,7 @@ python-magic
 # Cloud execution
 kubernetes
 boto3
+google-cloud-storage
 
 # External Resource Plugins
 ## Ray

--- a/requirements/requirements3_10.txt
+++ b/requirements/requirements3_10.txt
@@ -716,7 +716,10 @@ gitpython==3.1.30 \
 google-api-core==2.11.0 \
     --hash=sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22 \
     --hash=sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e
-    # via opencensus
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   opencensus
 google-auth==2.16.0 \
     --hash=sha256:5045648c821fb72384cdc0e82cc326df195f113a33049d9b62b74589243d2acc \
     --hash=sha256:ed7057a101af1146f0554a769930ac9de506aeca4fd5af6543ebe791851a9fbd
@@ -724,12 +727,96 @@ google-auth==2.16.0 \
     #   -r requirements/requirements.in
     #   google-api-core
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
     #   kubernetes
     #   tensorboard
 google-auth-oauthlib==0.4.6 \
     --hash=sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73 \
     --hash=sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a
     # via tensorboard
+google-cloud-core==2.3.3 \
+    --hash=sha256:37b80273c8d7eee1ae816b3a20ae43585ea50506cb0e60f3cf5be5f87f1373cb \
+    --hash=sha256:fbd11cad3e98a7e5b0343dc07cb1039a5ffd7a5bb96e1f1e27cee4bda4a90863
+    # via google-cloud-storage
+google-cloud-storage==2.10.0 \
+    --hash=sha256:934b31ead5f3994e5360f9ff5750982c5b6b11604dc072bc452c25965e076dc7 \
+    --hash=sha256:9433cf28801671de1c80434238fb1e7e4a1ba3087470e90f70c928ea77c2b9d7
+    # via -r requirements/requirements.in
+google-crc32c==1.5.0 \
+    --hash=sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a \
+    --hash=sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876 \
+    --hash=sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c \
+    --hash=sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289 \
+    --hash=sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298 \
+    --hash=sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02 \
+    --hash=sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f \
+    --hash=sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2 \
+    --hash=sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a \
+    --hash=sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb \
+    --hash=sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210 \
+    --hash=sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5 \
+    --hash=sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee \
+    --hash=sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c \
+    --hash=sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a \
+    --hash=sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314 \
+    --hash=sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd \
+    --hash=sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65 \
+    --hash=sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37 \
+    --hash=sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4 \
+    --hash=sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13 \
+    --hash=sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894 \
+    --hash=sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31 \
+    --hash=sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e \
+    --hash=sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709 \
+    --hash=sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740 \
+    --hash=sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc \
+    --hash=sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d \
+    --hash=sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c \
+    --hash=sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c \
+    --hash=sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d \
+    --hash=sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906 \
+    --hash=sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61 \
+    --hash=sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57 \
+    --hash=sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c \
+    --hash=sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a \
+    --hash=sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438 \
+    --hash=sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946 \
+    --hash=sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7 \
+    --hash=sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96 \
+    --hash=sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091 \
+    --hash=sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae \
+    --hash=sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d \
+    --hash=sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88 \
+    --hash=sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2 \
+    --hash=sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd \
+    --hash=sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541 \
+    --hash=sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728 \
+    --hash=sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178 \
+    --hash=sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968 \
+    --hash=sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346 \
+    --hash=sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8 \
+    --hash=sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93 \
+    --hash=sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7 \
+    --hash=sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273 \
+    --hash=sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462 \
+    --hash=sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94 \
+    --hash=sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd \
+    --hash=sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e \
+    --hash=sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57 \
+    --hash=sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b \
+    --hash=sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9 \
+    --hash=sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a \
+    --hash=sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100 \
+    --hash=sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325 \
+    --hash=sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183 \
+    --hash=sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556 \
+    --hash=sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4
+    # via google-resumable-media
+google-resumable-media==2.5.0 \
+    --hash=sha256:218931e8e2b2a73a58eb354a288e03a0fd5fb1c4583261ac6e4c078666468c93 \
+    --hash=sha256:da1bd943e2e114a56d85d6848497ebf9be6a14d3db23e9fc57581e7c3e8170ec
+    # via google-cloud-storage
 googleapis-common-protos==1.58.0 \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
@@ -2316,6 +2403,7 @@ requests==2.28.2 \
     #   docker
     #   fsspec
     #   google-api-core
+    #   google-cloud-storage
     #   gradio
     #   gradio-client
     #   huggingface-hub

--- a/requirements/requirements3_8.txt
+++ b/requirements/requirements3_8.txt
@@ -716,7 +716,10 @@ gitpython==3.1.30 \
 google-api-core==2.11.0 \
     --hash=sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22 \
     --hash=sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e
-    # via opencensus
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   opencensus
 google-auth==2.16.0 \
     --hash=sha256:5045648c821fb72384cdc0e82cc326df195f113a33049d9b62b74589243d2acc \
     --hash=sha256:ed7057a101af1146f0554a769930ac9de506aeca4fd5af6543ebe791851a9fbd
@@ -724,12 +727,96 @@ google-auth==2.16.0 \
     #   -r requirements/requirements.in
     #   google-api-core
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
     #   kubernetes
     #   tensorboard
 google-auth-oauthlib==0.4.6 \
     --hash=sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73 \
     --hash=sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a
     # via tensorboard
+google-cloud-core==2.3.3 \
+    --hash=sha256:37b80273c8d7eee1ae816b3a20ae43585ea50506cb0e60f3cf5be5f87f1373cb \
+    --hash=sha256:fbd11cad3e98a7e5b0343dc07cb1039a5ffd7a5bb96e1f1e27cee4bda4a90863
+    # via google-cloud-storage
+google-cloud-storage==2.10.0 \
+    --hash=sha256:934b31ead5f3994e5360f9ff5750982c5b6b11604dc072bc452c25965e076dc7 \
+    --hash=sha256:9433cf28801671de1c80434238fb1e7e4a1ba3087470e90f70c928ea77c2b9d7
+    # via -r requirements/requirements.in
+google-crc32c==1.5.0 \
+    --hash=sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a \
+    --hash=sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876 \
+    --hash=sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c \
+    --hash=sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289 \
+    --hash=sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298 \
+    --hash=sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02 \
+    --hash=sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f \
+    --hash=sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2 \
+    --hash=sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a \
+    --hash=sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb \
+    --hash=sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210 \
+    --hash=sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5 \
+    --hash=sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee \
+    --hash=sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c \
+    --hash=sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a \
+    --hash=sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314 \
+    --hash=sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd \
+    --hash=sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65 \
+    --hash=sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37 \
+    --hash=sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4 \
+    --hash=sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13 \
+    --hash=sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894 \
+    --hash=sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31 \
+    --hash=sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e \
+    --hash=sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709 \
+    --hash=sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740 \
+    --hash=sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc \
+    --hash=sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d \
+    --hash=sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c \
+    --hash=sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c \
+    --hash=sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d \
+    --hash=sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906 \
+    --hash=sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61 \
+    --hash=sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57 \
+    --hash=sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c \
+    --hash=sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a \
+    --hash=sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438 \
+    --hash=sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946 \
+    --hash=sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7 \
+    --hash=sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96 \
+    --hash=sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091 \
+    --hash=sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae \
+    --hash=sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d \
+    --hash=sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88 \
+    --hash=sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2 \
+    --hash=sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd \
+    --hash=sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541 \
+    --hash=sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728 \
+    --hash=sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178 \
+    --hash=sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968 \
+    --hash=sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346 \
+    --hash=sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8 \
+    --hash=sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93 \
+    --hash=sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7 \
+    --hash=sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273 \
+    --hash=sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462 \
+    --hash=sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94 \
+    --hash=sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd \
+    --hash=sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e \
+    --hash=sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57 \
+    --hash=sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b \
+    --hash=sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9 \
+    --hash=sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a \
+    --hash=sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100 \
+    --hash=sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325 \
+    --hash=sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183 \
+    --hash=sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556 \
+    --hash=sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4
+    # via google-resumable-media
+google-resumable-media==2.5.0 \
+    --hash=sha256:218931e8e2b2a73a58eb354a288e03a0fd5fb1c4583261ac6e4c078666468c93 \
+    --hash=sha256:da1bd943e2e114a56d85d6848497ebf9be6a14d3db23e9fc57581e7c3e8170ec
+    # via google-cloud-storage
 googleapis-common-protos==1.58.0 \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
@@ -2316,6 +2403,7 @@ requests==2.28.2 \
     #   docker
     #   fsspec
     #   google-api-core
+    #   google-cloud-storage
     #   gradio
     #   gradio-client
     #   huggingface-hub

--- a/requirements/requirements3_9.txt
+++ b/requirements/requirements3_9.txt
@@ -716,7 +716,10 @@ gitpython==3.1.30 \
 google-api-core==2.11.0 \
     --hash=sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22 \
     --hash=sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e
-    # via opencensus
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   opencensus
 google-auth==2.16.0 \
     --hash=sha256:5045648c821fb72384cdc0e82cc326df195f113a33049d9b62b74589243d2acc \
     --hash=sha256:ed7057a101af1146f0554a769930ac9de506aeca4fd5af6543ebe791851a9fbd
@@ -724,12 +727,96 @@ google-auth==2.16.0 \
     #   -r requirements/requirements.in
     #   google-api-core
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
     #   kubernetes
     #   tensorboard
 google-auth-oauthlib==0.4.6 \
     --hash=sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73 \
     --hash=sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a
     # via tensorboard
+google-cloud-core==2.3.3 \
+    --hash=sha256:37b80273c8d7eee1ae816b3a20ae43585ea50506cb0e60f3cf5be5f87f1373cb \
+    --hash=sha256:fbd11cad3e98a7e5b0343dc07cb1039a5ffd7a5bb96e1f1e27cee4bda4a90863
+    # via google-cloud-storage
+google-cloud-storage==2.10.0 \
+    --hash=sha256:934b31ead5f3994e5360f9ff5750982c5b6b11604dc072bc452c25965e076dc7 \
+    --hash=sha256:9433cf28801671de1c80434238fb1e7e4a1ba3087470e90f70c928ea77c2b9d7
+    # via -r requirements/requirements.in
+google-crc32c==1.5.0 \
+    --hash=sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a \
+    --hash=sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876 \
+    --hash=sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c \
+    --hash=sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289 \
+    --hash=sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298 \
+    --hash=sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02 \
+    --hash=sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f \
+    --hash=sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2 \
+    --hash=sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a \
+    --hash=sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb \
+    --hash=sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210 \
+    --hash=sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5 \
+    --hash=sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee \
+    --hash=sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c \
+    --hash=sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a \
+    --hash=sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314 \
+    --hash=sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd \
+    --hash=sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65 \
+    --hash=sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37 \
+    --hash=sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4 \
+    --hash=sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13 \
+    --hash=sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894 \
+    --hash=sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31 \
+    --hash=sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e \
+    --hash=sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709 \
+    --hash=sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740 \
+    --hash=sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc \
+    --hash=sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d \
+    --hash=sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c \
+    --hash=sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c \
+    --hash=sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d \
+    --hash=sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906 \
+    --hash=sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61 \
+    --hash=sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57 \
+    --hash=sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c \
+    --hash=sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a \
+    --hash=sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438 \
+    --hash=sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946 \
+    --hash=sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7 \
+    --hash=sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96 \
+    --hash=sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091 \
+    --hash=sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae \
+    --hash=sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d \
+    --hash=sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88 \
+    --hash=sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2 \
+    --hash=sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd \
+    --hash=sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541 \
+    --hash=sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728 \
+    --hash=sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178 \
+    --hash=sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968 \
+    --hash=sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346 \
+    --hash=sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8 \
+    --hash=sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93 \
+    --hash=sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7 \
+    --hash=sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273 \
+    --hash=sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462 \
+    --hash=sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94 \
+    --hash=sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd \
+    --hash=sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e \
+    --hash=sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57 \
+    --hash=sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b \
+    --hash=sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9 \
+    --hash=sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a \
+    --hash=sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100 \
+    --hash=sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325 \
+    --hash=sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183 \
+    --hash=sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556 \
+    --hash=sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4
+    # via google-resumable-media
+google-resumable-media==2.5.0 \
+    --hash=sha256:218931e8e2b2a73a58eb354a288e03a0fd5fb1c4583261ac6e4c078666468c93 \
+    --hash=sha256:da1bd943e2e114a56d85d6848497ebf9be6a14d3db23e9fc57581e7c3e8170ec
+    # via google-cloud-storage
 googleapis-common-protos==1.58.0 \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
@@ -2316,6 +2403,7 @@ requests==2.28.2 \
     #   docker
     #   fsspec
     #   google-api-core
+    #   google-cloud-storage
     #   gradio
     #   gradio-client
     #   huggingface-hub

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -34,6 +34,7 @@ sematic_py_lib(
         "//sematic/future_operators:init",
         "//sematic/plugins/external_resource:timed_message",
         "//sematic/plugins/kuberay_wrapper:standard",
+        "//sematic/plugins/storage:gcs_storage",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/resolvers:local_resolver",
         "//sematic/resolvers:silent_resolver",

--- a/sematic/api/BUILD
+++ b/sematic/api/BUILD
@@ -37,6 +37,7 @@ sematic_py_lib(
         "//sematic/config:config",
         "//sematic/config:server_settings",
         "//sematic:logs",
+        "//sematic/plugins/storage:gcs_storage",
         "//sematic/plugins/storage:local_storage",
         "//sematic/plugins:abstract_publisher",
         "//sematic/plugins/publishing:slack",

--- a/sematic/plugins/storage/BUILD
+++ b/sematic/plugins/storage/BUILD
@@ -1,3 +1,19 @@
+
+sematic_py_lib(
+    name = "gcs_storage",
+    srcs = ["gcs_storage.py"],
+    pip_deps = [
+        "google-cloud-storage",
+    ],
+    deps = [
+        "//sematic:abstract_plugin",
+        "//sematic/config:settings",
+        "//sematic/plugins:abstract_storage",
+        "//sematic/utils:memoized_property",
+        "//sematic/utils:retry",
+    ],
+)
+
 sematic_py_lib(
     name = "local_storage",
     srcs = ["local_storage.py"],

--- a/sematic/plugins/storage/gcs_storage.py
+++ b/sematic/plugins/storage/gcs_storage.py
@@ -1,0 +1,142 @@
+# Standard Library
+import enum
+import logging
+from datetime import timedelta
+from typing import Iterable, List, Type
+
+# Third-party
+from google.cloud import storage as gcs
+
+# Sematic
+from sematic.abstract_plugin import (
+    SEMATIC_PLUGIN_AUTHOR,
+    AbstractPlugin,
+    AbstractPluginSettingsVar,
+    PluginVersion,
+)
+from sematic.config.settings import get_plugin_setting
+from sematic.plugins.abstract_storage import AbstractStorage, StorageDestination
+from sematic.utils.memoized_property import memoized_property
+from sematic.utils.retry import retry
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_VERSION = (0, 1, 0)
+
+
+class GcsClientMethod(enum.Enum):
+    PUT = "PUT"
+    GET = "GET"
+
+
+class GcsStorageSettingsVar(AbstractPluginSettingsVar):
+    GCP_GCS_BUCKET = "GCP_GCS_BUCKET"
+
+
+class GcsStorage(AbstractStorage, AbstractPlugin):
+    """
+    Implementation of the `AbstractStorage` interface for GCP GCS storage. The
+    bucket where to store values is determined by the `GCP_GCS_BUCKET` plug-in
+    setting.
+    """
+
+    PRESIGNED_URL_EXPIRATION = timedelta(minutes=5)
+
+    @staticmethod
+    def get_author() -> str:
+        return SEMATIC_PLUGIN_AUTHOR
+
+    @staticmethod
+    def get_version() -> PluginVersion:
+        return _PLUGIN_VERSION
+
+    @classmethod
+    def get_settings_vars(cls) -> Type[AbstractPluginSettingsVar]:
+        return GcsStorageSettingsVar
+
+    @memoized_property
+    def _bucket_str(self) -> str:
+        return get_plugin_setting(self.__class__, GcsStorageSettingsVar.GCP_GCS_BUCKET)
+
+    @memoized_property
+    def _storage_client(self):
+        return gcs.Client()
+
+    @memoized_property
+    def _bucket(self) -> gcs.Bucket:
+        return self._storage_client.bucket(self._bucket_str)
+
+    def _blob_for_key(self, key: str) -> gcs.Blob:
+        return self._bucket.blob(key)
+
+    def _make_presigned_url(self, client_method: GcsClientMethod, key: str) -> str:
+        logger.info("Generating GCS presigned url for %s", key)
+        presigned_url = self._blob_for_key(key).generate_signed_url(
+            expiration=self.PRESIGNED_URL_EXPIRATION,
+            method=client_method.value,
+            version="v4",
+        )
+
+        return presigned_url
+
+    def get_write_destination(self, namespace: str, key: str, _) -> StorageDestination:
+        return StorageDestination(
+            uri=self._make_presigned_url(GcsClientMethod.PUT, f"{namespace}/{key}"),
+        )
+
+    def get_read_destination(self, namespace: str, key: str, _) -> StorageDestination:
+        return StorageDestination(
+            uri=self._make_presigned_url(GcsClientMethod.GET, f"{namespace}/{key}"),
+        )
+
+    @retry(tries=3, delay=5)
+    def get_line_stream(self, key: str, encoding: str = "utf8") -> Iterable[str]:
+        """Get value from GCS into a stream of text lines.
+
+        Note that currently this implementation is not suitable for large files, as
+        the whole file will be downloaded into memory. If large file downloads are
+        required, this implementation should be revisited. Currently log files have
+        a max size of 1k lines, and thus should be safe to load here.
+        """
+        # Note: it appears that a new python dependency is needed if we wanted to
+        # truly stream this: google-resumable-media.
+        blob = self._blob_for_key(key)
+        as_bytes = blob.download_as_bytes()
+        as_str = str(as_bytes, encoding)
+        return as_str.splitlines()
+
+    @retry(tries=3, delay=5)
+    def get_child_paths(self, key_prefix: str) -> List[str]:
+        """Get all descendants of the 'directory' specified by the prefix
+
+        Parameters
+        ----------
+        key_prefix:
+            The prefix to a key that would be used with 'get' or 'set'. The keys are
+            treated as being like directories, with '/' in a key specifying an
+            organizational unit for the objects.
+
+        Returns
+        -------
+        A list of all keys that start with the prefix. You can think of this as getting
+        the absolute file paths for all contents of a directory (including 'files' in
+        'subdirectories').
+        """
+        if not key_prefix.endswith("/"):
+            key_prefix = f"{key_prefix}/"
+
+        keys = []
+
+        list_objects_return = self._bucket.list_blobs(
+            prefix=key_prefix,
+            delimiter="/",
+            include_trailing_delimiter=False,
+        )
+
+        for blob in list_objects_return:
+            if blob.name == key_prefix:
+                # don't want the "directory" itself, only its children.
+                continue
+            keys.append(blob.name)
+
+        return keys

--- a/sematic/plugins/storage/tests/BUILD
+++ b/sematic/plugins/storage/tests/BUILD
@@ -10,6 +10,17 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_gcs_storage",
+    srcs = ["test_gcs_storage.py"],
+    pip_deps = ["flask"],
+    deps = [
+        "//sematic/api/tests:fixtures",
+        "//sematic/db/tests:fixtures",
+        "//sematic/plugins/storage:gcs_storage",
+    ],
+)
+
+pytest_test(
     name = "test_local_storage",
     srcs = ["test_local_storage.py"],
     pip_deps = ["flask"],

--- a/sematic/plugins/storage/tests/test_gcs_storage.py
+++ b/sematic/plugins/storage/tests/test_gcs_storage.py
@@ -1,0 +1,85 @@
+# Standard Library
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import List, Tuple
+from unittest import mock
+
+# Third-party
+import flask.testing
+
+# Sematic
+from sematic.api.tests.fixtures import mock_auth, test_client  # noqa: F401
+from sematic.db.tests.fixtures import test_db  # noqa: F401
+from sematic.plugins.storage.gcs_storage import GcsClientMethod, GcsStorage
+
+
+@dataclass
+class Blob:
+    name: str
+    contents: bytes
+    generation_requests: List[Tuple[timedelta, str, str]] = field(default_factory=list)
+
+    def generate_signed_url(
+        self,
+        expiration,
+        method,
+        version,
+    ):
+        self.generation_requests.append((expiration, method, version))
+        return f"http://storage.com/{self.name}?signature=abc123"
+
+
+@dataclass
+class FakeBucket:
+    name: str
+    blobs: List[Blob]
+
+    def blob(self, key) -> Blob:
+        return next(blob for blob in self.blobs if blob.name == key)
+
+
+class FakeBucketStorage(GcsStorage):
+    def __init__(self, bucket):
+        self.bucket = bucket
+
+    @property
+    def _bucket(self):
+        return self.bucket
+
+
+def test_upload_download(
+    mock_auth,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    gcs_storage = GcsStorage()
+
+    with mock.patch(
+        "sematic.plugins.storage.gcs_storage.GcsStorage._make_presigned_url",
+        return_value="https://presigned-url",
+    ):
+        destination = gcs_storage.get_write_destination("artifacts", "123", None)
+
+        assert destination.uri == "https://presigned-url"
+
+        destination = gcs_storage.get_read_destination("artifacts", "123", None)
+
+        assert destination.uri == "https://presigned-url"
+
+
+def test_make_presigned_url(
+    mock_auth,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    key = "my-key"
+    bucket_name = "my-bucket"
+    contents = b"hello\nto\n\the\nwhole\nworld"
+    generation_requests: List[Tuple[timedelta, str, str]] = []
+    blob = Blob(name=key, contents=contents, generation_requests=generation_requests)
+    gcs_storage = FakeBucketStorage(FakeBucket(name=bucket_name, blobs=[blob]))
+
+    url = gcs_storage._make_presigned_url(GcsClientMethod.GET, key=key)
+    assert key in url
+    assert len(generation_requests) == 1
+    time, method, _ = generation_requests[0]
+    assert time == timedelta(minutes=5)
+    assert method == "GET"


### PR DESCRIPTION
Adds support for an implementation of Sematic storage that leverages GCS.

Testing
-------

- Created a GCS Bucket and service account with access to it
- deployed a key for that SA to my k8s namespace as a k8s secret
- deployed Sematic to my namespace, configured to use GCS and that secret
- Executed the testing pipeline: [run with images](https://josh.dev-usw2-sematic0.sematic.cloud/runs/2d9df0663272442cb69006671d9b5f8e#run=7e76a2825a984288a439be4746261e17) [logs](https://josh.dev-usw2-sematic0.sematic.cloud/runs/2d9df0663272442cb69006671d9b5f8e#run=7e76a2825a984288a439be4746261e17&tab=logs)