### PR TITLE
Miscellaneous UI bug fixes

### DIFF
--- a/sematic/ui/packages/common/src/component/RunReference.tsx
+++ b/sematic/ui/packages/common/src/component/RunReference.tsx
@@ -1,7 +1,7 @@
 import Link from "@mui/material/Link";
 import Typography, { TypographyProps } from "@mui/material/Typography";
-import { Link as RouterLink } from "react-router-dom";
-import { getRunUrlPattern } from "src/hooks/runHooks";
+import { useCallback } from "react";
+import { useRunNavigation } from "src/hooks/runHooks";
 
 
 interface RunReferenceLinkProps {
@@ -13,8 +13,13 @@ interface RunReferenceLinkProps {
 export const RunReferenceLink = (props: RunReferenceLinkProps) => {
     const { runId, className, variant = "small" } = props;
 
-    return <Link to={getRunUrlPattern(runId)} variant={variant} type={"code"} className={className}
-        component={RouterLink}>
+    const navigate = useRunNavigation();
+
+    const onClick = useCallback(() => {
+        navigate(runId);
+    }, [navigate, runId]);
+
+    return <Link onClick={onClick} variant={variant} type={"code"} className={className}>
         {runId.substring(0, 7)}
     </Link>
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/FunctionSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/FunctionSectionMenu.tsx
@@ -60,7 +60,7 @@ function FunctionSectionActionMenu(props: FunctionSectionActionMenuProps) {
     const commands = useMemo(() => {
         return [
             {
-                title: "Rerun",
+                title: "Rerun from here",
                 disabled: !rerunEnable,
                 onClick: async () => {
                     try {

--- a/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/RunSectionMenu.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/contextMenus/RunSectionMenu.tsx
@@ -47,7 +47,7 @@ function RunSectionActionMenu(props: RunSectionActionMenuProps) {
     const commands = useMemo(() => {
         return [
             {
-                title: "Rerun",
+                title: "Rerun from scratch",
                 disabled: !rerunEnable,
                 onClick: async () => {
                     try {

--- a/sematic/ui/packages/common/src/pages/RunDetails/dag/ReactFlowDag.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/dag/ReactFlowDag.tsx
@@ -135,7 +135,7 @@ function ReactFlowDag(props: ReactFlowDagProps) {
         setNodes([..._nodes]);
         setEdges([..._edges]);
         reactFlowRef.current?.fitView({
-            maxZoom: 1,
+            maxZoom: 1, minZoom: 0.5
         });
     }, [_nodes, _edges, setNodes, setEdges]);
 
@@ -148,7 +148,8 @@ function ReactFlowDag(props: ReactFlowDagProps) {
             onEdgesChange={onEdgesChange}
             onInit={reactFlow => reactFlowRef.current = reactFlow}
             fitView
-            fitViewOptions={{maxZoom: 1}}
+            fitViewOptions={{maxZoom: 1, minZoom: 0.5}}
+            minZoom={0.1}
         />
     </div>;
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
@@ -1,12 +1,14 @@
 import styled from "@emotion/styled";
 import { TextField } from "@mui/material";
+import Alert from "@mui/material/Alert";
+import { buttonClasses } from "@mui/material/Button";
 import BidirectionalLogView, { ConciseLineTemplate } from "@sematic/common/src/pages/RunDetails/logs/BidirectionalLogView";
-import { useCallback, useRef, useState, useContext } from "react";
+import includes from "lodash/includes";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import useUnmount from "react-use/lib/useUnmount";
 import LayoutServiceContext from "src/context/LayoutServiceContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 import theme from "src/theme/new";
-import { buttonClasses } from "@mui/material/Button"
-import useUnmount from "react-use/lib/useUnmount";
 
 const Container = styled.div`
     max-height: 100%;
@@ -78,12 +80,16 @@ export default function LogsPane() {
         setIsLoading(false);
     });
 
-    if (!selectedRun) {
-        return null;
-    }
-
-    return (
-        <Container style={{ display: "flex", flexDirection: "column" }}>
+    const logsSection = useMemo(() => {
+        if (!selectedRun ) {
+            return null;
+        }
+        if (includes(["CREATED", "SCHEDULED"], selectedRun.future_state)) {
+            return <Alert severity="info" sx={{ mt: 3 }}>
+                {"Run has not started. There are no logs yet."}
+            </Alert>
+        }
+        return <>
             <StyledTextField
                 variant="standard"
                 fullWidth={true}
@@ -102,6 +108,12 @@ export default function LogsPane() {
                     </FloatingFooterAnchor>
                 </FloatingFooter>
             </ScrollContainer>
+        </>;
+    }, [filterString, footerRenderProp, id, onFilterStringChange, selectedRun, setFooterRenderProp, setIsLoading]);
+
+    return (
+        <Container style={{ display: "flex", flexDirection: "column" }}>
+            {logsSection}
         </Container>
     );
 }

--- a/sematic/ui/packages/common/src/pages/RunDetails/podLifecycle/PodLifecycle.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/podLifecycle/PodLifecycle.tsx
@@ -23,6 +23,13 @@ interface PodLifecycleProps {
     className?: string;
 }
 
+
+const disclaimer = <Typography fontSize="small" color="GrayText" style={{ marginBottom: "1em" }}>
+The information in this tab is provided for debugging purposes.
+The information it displays is periodically polled from Kubernetes,
+and some intermediate states may not be represented in the timelines.
+</Typography>;
+
 // Separate component to assign key to the component, so that it will be re-mounted when runId changes
 export default function PodLifecycle(prop: PodLifecycleProps) {
     const { runId, setIsLoading, className } = prop;
@@ -37,14 +44,13 @@ export default function PodLifecycle(prop: PodLifecycleProps) {
     }, [loading, setIsLoading]);
 
     if (!value) return null;
-    if (value?.length === 0) return <Typography variant="body2">No pod history found.</Typography>;
+    if (value?.length === 0) return <>
+        {disclaimer}
+        <Typography variant="body2">No pod history found.</Typography>
+    </>;
 
     return <>
-        <Typography fontSize="small" color="GrayText" style={{ marginBottom: "1em" }}>
-      The information in this tab is provided for debugging purposes.
-      The information it displays is periodically polled from Kubernetes,
-      and some intermediate states may not be represented in the timelines.
-        </Typography>
+        {disclaimer}
         {value!.map(
             (job, index) =>
                 <Accordion key={index} defaultExpanded={index === value.length - 1} className={className}>


### PR DESCRIPTION
Fixes the following bugs:

Fixes #988 : Url hashes are now preserved
Fixes #990 : The allowed max zoom level is now increased. But the autofit zoom level is still clamped to ensure the text is visible.

The following picture showcases the maximum allowed zoom level. 
![image](https://github.com/sematic-ai/sematic/assets/133257643/7cc75c4b-f20e-463c-a8ac-897996a6ffb2)


Fixes #993 : Logs will start streaming whenever the state shifted from "CREATED" or "SCHEDULED". But if the run does not provide logs initially during the first pull, it is still up to the user to manually pull the logs.

![capture1](https://github.com/sematic-ai/sematic/assets/133257643/bb6d6cc0-d7be-4bff-a2d0-6044a8f10c5e)

Fixes #994: The menu item labels are renamed to "start from scratch" and "start from here".
Fixes #996: Disclaimer will show up regardless of whether there is pod history. 