### PR TITLE
API capability of rerunning Pipelines with different Artifacts

### DIFF
--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -647,7 +647,7 @@ def test_rerun_resolution_endpoint_no_auth(
     assert None in edge_dict
     assert edge_dict[None].source_run_id == run.id
     assert edge_dict[None].destination_run_id is None
-    assert edge_dict[None].artifact_id == "output's artifact id"
+    assert edge_dict[None].artifact_id is None
 
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
@@ -689,29 +689,6 @@ def test_rerun_resolution_endpoint_auth_same_user(
         == persisted_resolution_w_user.root_id
     )
 
-    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
-
-    assert len(runs) == 1
-    assert runs[0].id == run.id
-
-    assert len(edges) == 3
-    edge_dict = {edge.destination_name: edge for edge in edges}
-
-    assert "a" in edge_dict
-    assert edge_dict["a"].source_run_id is None
-    assert edge_dict["a"].destination_run_id == run.id
-    assert edge_dict["a"].artifact_id == "param a's artifact id"
-
-    assert "b" in edge_dict
-    assert edge_dict["b"].source_run_id is None
-    assert edge_dict["b"].destination_run_id == run.id
-    assert edge_dict["b"].artifact_id == "param b's artifact id"
-
-    assert None in edge_dict
-    assert edge_dict[None].source_run_id == run.id
-    assert edge_dict[None].destination_run_id is None
-    assert edge_dict[None].artifact_id == "output's artifact id"
-
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
 def test_rerun_resolution_endpoint_auth_different_user(
@@ -752,29 +729,6 @@ def test_rerun_resolution_endpoint_auth_different_user(
         mock_schedule_resolution.call_args.kwargs["rerun_from"]
         == persisted_resolution_w_user.root_id
     )
-
-    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
-
-    assert len(runs) == 1
-    assert runs[0].id == run.id
-
-    assert len(edges) == 3
-    edge_dict = {edge.destination_name: edge for edge in edges}
-
-    assert "a" in edge_dict
-    assert edge_dict["a"].source_run_id is None
-    assert edge_dict["a"].destination_run_id == run.id
-    assert edge_dict["a"].artifact_id == "param a's artifact id"
-
-    assert "b" in edge_dict
-    assert edge_dict["b"].source_run_id is None
-    assert edge_dict["b"].destination_run_id == run.id
-    assert edge_dict["b"].artifact_id == "param b's artifact id"
-
-    assert None in edge_dict
-    assert edge_dict[None].source_run_id == run.id
-    assert edge_dict[None].destination_run_id is None
-    assert edge_dict[None].artifact_id == "output's artifact id"
 
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
@@ -889,7 +843,7 @@ def test_rerun_resolution_endpoint_artifact_override(
     assert None in edge_dict
     assert edge_dict[None].source_run_id == run.id
     assert edge_dict[None].destination_run_id is None
-    assert edge_dict[None].artifact_id == "output's artifact id"
+    assert edge_dict[None].artifact_id is None
 
 
 def test_list_external_resources_empty(

--- a/sematic/api/endpoints/tests/test_resolutions.py
+++ b/sematic/api/endpoints/tests/test_resolutions.py
@@ -37,6 +37,7 @@ from sematic.db.queries import (
     get_jobs_by_run_id,
     get_resolution,
     get_run,
+    get_run_graph,
     save_job,
     save_resolution,
     save_run,
@@ -625,6 +626,29 @@ def test_rerun_resolution_endpoint_no_auth(
         == persisted_resolution.root_id
     )
 
+    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
+
+    assert len(runs) == 1
+    assert runs[0].id == run.id
+
+    assert len(edges) == 3
+    edge_dict = {edge.destination_name: edge for edge in edges}
+
+    assert "a" in edge_dict
+    assert edge_dict["a"].source_run_id is None
+    assert edge_dict["a"].destination_run_id == run.id
+    assert edge_dict["a"].artifact_id == "param a's artifact id"
+
+    assert "b" in edge_dict
+    assert edge_dict["b"].source_run_id is None
+    assert edge_dict["b"].destination_run_id == run.id
+    assert edge_dict["b"].artifact_id == "param b's artifact id"
+
+    assert None in edge_dict
+    assert edge_dict[None].source_run_id == run.id
+    assert edge_dict[None].destination_run_id is None
+    assert edge_dict[None].artifact_id == "output's artifact id"
+
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
 def test_rerun_resolution_endpoint_auth_same_user(
@@ -664,6 +688,29 @@ def test_rerun_resolution_endpoint_auth_same_user(
         mock_schedule_resolution.call_args.kwargs["rerun_from"]
         == persisted_resolution_w_user.root_id
     )
+
+    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
+
+    assert len(runs) == 1
+    assert runs[0].id == run.id
+
+    assert len(edges) == 3
+    edge_dict = {edge.destination_name: edge for edge in edges}
+
+    assert "a" in edge_dict
+    assert edge_dict["a"].source_run_id is None
+    assert edge_dict["a"].destination_run_id == run.id
+    assert edge_dict["a"].artifact_id == "param a's artifact id"
+
+    assert "b" in edge_dict
+    assert edge_dict["b"].source_run_id is None
+    assert edge_dict["b"].destination_run_id == run.id
+    assert edge_dict["b"].artifact_id == "param b's artifact id"
+
+    assert None in edge_dict
+    assert edge_dict[None].source_run_id == run.id
+    assert edge_dict[None].destination_run_id is None
+    assert edge_dict[None].artifact_id == "output's artifact id"
 
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
@@ -706,6 +753,29 @@ def test_rerun_resolution_endpoint_auth_different_user(
         == persisted_resolution_w_user.root_id
     )
 
+    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
+
+    assert len(runs) == 1
+    assert runs[0].id == run.id
+
+    assert len(edges) == 3
+    edge_dict = {edge.destination_name: edge for edge in edges}
+
+    assert "a" in edge_dict
+    assert edge_dict["a"].source_run_id is None
+    assert edge_dict["a"].destination_run_id == run.id
+    assert edge_dict["a"].artifact_id == "param a's artifact id"
+
+    assert "b" in edge_dict
+    assert edge_dict["b"].source_run_id is None
+    assert edge_dict["b"].destination_run_id == run.id
+    assert edge_dict["b"].artifact_id == "param b's artifact id"
+
+    assert None in edge_dict
+    assert edge_dict[None].source_run_id == run.id
+    assert edge_dict[None].destination_run_id is None
+    assert edge_dict[None].artifact_id == "output's artifact id"
+
 
 @mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
 def test_rerun_resolution_endpoint_auth_no_user_fails(
@@ -723,6 +793,103 @@ def test_rerun_resolution_endpoint_auth_no_user_fails(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     mock_broadcast_update.assert_not_called()
+
+
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_corrupt_artifacts_override_fails(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution: Resolution,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution.root_id}/rerun",
+        json={"artifacts": "this should be a dict"},
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    mock_broadcast_update.assert_not_called()
+
+
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_exclusive_parameters_fails(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution: Resolution,  # noqa: F811
+    persisted_run: Run,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution.root_id}/rerun",
+        json={
+            "rerun_from": persisted_resolution.root_id,
+            "artifacts": {"a": "test id"},
+        },
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    mock_broadcast_update.assert_not_called()
+
+
+@mock.patch("sematic.api.endpoints.resolutions.broadcast_pipeline_update")
+def test_rerun_resolution_endpoint_artifact_override(
+    mock_broadcast_update: mock.MagicMock,
+    persisted_resolution: Resolution,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+    test_db,  # noqa: F811
+    mock_auth,  # noqa: F811
+    mock_schedule_resolution: mock.MagicMock,
+):
+    response = test_client.post(
+        f"/api/v1/resolutions/{persisted_resolution.root_id}/rerun",
+        json={"artifacts": {"a": "test id"}},
+    )
+    mock_broadcast_update.assert_called()
+
+    assert response.status_code == HTTPStatus.OK
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    cloned_resolution = get_resolution(payload["content"]["root_id"])
+
+    assert cloned_resolution.status == ResolutionStatus.SCHEDULED.value
+    assert cloned_resolution.user_id is None
+
+    run = get_run(cloned_resolution.root_id)  # noqa: F811
+
+    assert run.parent_id is None
+    assert run.future_state == FutureState.CREATED.value
+    assert run.user_id is None
+
+    mock_schedule_resolution.assert_called_once()
+
+    runs, _, edges = get_run_graph(run_id=cloned_resolution.root_id)
+
+    assert len(runs) == 1
+    assert runs[0].id == run.id
+
+    assert len(edges) == 3
+    edge_dict = {edge.destination_name: edge for edge in edges}
+
+    assert "a" in edge_dict
+    assert edge_dict["a"].source_run_id is None
+    assert edge_dict["a"].destination_run_id == run.id
+    assert edge_dict["a"].artifact_id == "test id"
+
+    assert "b" in edge_dict
+    assert edge_dict["b"].source_run_id is None
+    assert edge_dict["b"].destination_run_id == run.id
+    assert edge_dict["b"].artifact_id == "param b's artifact id"
+
+    assert None in edge_dict
+    assert edge_dict[None].source_run_id == run.id
+    assert edge_dict[None].destination_run_id is None
+    assert edge_dict[None].artifact_id == "output's artifact id"
 
 
 def test_list_external_resources_empty(

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -7,7 +7,7 @@ import enum
 import json
 import secrets
 from dataclasses import asdict, dataclass
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState, make_future_id
@@ -66,7 +66,9 @@ def make_run_from_future(future: AbstractFuture) -> Run:
     return run
 
 
-def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:
+def clone_root_run(
+    run: Run, edges: List[Edge], artifacts_override: Optional[Dict[str, str]] = None
+) -> Tuple[Run, List[Edge]]:
     """
     Clone a root run and its edges.
 
@@ -76,6 +78,11 @@ def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:
         Original run to clone.
     edges: List[Edge]
         Original run's input and output edges.
+    artifacts_override: Optional[Dict[str, str]]
+        A mapping between Function parameter names and Artifact ids. Used to overwrite the
+        original Run Artifact ids in the cloned Run, in order to produce reruns with
+        different input Artifacts. Defaults to None, meaning rerunning with the same
+        inputs.
 
     Returns
     -------
@@ -83,6 +90,8 @@ def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:
         A tuple whose first element is the cloned run, and the second element is
         the list of cloned edges.
     """
+    artifacts_override = artifacts_override or {}
+
     run_id = make_future_id()
     cloned_run = Run(
         id=run_id,
@@ -111,7 +120,9 @@ def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:
             destination_run_id=(run_id if edge.destination_run_id == run.id else None),
             source_run_id=(run_id if edge.source_run_id == run.id else None),
             destination_name=edge.destination_name,
-            artifact_id=edge.artifact_id,
+            artifact_id=artifacts_override.get(
+                edge.destination_name, edge.artifact_id  # type: ignore
+            ),
         )
         for edge in edges
     ]

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -120,8 +120,11 @@ def clone_root_run(
             destination_run_id=(run_id if edge.destination_run_id == run.id else None),
             source_run_id=(run_id if edge.source_run_id == run.id else None),
             destination_name=edge.destination_name,
-            artifact_id=artifacts_override.get(
-                edge.destination_name, edge.artifact_id  # type: ignore
+            artifact_id=(
+                artifacts_override.get(edge.destination_name, edge.artifact_id)
+                # the output artifact MUST be reset
+                if edge.destination_name is not None
+                else None
             ),
         )
         for edge in edges

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -193,7 +193,49 @@ def test_clone_root_run(run: Run):  # noqa: F811
 
     assert cloned_edges[2].destination_run_id is None
     assert cloned_edges[2].source_run_id == cloned_run.id
-    assert cloned_edges[2].artifact_id == "ghi789"
+    assert cloned_edges[2].artifact_id is None
+
+
+def test_clone_root_run_artifacts_override(run: Run):  # noqa: F811
+    edges = [
+        Edge(destination_run_id=run.id, destination_name="foo", artifact_id="abc123"),
+        Edge(destination_run_id=run.id, destination_name="bar", artifact_id="def456"),
+        Edge(source_run_id=run.id, artifact_id="ghi789"),
+    ]
+
+    cloned_run, cloned_edges = clone_root_run(
+        run=run, edges=edges, artifacts_override={"foo": "jkl123"}
+    )
+
+    assert cloned_run.id != run.id
+    assert cloned_run.root_id == cloned_run.id
+    assert cloned_run.future_state is FutureState.CREATED.value
+    assert cloned_run.name == run.name
+    assert cloned_run.function_path == run.function_path
+    assert cloned_run.parent_id is None
+    assert cloned_run.description is not None
+    assert cloned_run.description == run.description
+    assert cloned_run.tags == run.tags
+    assert cloned_run.source_code is not None
+    assert cloned_run.source_code == run.source_code
+    assert cloned_run.container_image_uri is not None
+    assert cloned_run.container_image_uri == run.container_image_uri
+    assert cloned_run.resource_requirements is not None
+    assert cloned_run.resource_requirements == run.resource_requirements
+
+    assert cloned_edges[0].destination_run_id == cloned_run.id
+    assert cloned_edges[0].source_run_id is None
+    assert cloned_edges[0].destination_name == "foo"
+    assert cloned_edges[0].artifact_id == "jkl123"
+
+    assert cloned_edges[1].destination_run_id == cloned_run.id
+    assert cloned_edges[1].source_run_id is None
+    assert cloned_edges[1].destination_name == "bar"
+    assert cloned_edges[1].artifact_id == "def456"
+
+    assert cloned_edges[2].destination_run_id is None
+    assert cloned_edges[2].source_run_id == cloned_run.id
+    assert cloned_edges[2].artifact_id is None
 
 
 def test_clone_resolution(resolution: Resolution):  # noqa: F811

--- a/sematic/db/tests/BUILD
+++ b/sematic/db/tests/BUILD
@@ -14,6 +14,7 @@ sematic_py_lib(
         "//sematic:abstract_future",
         "//sematic/db:db",
         "//sematic/db:queries",
+        "//sematic/db/models:edge",
         "//sematic/db/models:external_resource",
         "//sematic/db/models:factories",
         "//sematic/db/models:job",

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -65,6 +65,9 @@ INLINE_HELP = (
 )
 NESTED_HELP = "Whether to include nested functions in the pipeline. Defaults to False."
 NO_INPUT_HELP = "Whether to include a function that takes no input. Defaults to False."
+RANDOM_HELP = (
+    "Whether to include a function that adds a random number. Defaults to False."
+)
 SLEEP_HELP = (
     "If greater than zero, includes a function which sleeps for the specified number of "
     "seconds, logging a message every second. Defaults to 0."
@@ -244,6 +247,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--no-input", action="store_true", default=False, help=NO_INPUT_HELP
+    )
+    parser.add_argument(
+        "--random", action="store_true", default=False, help=RANDOM_HELP
     )
     parser.add_argument(
         "--sleep", type=int, default=0, dest="sleep_time", help=SLEEP_HELP

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -200,6 +200,17 @@ def add_fan_out(val: float, fan_out: int) -> float:
 
 
 @sematic.func(standalone=True)
+def add_random(a: float) -> float:
+    """
+    Adds a random integer between 0 and 10 to the specified number.
+    """
+    logger.info("Executing: add_random(a=%s)", a)
+    time.sleep(5)
+    b = int(random.random() * 11)
+    return a + b
+
+
+@sematic.func(standalone=True)
 def do_sleep(val: float, sleep_time: int) -> float:
     """
     Sleeps for the specified number of seconds, in 1-second stretches, logging an INFO
@@ -416,6 +427,7 @@ def testing_pipeline(
     inline: bool = False,
     nested: bool = False,
     no_input: bool = False,
+    random: bool = False,
     fan_out: int = 0,
     sleep_time: int = 0,
     spam_logs: int = 0,
@@ -447,6 +459,8 @@ def testing_pipeline(
         Whether to include nested functions in the pipeline. Defaults to False.
     no_input: bool
         Whether to include a function that takes no input. Defaults to False.
+    random: bool
+        Whether to include a function that adds a random number. Defaults to False.
     sleep_time: int
         If greater than zero, includes a function which sleeps for the specified number of
         seconds, logging a message every second. Defaults to 0.
@@ -524,6 +538,9 @@ def testing_pipeline(
 
     if no_input:
         futures.append(do_no_input())
+
+    if random:
+        futures.append(add_random(initial_future))
 
     if sleep_time > 0:
         futures.append(do_sleep(initial_future, sleep_time))


### PR DESCRIPTION
This PR add the ability to trigger a Pipeline rerun in the Server API with Artifact ID overrides for the root Run Function's input parameters. This results in the new Pipeline Run effectively executing on new input data.

The rationale is to support a scenario in which rapid bootstrapping of cloud Pipeline runs are necessary on different inputs. The same Worker container can be reused, without re-building it for each execution. The submitter would have to ensure the desired Artifacts exist in Sematic's database in order to specify an override.

There exist 2 API endpoints that trigger reruns: one which requires the Pipeline Run to already exist (used by the Runner), and one which does not (used by the Dashboard). This PR enhances only the latter one with this capability, as the desired supported scenario should not complicate the user with pre-creating a Pipeline Run fore the rerun, and because the Runner does not need to support this feature yet.

Implementation work on this feature also uncovered an existing undiscovered bug: once a Pipeline Run was completed successfully, then rerunning it from any point (not only from scratch) would always result in its rerun Pipeline Runs having the same output Artifact as the original Run, even if their business logic was non-deterministic. To give a real world example, this impacts the output of pipelines that perform model training.

This bug is fixed in the same PR by force-invalidating the output Artifact on the rerun Pipeline Run when cloning it from the original Pipeline Run.

## Testing

### Bug Fix

This PR introduces a new Testing Pipeline Function that adds a random number. To reproduce the bug we first use it to create [a base Pipeline Run](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/48dad71d96b84d33a2d63c82d94fa77b#tab=output):

```bash
$ bazel run sematic/examples/testing_pipeline/__main__ -- --cloud --detach --random
```

By re-running the [`add_random`](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/48dad71d96b84d33a2d63c82d94fa77b#tab=output&run=aedaf082299e4abe857732962477d0b3) from the Dashboard, we get different Pipeline Runs, which all have the same final output ([1](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/12bd145ea64f4bbaa045f41f49352f94#tab=output) ,[2](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/f19436ceb5d946c2b378ae4cfb6a2f2a#tab=output) ,[3](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/e8fca411de27452fbc8491576d5bd48a#tab=output)), even though their respective `add_random` Functions have different outputs ([1](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/12bd145ea64f4bbaa045f41f49352f94#tab=output&run=01d9b3d7616f4e788231f28c6d4b4e39), [2](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/f19436ceb5d946c2b378ae4cfb6a2f2a#tab=output&run=439985ebd8ae4a669df7a805d719080f), [3](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/e8fca411de27452fbc8491576d5bd48a#tab=output&run=c76c81b919344c79aff3c73a24558856)).

After applying the patch, a new set of reran Pipeline Runs have different, correct outputs ([1](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/2f22602746a34b679ba6a1d3712f2127#tab=output), [2](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/4b738b5e3d5c4ad09d82a748eef46ded#tab=output), [3](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/d5ebe8dce53f43fe8f3210d95c68d78e#tab=output)).

### Override Feature

Existing rerun unit / integration tests were updated to also validate Artifact metadata, and new tests were added for the new override logic.

```bash
$ bazel test //sematic/api/endpoints/tests:test_resolutions
$ bazel test //sematic/db/models/tests:test_factories
```

For a manual test, [this original Pipeline Run](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/574c51d8ceda4a368e201ccf1b8b9977#tab=input) has the expected values for its input Artifacts:

```bash
$ bazel run sematic/examples/add/__main__ -- --cloud --detach
```

<img width="1308" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/31b23627-2143-46e5-a89d-79430a861445">

It was reran with this call:
```bash
$ curl -d '{"artifacts": {"b": "2241eb13db0200520fbbb894a74b67c7fb765ac1"}}' \
    -X POST -H "Content-Type: application/json" \
    -H "X-API-KEY: XXX" \
    https://tudor.dev-usw2-sematic0.sematic.cloud/api/v1/resolutions/574c51d8ceda4a368e201ccf1b8b9977/rerun
```

And [the resulting Pipeline Run](https://tudor.dev-usw2-sematic0.sematic.cloud/runs/83d2afbc1eb84c8b9906236d57dfe672#tab=input) has a different value for the `"b"` input Artifact:

<img width="1310" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/6bf969cc-8508-43fd-9861-4be754807adf">

The Pipeline Run outputs are also different:

<img width="1312" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/e33b0972-8351-435a-ace7-02d14574adf7">

<img width="1312" alt="image" src="https://github.com/sematic-ai/sematic/assets/1894533/2685dbb0-1477-4ec8-87a9-c6fcdf934d33">
