### PR TITLE
Fixe a bug that could cause context menu missing.

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -17,6 +17,8 @@ import { useRootRunContext } from "src/context/RootRunContext";
 import { useRunDetailsSelectionContext } from "src/context/RunDetailsSelectionContext";
 import FunctionSectionActionMenu from "src/pages/RunDetails/contextMenus/FunctionSectionMenu";
 import theme from "src/theme/new";
+import useCounter from "react-use/lib/useCounter";
+import useLatest from "react-use/lib/useLatest";
 
 const StyledSection = styled(Section)`
     height: fit-content;
@@ -131,12 +133,22 @@ const FunctionSection = () => {
     }, [selectedRun]);
 
     const contextMenuAnchor = useRef<HTMLButtonElement>(null);
+    const latestAnchor = useLatest(contextMenuAnchor.current);
 
     useEffect(() => {
         if (!isGraphLoading) {
             setIsGraphLoaded(true);
         }
     }, [isGraphLoading]);
+    
+    const [counter, { inc }] = useCounter();
+
+    useEffect(() => {
+        // Re-render until the context menu anchor is set
+        if (!latestAnchor.current) {
+            inc();
+        }
+    }, [latestAnchor, counter, inc]);
 
     return <StyledSection>
         <Headline>Function Run</Headline>
@@ -160,7 +172,7 @@ const FunctionSection = () => {
                 : <ImportPath>{selectedRun?.function_path}</ImportPath>}
         </ImportPathContainer>
         <StyledVertButton ref={contextMenuAnchor} />
-        <FunctionSectionActionMenu anchorEl={contextMenuAnchor.current} />
+        <FunctionSectionActionMenu anchorEl={latestAnchor.current} />
         {!isGraphLoaded ? <MediumPlaceholderSkeleton />
             : <TagsContainer>
                 <div className={"tags-list-wrapper"} key={selectedRun?.id}><TagsList tags={selectedRun?.tags || []} /></div>


### PR DESCRIPTION
The moment when the "useRef" would be filled is unpredictable under certain scenarios. So this change aims to re-render until the reference become available before passing to the child component. 

A similar approach pre-existed in https://github.com/sematic-ai/sematic/blob/25e92ffba2f61a9bb679963a8ec6b4f087b3fb8c/sematic/ui/packages/common/src/pages/RunDetails/artifacts/artifact.tsx#L52-L59

Fixes #1035 