### PR TITLE
Extend retry delay

### DIFF
--- a/.circleci/retry
+++ b/.circleci/retry
@@ -8,6 +8,7 @@
 retry() {
     local -r -i max_attempts="$1"; shift
     local -i attempt_num=1
+    local -i delay=10
     until "$@"
     do
         if ((attempt_num==max_attempts))
@@ -15,8 +16,10 @@ retry() {
             echo "Attempt $attempt_num failed and there are no more attempts left!"
             return 1
         else
-            echo "Attempt $attempt_num failed! Trying again in $attempt_num seconds..."
-            sleep $((attempt_num++))
+            echo "Attempt $attempt_num failed! Trying again in $delay seconds..."
+            sleep $delay
+            $((attempt_num++))
+            delay=$((delay * 2))
         fi
     done
 }


### PR DESCRIPTION
CI sometimes still fails with too many consecutive retries for the ephemeral issues of downloading dependencies during pre-build. This PR increases the delay between tries so we give more time for the issue to resolve itself before trying again.