### PR TITLE
Fix a bug and pin libs for fine-tuning

### DIFF
--- a/sematic/examples/summarization_finetune/requirements.txt
+++ b/sematic/examples/summarization_finetune/requirements.txt
@@ -1,11 +1,12 @@
-accelerate
+accelerate==0.19.0
 bitsandbytes
-datasets
+datasets==2.12.0
+gradio
 huggingface-hub
 # If training on linux, this dependency may be required.
 #nvidia-cusparse-cu11
-peft
+peft==0.3.0
 scipy
 torch<=2.0.0
-transformers
+transformers==4.29.2
 trl

--- a/sematic/examples/summarization_finetune/train_eval.py
+++ b/sematic/examples/summarization_finetune/train_eval.py
@@ -108,7 +108,7 @@ _FLAN_PROPS = ModelProperties(model_type=ModelType.seq_to_seq)
 _GPTJ_PROPS = ModelProperties(
     model_type=ModelType.causal,
     pad_token="eos_token",
-    device_map=None,
+    device_map="auto",
     load_in_8bit=True,
 )
 
@@ -428,7 +428,7 @@ def evaluate(
             dataset_config.max_output_length,
             eval_tokens[0],
         )
-        results.append(PromptResponse(sanitize(input_text[0]), sanitize(output_text)))
+        results.append(PromptResponse(sanitize(input_text), sanitize(output_text)))
     eval_results = EvaluationResults(results)
     return eval_results
 


### PR DESCRIPTION
It turns out that some library versions that have been released since this was created have broken some functionality. This pins the libs to working versions. There was also a bug introduced in the gradio refactor that made the prompt get truncated to only the first character. This fixes that.