### PR TITLE
Better error message for Ray cluster from non-standalone function

### DIFF
--- a/sematic/ee/tests/test_metrics.py
+++ b/sematic/ee/tests/test_metrics.py
@@ -27,7 +27,9 @@ from sematic.utils.exceptions import NotInSematicFuncError
 @mock.patch(
     "sematic.ee.metrics.context",
     return_value=SematicContext(
-        run_id="foo", root_id="bar", private=PrivateContext(runner_class_path="bat")
+        run_id="foo",
+        root_id="bar",
+        private=PrivateContext(runner_class_path="bat", is_standalone=True),
     ),
 )
 @mock.patch("sematic.ee.metrics._get_function_path", return_value="function_path")

--- a/sematic/future_context.py
+++ b/sematic/future_context.py
@@ -34,6 +34,7 @@ class PrivateContext:
     """
 
     runner_class_path: str
+    is_standalone: bool
     created_futures: List[AbstractFuture] = field(default_factory=list)
 
     def load_runner_class(self) -> Type[Runner]:

--- a/sematic/plugins/abstract_external_resource.py
+++ b/sematic/plugins/abstract_external_resource.py
@@ -457,3 +457,8 @@ class AbstractExternalResource(AbstractPlugin):
                 message=message,
             ),
         )
+
+    @classmethod
+    def cloud_requires_standalone(cls) -> bool:
+        """Indicate if CloudRunner should require wrapping functions to be standalone."""
+        return True

--- a/sematic/plugins/external_resource/timed_message.py
+++ b/sematic/plugins/external_resource/timed_message.py
@@ -160,3 +160,8 @@ class TimedMessage(AbstractExternalResource):
                 message="Nothing has changed...",
             ),
         )
+
+    @classmethod
+    def cloud_requires_standalone(cls) -> bool:
+        """Indicate if CloudRunner should require wrapping functions to be standalone."""
+        return False

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -90,7 +90,7 @@ def test_main(
             run_id=future.id,
             root_id=future.id,
             private=PrivateContext(
-                runner_class_path=CloudRunner.classpath(),
+                runner_class_path=CloudRunner.classpath(), is_standalone=True
             ),
         )
     )
@@ -174,7 +174,7 @@ def test_main_func(
             run_id=future.id,
             root_id=future.id,
             private=PrivateContext(
-                runner_class_path=CloudRunner.classpath(),
+                runner_class_path=CloudRunner.classpath(), is_standalone=True
             ),
         )
     )

--- a/sematic/resolvers/tests/test_worker.py
+++ b/sematic/resolvers/tests/test_worker.py
@@ -90,7 +90,7 @@ def test_main(
             run_id=future.id,
             root_id=future.id,
             private=PrivateContext(
-                runner_class_path=CloudRunner.classpath(), is_standalone=True
+                runner_class_path=CloudRunner.classpath(), is_standalone=False
             ),
         )
     )

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -196,7 +196,7 @@ def main(
                     run_id=run.id,
                     root_id=run.root_id,
                     private=PrivateContext(
-                        runner_class_path=CloudRunner.classpath(),
+                        runner_class_path=CloudRunner.classpath(), is_standalone=True
                     ),
                 )
             ):

--- a/sematic/runners/cloud_runner.py
+++ b/sematic/runners/cloud_runner.py
@@ -480,6 +480,9 @@ class CloudRunner(LocalRunner):
     def _do_resource_activate(
         cls, resource: AbstractExternalResource
     ) -> AbstractExternalResource:
+
+        # Raising the message here rather than from the server ensures the
+        # user gets the full message and trace in their logs and dashboard.
         if resource.cloud_requires_standalone() and not context().private.is_standalone:
             raise RuntimeError(
                 f"{resource.__class__.__name__} must be activated from a "

--- a/sematic/runners/cloud_runner.py
+++ b/sematic/runners/cloud_runner.py
@@ -480,7 +480,7 @@ class CloudRunner(LocalRunner):
     def _do_resource_activate(
         cls, resource: AbstractExternalResource
     ) -> AbstractExternalResource:
-        if not context().private.is_standalone:
+        if resource.cloud_requires_standalone() and not context().private.is_standalone:
             raise RuntimeError(
                 f"{resource.__class__.__name__} must be activated from a "
                 "standalone function."

--- a/sematic/runners/cloud_runner.py
+++ b/sematic/runners/cloud_runner.py
@@ -19,6 +19,7 @@ from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
 from sematic.db.models.resolution import PipelineRunKind, PipelineRunStatus
 from sematic.db.models.run import Run
+from sematic.future_context import context
 from sematic.graph import RerunMode
 from sematic.plugins.abstract_external_resource import AbstractExternalResource
 from sematic.runners.local_runner import LocalRunner, RunnerRestartError, make_edge_key
@@ -479,6 +480,11 @@ class CloudRunner(LocalRunner):
     def _do_resource_activate(
         cls, resource: AbstractExternalResource
     ) -> AbstractExternalResource:
+        if not context().private.is_standalone:
+            raise RuntimeError(
+                f"{resource.__class__.__name__} must be activated from a "
+                "standalone function."
+            )
         resource = api_client.activate_external_resource(resource.id)
         return resource
 

--- a/sematic/runners/silent_runner.py
+++ b/sematic/runners/silent_runner.py
@@ -52,6 +52,7 @@ class SilentRunner(StateMachineRunner):
                     root_id=self._root_future.id,
                     private=PrivateContext(
                         runner_class_path=self.classpath(),
+                        is_standalone=False,
                     ),
                 )
             ):

--- a/sematic/runners/tests/test_silent_runner.py
+++ b/sematic/runners/tests/test_silent_runner.py
@@ -212,7 +212,9 @@ def test_activation_failures_for_resource():
             SematicContext(
                 run_id=run_id,
                 root_id=root_id,
-                private=PrivateContext(runner_class_path=SilentRunner.classpath()),
+                private=PrivateContext(
+                    runner_class_path=SilentRunner.classpath(), is_standalone=False
+                ),
             )
         ):
             with FakeExternalResource(
@@ -231,7 +233,9 @@ def test_activation_failures_for_resource():
             SematicContext(
                 run_id=run_id,
                 root_id=root_id,
-                private=PrivateContext(runner_class_path=SilentRunner.classpath()),
+                private=PrivateContext(
+                    runner_class_path=SilentRunner.classpath(), is_standalone=False
+                ),
             )
         ):
             with FakeExternalResource(
@@ -258,7 +262,9 @@ def test_activation_timeout_for_resource():
             SematicContext(
                 run_id=run_id,
                 root_id=root_id,
-                private=PrivateContext(runner_class_path=SilentRunner.classpath()),
+                private=PrivateContext(
+                    runner_class_path=SilentRunner.classpath(), is_standalone=False
+                ),
             )
         ):
             started_activate = time.time()
@@ -281,7 +287,9 @@ def test_deactivation_timeout_for_resource():
             SematicContext(
                 run_id=run_id,
                 root_id=root_id,
-                private=PrivateContext(runner_class_path=SilentRunner.classpath()),
+                private=PrivateContext(
+                    runner_class_path=SilentRunner.classpath(), is_standalone=False
+                ),
             )
         ):
             started_activate = time.time()
@@ -307,7 +315,9 @@ def test_deactivation_failures_for_resource():
             SematicContext(
                 run_id=run_id,
                 root_id=root_id,
-                private=PrivateContext(runner_class_path=SilentRunner.classpath()),
+                private=PrivateContext(
+                    runner_class_path=SilentRunner.classpath(), is_standalone=False
+                ),
             )
         ):
             with FakeExternalResource(


### PR DESCRIPTION
Currently, if a user tries to create a Ray cluster from a non-standalone (aka inline) function, the message they get in the UI is something like "can't create manifest for Ray cluster." the server logs have more detail, showing a failure of the assert: `assert image_uri is not None  # please mypy`, which still leaves them very little information about what's going on. This PR changes it such that the message they get in the UI will be:

`sematic.utils.exceptions.ExternalResourceError: Could not activate resource with id 2b03efcfd1214d1480539151e3355818: RayCluster must be activated from a standalone function`. Furthermore, this kind of error message will be shown for other external resources that have a similar restriction that their cloud variants must use a standalone func (which is likely to be most of them).

Testing
--------

Ran `bazel run //sematic/examples/testing_pipeline:__main__ -- --cloud --detach --external-resource`, and confirmed that it passed. Then commented out the `cloud_requires_standalone` override in `TimedMessage` and executed again. Confirmed the user got the message `sematic.utils.exceptions.ExternalResourceError: Could not activate resource with id 2b03efcfd1214d1480539151e3355818: TimedMessage must be activated from a standalone function.` Ref [run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/7c8678cd490b4ea9a67f50ee740111c8#run=4feebeed4b8c481ead2e6d656fe9ba6a)