### PR TITLE
Make runner reentrant

### DIFF
--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -236,7 +236,6 @@ sematic_py_lib(
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",
         "//sematic/db/models:run",
-        "//sematic/resolvers:type_utils",
         "//sematic/utils:algorithms",
         "//sematic/utils:memoized_property",
     ],

--- a/sematic/db/models/BUILD
+++ b/sematic/db/models/BUILD
@@ -34,6 +34,7 @@ sematic_py_lib(
         ":user",
         "//sematic:abstract_future",
         "//sematic/scheduling:job_details",
+        "//sematic/resolvers:type_utils",
         "//sematic/types:serialization",
         "//sematic/types/types:union",
         "//sematic/utils:hashing",

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -7,7 +7,7 @@ import enum
 import json
 import secrets
 from dataclasses import asdict, dataclass
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Sematic
 from sematic.abstract_future import AbstractFuture, FutureState, make_future_id
@@ -19,6 +19,7 @@ from sematic.db.models.organization_user import OrganizationUser
 from sematic.db.models.resolution import Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.models.user import User
+from sematic.resolvers.type_utils import make_list_type, make_tuple_type
 from sematic.scheduling.job_details import JobDetails, JobKindString, JobStatus
 from sematic.types.serialization import (
     get_json_encodable_summary,
@@ -36,6 +37,8 @@ def make_run_from_future(future: AbstractFuture) -> Run:
     """
     Create a Run model instance from a future.
     """
+    # Note: when updating this you likely need to also update
+    # initialize_future_from_run below.
     run = Run(
         id=future.id,
         original_run_id=future.original_future_id,
@@ -64,6 +67,74 @@ def make_run_from_future(future: AbstractFuture) -> Run:
     run.resource_requirements = future.props.resource_requirements
 
     return run
+
+
+def initialize_future_from_run(
+    run: Run, kwargs: Dict[str, Any], use_same_id: bool = True
+) -> AbstractFuture:
+    """Initialize a future using corresponding properties in the run.
+
+    Only properties that are completely represented
+    in the run itself or its corresponding Sematic Function arguments will
+    be set. In particular, properties requiring access to a broader run graph
+    or external sources of information will NOT be updated by this function.
+    It is thus primarily useful in conjunction with something constructing
+    futures with access to a full run graph (ex: see graph.py).
+
+    A list (not necessarily exhaustive) of fields that will explicitly
+    NOT be updated on the future from the run, due to lack of broader
+    graph access or other listed reasons:
+
+    - resolved_kwargs: requires full graph access
+    - value: requires full graph access
+    - parent_future: requires full graph access
+    - nested_future: requires full graph access
+    - standalone: May be set by the run's function; see Issue #1032
+    - cache: May be set by the run's function; see Issue #1032
+    - timeout_mins: May be set by the run's function; see Issue #1032
+    - retry_settings: May be set by the run's function; see Issue #1032
+
+    Parameters
+    ----------
+    run:
+        The run to update properties from.
+    kwargs:
+        The keyword arguments for the future.
+    use_same_id:
+        Whether the new future should have the same id as the provided run.
+        Defaults to True.
+
+    Returns
+    -------
+    A future created from the given run.
+    """
+    # Note: when updating this you likely need to also update
+    # make_run_from_future above.
+    func = run.get_func()
+
+    # _make_list and _make_tuple need special treatment as they are not
+    # decorated functions, but factories that dynamically generate futures.
+    if run.function_path == "sematic.function._make_list":
+        # Dict values insertion order guaranteed as of Python 3.7
+        input_list = list(kwargs.values())
+        future = func(make_list_type(input_list), input_list)  # type: ignore
+    elif run.function_path == "sematic.function._make_tuple":
+        # Dict values insertion order guaranteed as of Python 3.7
+        input_tuple = tuple(kwargs.values())
+        future = func(make_tuple_type(input_tuple), input_tuple)  # type: ignore
+    else:
+        future = func(**kwargs)
+
+    if use_same_id:
+        future.id = run.id
+    future.props.name = run.name
+    future.props.tags = json.loads(str(run.tags))
+    future.props.state = run.future_state
+    future.props.resource_requirements = run.resource_requirements
+    if run.started_at is not None:
+        future.props.scheduled_epoch_time = run.started_at.timestamp()
+
+    return future
 
 
 def clone_root_run(run: Run, edges: List[Edge]) -> Tuple[Run, List[Edge]]:

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -129,7 +129,10 @@ def initialize_future_from_run(
         future.id = run.id
     future.props.name = run.name
     future.props.tags = json.loads(str(run.tags))
-    future.props.state = run.future_state
+    future_state = run.future_state
+    if isinstance(future_state, str):
+        future_state = FutureState[future_state]
+    future.props.state = future_state
     future.props.resource_requirements = run.resource_requirements
     if run.started_at is not None:
         future.props.scheduled_epoch_time = run.started_at.timestamp()

--- a/sematic/db/models/tests/test_factories.py
+++ b/sematic/db/models/tests/test_factories.py
@@ -2,6 +2,7 @@
 import hashlib
 import json
 import time
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
 # Third-party
@@ -13,6 +14,7 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import (
     clone_resolution,
     clone_root_run,
+    initialize_future_from_run,
     make_artifact,
     make_job,
     make_run_from_future,
@@ -45,6 +47,11 @@ def f():
     An informative docstring.
     """
     pass  # Some note
+
+
+@func
+def f2(a: int, b: int) -> int:
+    return a + b
 
 
 def test_make_run_from_future():
@@ -211,6 +218,57 @@ def test_clone_resolution(resolution: Resolution):  # noqa: F811
     assert cloned_resolution.user_id == resolution.user_id
     assert cloned_resolution.run_command == resolution.run_command
     assert cloned_resolution.build_config == resolution.build_config
+
+
+def test_initialize_future_from_run():
+    created_at = datetime(
+        year=2023, month=8, day=10, tzinfo=timezone(timedelta(hours=4))
+    )
+    run = Run(  # noqa: F811
+        id="theid",
+        original_run_id=None,
+        future_state=FutureState.RAN,
+        name="the name",
+        function_path=f"{f2.__module__}.{f2.__name__}",
+        parent_id="parentid",
+        root_id="rootid",
+        description="the description",
+        tags=["foo", "bar"],
+        nested_future_id="nestedid",
+        container_image_uri="imageuri",
+        created_at=created_at,
+        updated_at=created_at + timedelta(hours=2),
+        started_at=created_at + timedelta(hours=1),
+        ended_at=created_at + timedelta(2),
+        resolved_at=created_at + timedelta(2),
+        failed_at=None,
+        cache_key="cachekey",
+    )
+    requirements = ResourceRequirements(
+        kubernetes=KubernetesResourceRequirements(
+            node_selector={"foo": "bar"},
+        )
+    )
+    run.resource_requirements = requirements
+
+    kwargs = {"a": 1, "b": 2}
+    future = initialize_future_from_run(run, kwargs=kwargs, use_same_id=True)
+
+    assert future.id == run.id
+    assert future.function is f2
+    assert future.props.name == run.name
+    assert future.props.tags == json.loads(run.tags)  # type: ignore
+    assert future.props.state == FutureState[run.future_state]  # type: ignore
+    assert future.props.resource_requirements == requirements
+    assert future.props.scheduled_epoch_time == 1691614800
+    assert future.kwargs == kwargs
+
+    future2 = initialize_future_from_run(run, kwargs, use_same_id=False)
+    assert future2.id != future.id
+
+    run.function_path = "sematic.function._make_list"
+    future3 = initialize_future_from_run(run, kwargs={"v0": 0, "v1": 1})
+    assert future3.function.execute(**future3.kwargs) == [0, 1]
 
 
 def test_new():

--- a/sematic/db/tests/BUILD
+++ b/sematic/db/tests/BUILD
@@ -12,6 +12,7 @@ sematic_py_lib(
     # buildifier: leave-alone
     deps = [
         "//sematic:abstract_future",
+        "//sematic:function",
         "//sematic/db:db",
         "//sematic/db:queries",
         "//sematic/db/models:external_resource",

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -1,12 +1,16 @@
+# Standard Library
+import time
+
 # Sematic
 import sematic
 
 
-@sematic.func
+@sematic.func(standalone=True)
 def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
+    time.sleep(30)
     return a + b
 
 
@@ -33,6 +37,9 @@ def pipeline(a: float, b: float, c: float) -> float:
     `pretty_cool`.
     """
     sum1 = add(a, b)
-    sum2 = add(b, c)
-    sum3 = add(a, c)
-    return add3(sum1, sum2, sum3)
+    # sum2 = add(sum1, c)
+    # sum3 = add(sum2, 0)
+    # sum4 = add(sum3, 0)
+    # sum5 = add(sum4, 0)
+    # sum6 = add(sum5, 0)
+    return add3(0, 0, sum1)

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -1,16 +1,12 @@
-# Standard Library
-import time
-
 # Sematic
 import sematic
 
 
-@sematic.func(standalone=True)
+@sematic.func
 def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
-    time.sleep(30)
     return a + b
 
 
@@ -37,9 +33,6 @@ def pipeline(a: float, b: float, c: float) -> float:
     `pretty_cool`.
     """
     sum1 = add(a, b)
-    # sum2 = add(sum1, c)
-    # sum3 = add(sum2, 0)
-    # sum4 = add(sum3, 0)
-    # sum5 = add(sum4, 0)
-    # sum6 = add(sum5, 0)
-    return add3(0, 0, sum1)
+    sum2 = add(b, c)
+    sum3 = add(a, c)
+    return add3(sum1, sum2, sum3)

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -1,3 +1,6 @@
+# Standard Library
+import time
+
 # Sematic
 import sematic
 
@@ -7,6 +10,7 @@ def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
+    time.sleep(3)
     return a + b
 
 
@@ -16,6 +20,16 @@ def add3(a: float, b: float, c: float) -> float:
     Adds three numbers.
     """
     return add(add(a, b), c)
+
+
+@sematic.func
+def chain(a: float) -> float:
+    x = add(0, a)
+    x = add(0, x)
+    x = add(0, x)
+    x = add(0, x)
+    x = add(0, x)
+    return x
 
 
 @sematic.func
@@ -32,7 +46,8 @@ def pipeline(a: float, b: float, c: float) -> float:
 
     `pretty_cool`.
     """
-    sum1 = add(a, b)
-    sum2 = add(b, c)
-    sum3 = add(a, c)
-    return add3(sum1, sum2, sum3)
+    return chain(a)
+    # sum1 = add(a, b)
+    # sum2 = add(b, c)
+    # sum3 = add(a, c)
+    # return add3(sum1, sum2, sum3)

--- a/sematic/examples/add/pipeline.py
+++ b/sematic/examples/add/pipeline.py
@@ -1,6 +1,3 @@
-# Standard Library
-import time
-
 # Sematic
 import sematic
 
@@ -10,7 +7,6 @@ def add(a: float, b: float) -> float:
     """
     Adds two numbers.
     """
-    time.sleep(3)
     return a + b
 
 
@@ -20,16 +16,6 @@ def add3(a: float, b: float, c: float) -> float:
     Adds three numbers.
     """
     return add(add(a, b), c)
-
-
-@sematic.func
-def chain(a: float) -> float:
-    x = add(0, a)
-    x = add(0, x)
-    x = add(0, x)
-    x = add(0, x)
-    x = add(0, x)
-    return x
 
 
 @sematic.func
@@ -46,8 +32,7 @@ def pipeline(a: float, b: float, c: float) -> float:
 
     `pretty_cool`.
     """
-    return chain(a)
-    # sum1 = add(a, b)
-    # sum2 = add(b, c)
-    # sum3 = add(a, c)
-    # return add3(sum1, sum2, sum3)
+    sum1 = add(a, b)
+    sum2 = add(b, c)
+    sum3 = add(a, c)
+    return add3(sum1, sum2, sum3)

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -34,12 +34,20 @@ class RerunMode(Enum):
         whatever runs are required to determine the final result of the
         graph.
     CONTINUE:
-        Execute only runs that are required to determine the final
+        Clone the state of the provided pipeline run, then
+        execute only runs that are required to determine the final
         result of the graph.
+    REENTER:
+        Attempt to recreate an existing future graph in memory
+        and pick up where it was left off. This differs from
+        CONTINUE in that CONTINUE represents an entirely new
+        graph (cloned from an original), while REENTER uses
+        the existing graph.
     """
 
     SPECIFIC_RUN = "SPECIFIC_RUN"
     CONTINUE = "CONTINUE"
+    REENTER = "REENTER"
 
 
 @dataclass

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -688,7 +688,7 @@ class Graph:
         return cloned_graph
 
     def to_future_graph(self) -> FutureGraph:
-        """Convert this `Run` graph into a corresponding graph of `Future`s
+        """Convert this `Run` graph into a corresponding graph of `Future`s.
 
         The future graph will use all the same ids as the runs.
         """

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -47,6 +47,8 @@ class RerunMode(Enum):
 
     SPECIFIC_RUN = "SPECIFIC_RUN"
     CONTINUE = "CONTINUE"
+
+    # We keep CONTINUE as distinct because it can still be used to rerun from failed.
     REENTER = "REENTER"
 
 

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -688,6 +688,10 @@ class Graph:
         return cloned_graph
 
     def to_future_graph(self) -> FutureGraph:
+        """Convert this `Run` graph into a corresponding graph of `Future`s
+
+        The future graph will use all the same ids as the runs.
+        """
         future_graph = FutureGraph()
 
         # run order guarantees parents and upstream come first

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -52,9 +52,28 @@ class RerunMode(Enum):
 
 @dataclass
 class FutureGraph:
-    """A graph of futures and their associated artifacts."""
+    """A graph of futures and their associated artifacts.
 
-    futures_by_id: OrderedDictType[RunID, AbstractFuture] = field(
+    Attributes
+    ----------
+    futures_by_run_id:
+        A dictionary of futures stored using the id of a corresponding run.
+        This can be the id of the future itself, or potentially a run that
+        the future was derived from.
+    input_artifacts:
+        A dictionary mapping a run id to the input artifacts for that run.
+        The input artifacts for a given run will itself be a dictionary from
+        the name of the input parameter for the run to the Artifact object
+        that should be used as its input. The graph may be in a partially
+        executed state, in which case not all runs may have known input
+        artifacts.
+    output_artifacts:
+        A dictionary mapping run ids to the Artifact object resulting from
+        that run. The graph may be in a partially executed state, in which
+        case not all runs will have known output artifacts.
+    """
+
+    futures_by_run_id: OrderedDictType[RunID, AbstractFuture] = field(
         init=False, default_factory=OrderedDict
     )
     input_artifacts: Dict[RunID, Dict[str, Artifact]] = field(
@@ -66,12 +85,12 @@ class FutureGraph:
         """Sort futures in-place according to the order of run_ids."""
         ordered_futures = OrderedDict(
             (
-                (run_id, self.futures_by_id[run_id])
+                (run_id, self.futures_by_run_id[run_id])
                 for run_id in run_ids
-                if run_id in self.futures_by_id
+                if run_id in self.futures_by_run_id
             )
         )
-        self.futures_by_id = ordered_futures
+        self.futures_by_run_id = ordered_futures
 
 
 @dataclass
@@ -79,23 +98,16 @@ class ClonedFutureGraph(FutureGraph):
     """
     A cloned future graph. This graph is potentially partial, as it is meant to
     be used as a resolution seed.
+
+    Its futures_by_run_id field maps the id of a run to the future cloned from that
+    run.
     """
-
-    @property
-    def futures_by_original_id(self) -> OrderedDictType[RunID, AbstractFuture]:
-        return self.futures_by_id
-
-    @futures_by_original_id.setter
-    def futures_by_original_id(
-        self, futures_by_id: OrderedDictType[RunID, AbstractFuture]
-    ) -> None:
-        self.futures_by_id = futures_by_id
 
     def set_root_future_id(self, root_id: str):
         """Update the id of the root future in this graph to match the passed one."""
         root_future = next(
             future
-            for future in self.futures_by_original_id.values()
+            for future in self.futures_by_run_id.values()
             if future.is_root_future()
         )
 
@@ -477,7 +489,7 @@ class Graph:
             if input_edge.source_run_id is not None:
                 # We set the input as the upstream future to mimick what
                 # happens in a greenfield resolution.
-                kwargs[input_edge.destination_name] = future_graph.futures_by_id[
+                kwargs[input_edge.destination_name] = future_graph.futures_by_run_id[
                     input_edge.source_run_id
                 ]
 
@@ -531,7 +543,7 @@ class Graph:
         if run.parent_id is None:
             return
 
-        parent_future = future_graph.futures_by_id[run.parent_id]
+        parent_future = future_graph.futures_by_run_id[run.parent_id]
 
         future.parent_future = parent_future
 
@@ -567,7 +579,7 @@ class Graph:
             run.parent_id is not None
             and self._runs_by_id[run.parent_id].nested_future_id == run.id
         ):
-            parent_future = cloned_graph.futures_by_original_id[run.parent_id]
+            parent_future = cloned_graph.futures_by_run_id[run.parent_id]
             if run.id in reset_run_ids:
                 parent_future.state = FutureState.RAN
 
@@ -655,11 +667,11 @@ class Graph:
             if run_id in skip_run_ids:
                 continue
 
-            cloned_graph.futures_by_original_id[run_id] = self._clone_future(
+            cloned_graph.futures_by_run_id[run_id] = self._clone_future(
                 run_id, cloned_graph, reset_run_ids
             )
 
-        if reset_from is None and len(cloned_graph.futures_by_original_id) != len(
+        if reset_from is None and len(cloned_graph.futures_by_run_id) != len(
             list(self.runs)
         ):
             raise RuntimeError("Not all futures duplicated")
@@ -687,11 +699,11 @@ class Graph:
         )
 
         for run_id in run_ids_by_execution_order:
-            future_graph.futures_by_id[run_id] = self._future_from_run(
+            future_graph.futures_by_run_id[run_id] = self._future_from_run(
                 run_id, future_graph
             )
 
-        if len(future_graph.futures_by_id) != len(list(self.runs)):
+        if len(future_graph.futures_by_run_id) != len(list(self.runs)):
             raise RuntimeError("Not all futures duplicated")
 
         # We return future sorted by how they would be sorted for a resolution

--- a/sematic/graph.py
+++ b/sematic/graph.py
@@ -1,5 +1,4 @@
 # Standard Library
-import json
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, unique
@@ -12,8 +11,8 @@ import sematic.api_client as api_client
 from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.db.models.artifact import Artifact
 from sematic.db.models.edge import Edge
+from sematic.db.models.factories import initialize_future_from_run
 from sematic.db.models.run import Run
-from sematic.resolvers.type_utils import make_list_type, make_tuple_type
 from sematic.utils.algorithms import breadth_first_search, topological_sort
 from sematic.utils.memoized_property import memoized_indexed, memoized_property
 
@@ -44,13 +43,10 @@ class RerunMode(Enum):
 
 
 @dataclass
-class ClonedFutureGraph:
-    """
-    A cloned future graph. This graph is potentially partial, as it is meant to
-    be used as a resolution seed.
-    """
+class FutureGraph:
+    """A graph of futures and their associated artifacts."""
 
-    futures_by_original_id: OrderedDictType[RunID, AbstractFuture] = field(
+    futures_by_id: OrderedDictType[RunID, AbstractFuture] = field(
         init=False, default_factory=OrderedDict
     )
     input_artifacts: Dict[RunID, Dict[str, Artifact]] = field(
@@ -59,22 +55,36 @@ class ClonedFutureGraph:
     output_artifacts: Dict[RunID, Artifact] = field(init=False, default_factory=dict)
 
     def sort_by(self, run_ids: List[RunID]):
-        """
-        Sort futures according to the order of run_ids.
-        """
+        """Sort futures in-place according to the order of run_ids."""
         ordered_futures = OrderedDict(
             (
-                (run_id, self.futures_by_original_id[run_id])
+                (run_id, self.futures_by_id[run_id])
                 for run_id in run_ids
-                if run_id in self.futures_by_original_id
+                if run_id in self.futures_by_id
             )
         )
-        self.futures_by_original_id = ordered_futures
+        self.futures_by_id = ordered_futures
+
+
+@dataclass
+class ClonedFutureGraph(FutureGraph):
+    """
+    A cloned future graph. This graph is potentially partial, as it is meant to
+    be used as a resolution seed.
+    """
+
+    @property
+    def futures_by_original_id(self) -> OrderedDictType[RunID, AbstractFuture]:
+        return self.futures_by_id
+
+    @futures_by_original_id.setter
+    def futures_by_original_id(
+        self, futures_by_id: OrderedDictType[RunID, AbstractFuture]
+    ) -> None:
+        self.futures_by_id = futures_by_id
 
     def set_root_future_id(self, root_id: str):
-        """
-        Set the root future ID
-        """
+        """Update the id of the root future in this graph to match the passed one."""
         root_future = next(
             future
             for future in self.futures_by_original_id.values()
@@ -436,8 +446,8 @@ class Graph:
         artifact = self._artifacts_by_id[artifact_id]
         return api_client.get_artifact_value(artifact)
 
-    def _get_cloned_future_inputs(
-        self, run_id: RunID, cloned_graph: ClonedFutureGraph
+    def _get_future_inputs(
+        self, run_id: RunID, future_graph: FutureGraph
     ) -> Tuple[Dict[str, Any], Dict[str, Artifact]]:
         kwargs: Dict[str, Any] = {}
 
@@ -459,9 +469,9 @@ class Graph:
             if input_edge.source_run_id is not None:
                 # We set the input as the upstream future to mimick what
                 # happens in a greenfield resolution.
-                kwargs[
-                    input_edge.destination_name
-                ] = cloned_graph.futures_by_original_id[input_edge.source_run_id]
+                kwargs[input_edge.destination_name] = future_graph.futures_by_id[
+                    input_edge.source_run_id
+                ]
 
             elif input_edge.artifact_id is not None:
                 kwargs[input_edge.destination_name] = value
@@ -485,17 +495,35 @@ class Graph:
 
         return None, None
 
-    def _set_cloned_parent_future(
+    def _set_parent_future_using_run(
         self,
         future: AbstractFuture,
         run: Run,
-        cloned_graph: ClonedFutureGraph,
-        reset_run_ids: List[RunID],
-    ):
+        future_graph: FutureGraph,
+    ) -> None:
+        """Use this run graph and provided run to set the parent future in future_graph.
+
+        To be used in the process of constructing a FutureGraph from this run graph
+        (potentially as a cloned future graph). This method will update futures in
+        future_graph in-place.
+
+        The parent run of the provided run will be used to identify the appropriate
+        parent future for the provided future. The provided future and its parent
+        future will be modified as necessary.
+
+        Parameters
+        ----------
+        future:
+           The future whose parent should be updated.
+        run:
+            The run to be used as a reference to update the future's parent.
+        future_graph:
+            The future graph being constructed.
+        """
         if run.parent_id is None:
             return
 
-        parent_future = cloned_graph.futures_by_original_id[run.parent_id]
+        parent_future = future_graph.futures_by_id[run.parent_id]
 
         future.parent_future = parent_future
 
@@ -503,37 +531,18 @@ class Graph:
         if self._runs_by_id[run.parent_id].nested_future_id == run.id:
             parent_future.nested_future = future
 
-            if run.id in reset_run_ids:
-                parent_future.state = FutureState.RAN
-
     def _clone_future(
         self, run_id: RunID, cloned_graph: ClonedFutureGraph, reset_run_ids: List[RunID]
     ) -> AbstractFuture:
         run = self._runs_by_id[run_id]
 
-        kwargs, run_input_artifacts = self._get_cloned_future_inputs(
-            run_id, cloned_graph
-        )
+        kwargs, run_input_artifacts = self._get_future_inputs(run_id, cloned_graph)
 
-        func = run.get_func()
+        future = initialize_future_from_run(run, kwargs, use_same_id=False)
 
-        # _make_list and _make_tuple need special treatment as they are not
-        # decorated functions, but factories that dynamically generate futures.
-        if run.function_path == "sematic.function._make_list":
-            # Dict values insertion order guaranteed as of Python 3.7
-            input_list = list(kwargs.values())
-            future = func(make_list_type(input_list), input_list)  # type: ignore
-        elif run.function_path == "sematic.function._make_tuple":
-            # Dict values insertion order guaranteed as of Python 3.7
-            input_tuple = tuple(kwargs.values())
-            future = func(make_tuple_type(input_tuple), input_tuple)  # type: ignore
-        else:
-            future = func(**kwargs)
-
-        future.name = run.name
-
-        future.props.name = run.name
-        future.props.tags = json.loads(str(run.tags))
+        # For cloning a graph, we want the default state of the future to be
+        # created unless explicitly updated to a different value.
+        future.props.state = FutureState.CREATED
 
         cloned_graph.input_artifacts[future.id] = run_input_artifacts
 
@@ -543,7 +552,16 @@ class Graph:
                 cloned_graph.output_artifacts[future.id] = output_artifact
                 future.value = value
 
-        self._set_cloned_parent_future(future, run, cloned_graph, reset_run_ids)
+        self._set_parent_future_using_run(future, run, cloned_graph)
+
+        # Is future parent_future's nested future?
+        if (
+            run.parent_id is not None
+            and self._runs_by_id[run.parent_id].nested_future_id == run.id
+        ):
+            parent_future = cloned_graph.futures_by_original_id[run.parent_id]
+            if run.id in reset_run_ids:
+                parent_future.state = FutureState.RAN
 
         # Settings state for resolved runs unless reset
         if FutureState[run.future_state] == FutureState.RESOLVED:  # type: ignore
@@ -553,6 +571,24 @@ class Graph:
                 future.original_future_id = (
                     run.original_run_id if run.original_run_id is not None else run_id
                 )
+
+        return future
+
+    def _future_from_run(
+        self, run_id: RunID, future_graph: FutureGraph
+    ) -> AbstractFuture:
+        run = self._runs_by_id[run_id]
+        kwargs, run_input_artifacts = self._get_future_inputs(run_id, future_graph)
+
+        future = initialize_future_from_run(run, kwargs)
+        future_graph.input_artifacts[future.id] = run_input_artifacts
+
+        value, output_artifact = self._get_run_output(run_id)
+        if output_artifact is not None:
+            future_graph.output_artifacts[future.id] = output_artifact
+            future.value = value
+
+        self._set_parent_future_using_run(future, run, future_graph)
 
         return future
 
@@ -630,3 +666,33 @@ class Graph:
         cloned_graph.sort_by(run_ids_by_reverse_execution_order)
 
         return cloned_graph
+
+    def to_future_graph(self) -> FutureGraph:
+        future_graph = FutureGraph()
+
+        # run order guarantees parents and upstream come first
+        # This is necessary because we want upstream futures
+        # to be created before downstreams so that the appropriate
+        # kwargs can be built
+        run_ids_by_execution_order = self._sorted_run_ids_by_layer(
+            run_sorter=self._execution_order
+        )
+
+        for run_id in run_ids_by_execution_order:
+            future_graph.futures_by_id[run_id] = self._future_from_run(
+                run_id, future_graph
+            )
+
+        if len(future_graph.futures_by_id) != len(list(self.runs)):
+            raise RuntimeError("Not all futures duplicated")
+
+        # We return future sorted by how they would be sorted for a resolution
+        # from scratch: grouped by layer (outermost first), and sorter in reverse
+        # execution order within each layer
+        run_ids_by_reverse_execution_order = self._sorted_run_ids_by_layer(
+            run_sorter=self._reverse_execution_order
+        )
+
+        future_graph.sort_by(run_ids_by_reverse_execution_order)
+
+        return future_graph

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -92,6 +92,8 @@ sematic_py_lib(
         "//sematic/db/models:artifact",
         "//sematic/db/models:edge",
         "//sematic/db/models:factories",
+        "//sematic/db/models:run",
+        "//sematic/db/models:resolution",
         "//sematic/runners:cloud_runner",
         "//sematic/runners:local_runner",
         "//sematic/scheduling:job_details",

--- a/sematic/runners/cloud_runner.py
+++ b/sematic/runners/cloud_runner.py
@@ -334,7 +334,7 @@ class CloudRunner(LocalRunner):
         else:
             output_edge = self._get_output_edges(run.id)[0]
 
-            # Pleasing mymy
+            # Pleasing mypy
             if output_edge.artifact_id is None:
                 raise RuntimeError("Missing output artifact")
 

--- a/sematic/runners/cloud_runner.py
+++ b/sematic/runners/cloud_runner.py
@@ -9,7 +9,7 @@ import cloudpickle
 
 # Sematic
 import sematic.api_client as api_client
-from sematic.abstract_future import AbstractFuture, FutureState, clone_future
+from sematic.abstract_future import AbstractFuture, FutureState
 from sematic.container_images import (
     DEFAULT_BASE_IMAGE_TAG,
     MissingContainerImage,
@@ -20,9 +20,8 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.resolution import PipelineRunKind, PipelineRunStatus
 from sematic.db.models.run import Run
 from sematic.future_context import context
-from sematic.graph import RerunMode
 from sematic.plugins.abstract_external_resource import AbstractExternalResource
-from sematic.runners.local_runner import LocalRunner, RunnerRestartError, make_edge_key
+from sematic.runners.local_runner import LocalRunner, make_edge_key
 from sematic.utils.exceptions import format_exception_for_run
 from sematic.utils.memoized_property import memoized_property
 
@@ -75,13 +74,29 @@ class CloudRunner(LocalRunner):
         that runs that are in the RAN state do not contribute to the limit,
         since they do not consume computing resources.
     rerun_from: Optional[str]
-        When `None`, the pipeline is executed from scratch, as normally. When
-        not `None`, must be the id of a `Run` from a previous pipeline run.
-        Instead of running from scratch, parts of that previous pipeline run is
-        cloned up until the specified `Run`, and only the specified `Run`,
-        nested and downstream `Future`s are executed. This is meant to be used
-        for retries or for hotfixes, without needing to re-run the entire
-        pipeline again.
+        When `None`, the pipeline is executed from scratch, as normally. When not `None`,
+        must be the id of a `Run` from a previous pipeline run. The nature of the rerun
+        when an id is specified will depend on the `rerun_mode` parameter.
+    rerun_mode: RerunMode
+        This option is only used when `rerun_from` has been given a run id.
+        If set to
+        `RerunMode.SPECIFIC_RUN` (the default):
+            Instead of running from scratch, parts of that previous
+            pipeline run will be cloned up until the specific `Run`, and only the
+            specified `Run`, nested and downstream `Future`s will be executed.
+            This is meant to be used for retries or for hotfixes, without needing to
+            re-run the entire pipeline again.
+        `RerunMode.CONTINUE`:
+            In this case, the run id passed to rerun_from must be the root id of a
+            pipeline run. The new pipeline run will use any available results from the
+            old one and only execute what is necessary to determine the final result.
+            The new pipeline run will use a NEW future graph, cloned from the old one.
+        `RerunMode.REENTER`:
+            In this case, the run id passed to rerun_from must be the root id of the
+            pipeline run. The new pipeline run will use any available results from the
+            old one and only execute what is necessary to determine the final result.
+            The new pipeline run will use the EXISTING future graph, recreated from
+            the runs in the DB.
     _is_running_remotely: bool
         For Sematic internal usage. End users should always leave this at the
         default value of `False`.
@@ -328,35 +343,6 @@ class CloudRunner(LocalRunner):
             value = api_client.get_artifact_value(output_artifact)
 
         self._update_future_with_value(future, value)
-
-    def _pipeline_run_did_fail(
-        self, error: Exception, reason: Optional[str] = None
-    ) -> None:
-        if not isinstance(error, RunnerRestartError):
-            super()._pipeline_run_did_fail(error)
-            return
-
-        try:
-            new_root_future = clone_future(self._root_future)
-            new_runner = self.__class__(
-                cache_namespace=self._cache_namespace_str,
-                rerun_from=self._root_future.id,
-                rerun_mode=RerunMode.CONTINUE,
-                detach=True,
-                max_parallelism=self._max_parallelism,
-                _base_image_tag=self._base_image_tag,
-            )
-            new_runner._git_info = api_client.get_pipeline_run(
-                self._root_future.id
-            ).git_info
-            new_runner.run(new_root_future)
-            reason = (
-                f"Pipeline Run restarted mid-execution. A new one has been started "
-                f"with the id {new_root_future.id}"
-            )
-            logger.error(reason)
-        finally:
-            super()._pipeline_run_did_fail(error, reason)
 
     def _future_did_fail(self, failed_future: AbstractFuture) -> None:
         # Unlike LocalRunner._future_did_fail, we only care about

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -27,7 +27,7 @@ from sematic.db.models.factories import make_artifact, make_run_from_future
 from sematic.db.models.git_info import GitInfo
 from sematic.db.models.resolution import PipelineRun, PipelineRunKind, PipelineRunStatus
 from sematic.db.models.run import Run
-from sematic.graph import Graph, RerunMode
+from sematic.graph import FutureGraph, Graph, RerunMode
 from sematic.plugins.abstract_builder import get_build_config, get_run_command
 from sematic.resolvers.resource_managers.server_manager import ServerResourceManager
 from sematic.runners.silent_runner import SilentRunner
@@ -74,6 +74,13 @@ class LocalRunner(SilentRunner):
             In this case, the run id passed to rerun_from must be the root id of a
             pipeline run. The new pipeline run will use any available results from the
             old one and only execute what is necessary to determine the final result.
+            The new pipeline run will use a NEW future graph, cloned from the old one.
+        `RerunMode.REENTER`:
+            In this case, the run id passed to rerun_from must be the root id of the
+            pipeline run. The new pipeline run will use any available results from the
+            old one and only execute what is necessary to determine the final result.
+            The new pipeline run will use the EXISTING future graph, recreated from
+            the runs in the DB.
     """
 
     _resource_manager: Optional[ServerResourceManager] = None  # type: ignore
@@ -122,14 +129,16 @@ class LocalRunner(SilentRunner):
         if self._rerun_from_run_id is None:
             super()._seed_graph(future)
         else:
-            self._seed_from_clone(future, self._rerun_from_run_id, self._rerun_mode)
+            self._seed_from_existing(future, self._rerun_from_run_id, self._rerun_mode)
 
-    def _seed_from_clone(
+    def _seed_from_existing(
         self, future: AbstractFuture, from_run_id: str, rerun_mode: Optional[RerunMode]
     ):
         """
         Instead of simply queuing the root future, this method seeds the future graph
-        from a clone of another execution of same pipeline.
+        from an existing execution. This execution may be another execution of
+        same pipeline, or it may be the same execution of that pipeline that originated
+        from an earlier runner pod (if the runner pod has restarted).
         """
         rerun_mode = rerun_mode or RerunMode.SPECIFIC_RUN
 
@@ -142,6 +151,12 @@ class LocalRunner(SilentRunner):
 
         if rerun_mode is RerunMode.CONTINUE and run.id != run.root_id:
             raise ValueError("Cannot use RerunMode.CONTINUE with a non-root run.")
+        elif rerun_mode is RerunMode.REENTER and run.id != future.id:
+            raise ValueError(
+                f"Seeding from the DB for a reentered runner requires that "
+                f"The root future id ('{future.id}') must match the rerun id "
+                f"('{run.id}')."
+            )
 
         runs, artifacts, edges = api_client.get_graph(run.root_id, root=True)
 
@@ -158,17 +173,23 @@ class LocalRunner(SilentRunner):
 
         logger.info(f"Attempting to rerun from {from_run_id}")
 
+        is_clone = False
         if rerun_mode is RerunMode.SPECIFIC_RUN:
-            cloned_graph = graph.clone_futures(
+            future_graph: FutureGraph = graph.clone_futures(
                 reset_from=from_run_id,
             )
+            is_clone = True
+        elif rerun_mode is RerunMode.CONTINUE:
+            future_graph = graph.clone_futures()
+            is_clone = True
         else:
-            cloned_graph = graph.clone_futures()
+            future_graph = graph.to_future_graph()
 
-        # Making sure we honor id of future passed from the outside
-        cloned_graph.set_root_future_id(future.id)
+        if is_clone:
+            # Making sure we honor id of future passed from the outside
+            future_graph.set_root_future_id(future.id)  # type: ignore
 
-        self._futures = list(cloned_graph.futures_by_original_id.values())
+        self._futures = list(future_graph.futures_by_id.values())
 
         # This is necessary, otherwise the root run will not be updated with its
         # cloned status. In detached execution, or rerun, the root run is
@@ -182,13 +203,16 @@ class LocalRunner(SilentRunner):
             if future.state == FutureState.RESOLVED:
                 self._artifacts_by_run_id[future.id][
                     None
-                ] = cloned_graph.output_artifacts[future.id]
+                ] = future_graph.output_artifacts[future.id]
 
             if future.state in {FutureState.RESOLVED, FutureState.RAN}:
-                for name, artifact in cloned_graph.input_artifacts[future.id].items():
+                for name, artifact in future_graph.input_artifacts[future.id].items():
                     self._artifacts_by_run_id[future.id][name] = artifact
 
-            self._populate_graph(future)
+            if is_clone:
+                self._populate_graph_from_future(future)
+            else:
+                self._populate_graph_from_objects(runs, artifacts, edges)
 
         self._save_graph()
 
@@ -248,7 +272,7 @@ class LocalRunner(SilentRunner):
         if len(future.kwargs) != len(future.resolved_kwargs):
             raise RuntimeError("Not all input arguments are concrete")
 
-        run = self._populate_graph(future)
+        run = self._populate_graph_from_future(future)
 
         return run
 
@@ -295,7 +319,8 @@ class LocalRunner(SilentRunner):
         self._save_graph()
         self._cache_namespace_str = self._make_cache_namespace()
         self._create_pipeline_run(self._root_future)
-        self._update_pipeline_run_status(PipelineRunStatus.RUNNING)
+        if self._rerun_mode != RerunMode.REENTER:
+            self._update_pipeline_run_status(PipelineRunStatus.RUNNING)
 
     def _clean_up_pipeline_run(self, save_graph: bool) -> None:
         self._cancel_non_terminal_futures()
@@ -531,7 +556,7 @@ class LocalRunner(SilentRunner):
 
         run.nested_future_id = future.nested_future.id
 
-        self._populate_graph(future.nested_future)
+        self._populate_graph_from_future(future.nested_future)
         self._add_run(run)
         self._save_graph()
 
@@ -542,7 +567,7 @@ class LocalRunner(SilentRunner):
         run.future_state = FutureState.RESOLVED
         run.resolved_at = datetime.datetime.utcnow()
 
-        self._populate_graph(future)
+        self._populate_graph_from_future(future)
         self._add_run(run)
         self._save_graph()
 
@@ -782,7 +807,18 @@ class LocalRunner(SilentRunner):
 
         return artifact
 
-    def _populate_graph(self, future: AbstractFuture) -> Run:
+    def _populate_graph_from_objects(
+        self,
+        runs: List[Run],
+        artifacts: List[Artifact],
+        edges: List[Edge],
+    ):
+        """Update the in-memory caches of the graph objects using the provided objects"""
+        self._edges = {edge.id: edge for edge in edges}
+        self._runs = {run.id: run for run in runs}
+        self._artifacts = {artifact.id: artifact for artifact in artifacts}
+
+    def _populate_graph_from_future(self, future: AbstractFuture) -> Run:
         """
         Update the graph to include the given Future.
         """
@@ -896,7 +932,7 @@ class LocalRunner(SilentRunner):
         # populate the graph for upstream futures
         for value in future.kwargs.values():
             if isinstance(value, AbstractFuture):
-                self._populate_graph(value)
+                self._populate_graph_from_future(value)
 
         return self._runs[future.id]
 

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -144,7 +144,9 @@ class LocalRunner(SilentRunner):
                 # So we need to start it again.
                 logger.warning(
                     "The future %s was executing in the runner when the runner "
-                    "restarted. Restarting execution of the future.",
+                    "restarted. Restarting execution of the future. "
+                    "Some of the future's properties may have changed "
+                    "(see Issue #1032)",
                     future.id,
                 )
                 future.state = FutureState.RETRYING
@@ -173,6 +175,8 @@ class LocalRunner(SilentRunner):
         if rerun_mode is RerunMode.CONTINUE and run.id != run.root_id:
             raise ValueError("Cannot use RerunMode.CONTINUE with a non-root run.")
         elif rerun_mode is RerunMode.REENTER and run.id != future.id:
+            # This should be impossible. Raise a helpful message in case
+            # it ever happens anyway.
             raise ValueError(
                 f"Seeding from the DB for a reentered runner requires that "
                 f"The root future id ('{future.id}') must match the rerun id "
@@ -203,8 +207,10 @@ class LocalRunner(SilentRunner):
         elif rerun_mode is RerunMode.CONTINUE:
             future_graph = graph.clone_futures()
             is_clone = True
-        else:
+        elif rerun_mode is RerunMode.REENTER:
             future_graph = graph.to_future_graph()
+        else:
+            raise ValueError(f"Unrecognized rerun mode: {rerun_mode}")
 
         if is_clone:
             # Making sure we honor id of future passed from the outside
@@ -235,8 +241,9 @@ class LocalRunner(SilentRunner):
 
             if is_clone:
                 self._populate_graph_from_future(future)
-            else:
-                self._populate_graph_from_objects(runs, artifacts, edges)
+
+        if not is_clone:
+            self._populate_graph_from_objects(runs, artifacts, edges)
 
         self._save_graph()
 
@@ -838,7 +845,7 @@ class LocalRunner(SilentRunner):
         artifacts: List[Artifact],
         edges: List[Edge],
     ):
-        """Update the in-memory caches of the graph objects using the provided objects"""
+        """Update the in-memory caches of the graph objects using the provided objects."""
         for edge in edges:
             self._add_edge(edge)
         self._runs = {run.id: run for run in runs}

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -189,7 +189,7 @@ class LocalRunner(SilentRunner):
             # Making sure we honor id of future passed from the outside
             future_graph.set_root_future_id(future.id)  # type: ignore
 
-        self._futures = list(future_graph.futures_by_id.values())
+        self._futures = list(future_graph.futures_by_run_id.values())
 
         # This is necessary, otherwise the root run will not be updated with its
         # cloned status. In detached execution, or rerun, the root run is

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -152,7 +152,9 @@ class LocalRunner(SilentRunner):
                 future.state = FutureState.RETRYING
                 inline_run = next(run for run in runs if run.id == future.id)
                 inline_run.future_state = FutureState.RETRYING
-                api_client.save_run(inline_run)
+                api_client.save_graph(
+                    self._root_future.id, runs=[inline_run], artifacts=[], edges=[]
+                )
 
     def _seed_from_existing(
         self, future: AbstractFuture, from_run_id: str, rerun_mode: Optional[RerunMode]

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -131,6 +131,27 @@ class LocalRunner(SilentRunner):
         else:
             self._seed_from_existing(future, self._rerun_from_run_id, self._rerun_mode)
 
+    def _reenter_inline_runs(self, futures, runs):
+        """During runner reentry, correct the state of any inline futures/runs.
+
+        A correction may be needed if the future was executing in the runner when the
+        runner restarted. In this case, this method will mark the future and run for retry.
+        The update to the future and run happen in-place.
+        """
+        for future in futures:
+            if not future.props.standalone and future.state == FutureState.SCHEDULED:
+                # The future was executing in the runner when the runner restarted.
+                # So we need to start it again.
+                logger.warning(
+                    "The future %s was executing in the runner when the runner "
+                    "restarted. Restarting execution of the future.",
+                    future.id,
+                )
+                future.state = FutureState.RETRYING
+                inline_run = next(run for run in runs if run.id == future.id)
+                inline_run.future_state = FutureState.RETRYING
+                api_client.save_run(inline_run)
+
     def _seed_from_existing(
         self, future: AbstractFuture, from_run_id: str, rerun_mode: Optional[RerunMode]
     ):
@@ -190,6 +211,9 @@ class LocalRunner(SilentRunner):
             future_graph.set_root_future_id(future.id)  # type: ignore
 
         self._futures = list(future_graph.futures_by_run_id.values())
+
+        if rerun_mode == RerunMode.REENTER:
+            self._reenter_inline_runs(self._futures, runs)
 
         # This is necessary, otherwise the root run will not be updated with its
         # cloned status. In detached execution, or rerun, the root run is
@@ -814,7 +838,8 @@ class LocalRunner(SilentRunner):
         edges: List[Edge],
     ):
         """Update the in-memory caches of the graph objects using the provided objects"""
-        self._edges = {edge.id: edge for edge in edges}
+        for edge in edges:
+            self._add_edge(edge)
         self._runs = {run.id: run for run in runs}
         self._artifacts = {artifact.id: artifact for artifact in artifacts}
 

--- a/sematic/runners/tests/test_cloud_runner.py
+++ b/sematic/runners/tests/test_cloud_runner.py
@@ -17,10 +17,10 @@ from sematic.api.tests.fixtures import (  # noqa: F401
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import PipelineRunKind, PipelineRunStatus
-from sematic.db.queries import get_run, save_graph, save_resolution
+from sematic.db.queries import get_run, save_graph, save_resolution, save_run
+from sematic.db.tests.fixtures import make_resolution  # noqa: F401
 from sematic.db.tests.fixtures import make_run  # noqa: F401
 from sematic.db.tests.fixtures import persisted_resolution  # noqa: F401
-from sematic.db.tests.fixtures import persisted_run  # noqa: F401
 from sematic.db.tests.fixtures import pg_mock  # noqa: F401
 from sematic.db.tests.fixtures import run  # noqa: F401
 from sematic.db.tests.fixtures import (  # noqa: F401
@@ -272,13 +272,15 @@ def test_runner_restart(
     test_db,  # noqa: F811
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
-    persisted_resolution,  # noqa: F811
+    run,  # noqa: F811
     mock_get_artifact_value,  # noqa: F811
 ):
     # Emulate the state of a pipeline run which was partially
     # done already
-    persisted_pipeline_run = persisted_resolution
-    persisted_pipeline_run.status = PipelineRunStatus.RUNNING
+    saved_run = save_run(run)
+    persisted_pipeline_run = make_resolution(
+        root_id=saved_run.id, status=PipelineRunStatus.RUNNING
+    )
     save_resolution(persisted_pipeline_run)
 
     foo_func_path = f"{foo.__module__}.{foo.__name__}"

--- a/sematic/runners/tests/test_cloud_runner.py
+++ b/sematic/runners/tests/test_cloud_runner.py
@@ -17,7 +17,7 @@ from sematic.api.tests.fixtures import (  # noqa: F401
 from sematic.db.models.edge import Edge
 from sematic.db.models.factories import make_artifact
 from sematic.db.models.resolution import PipelineRunKind, PipelineRunStatus
-from sematic.db.queries import get_root_graph, get_run, save_graph, save_resolution
+from sematic.db.queries import get_run, save_graph, save_resolution
 from sematic.db.tests.fixtures import make_run  # noqa: F401
 from sematic.db.tests.fixtures import persisted_resolution  # noqa: F401
 from sematic.db.tests.fixtures import persisted_run  # noqa: F401
@@ -45,20 +45,28 @@ def pipeline() -> float:
     return add(1, 2)
 
 
+@pytest.fixture
+def mock_get_artifact_value():
+    with mock.patch("sematic.api_client.get_artifact_value") as patched:
+        yield patched
+
+
 class InstrumentedCloudRunner(CloudRunner):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, no_op_main_loop=False, **kwargs):
         super().__init__(*args, **kwargs)
         _INSTRUMENTED_INSTANCES.append(self)
         self._init_args = (args, kwargs)
         self._run_called_with = None
         self._detach_pipeline_run_called_with = None
+        self._no_op_main_loop = no_op_main_loop
 
     def run(self, future):  # noqa: F811
         self._run_called_with = future
         super().run(future)
 
-    def _detach_pipeline_run(self, future):
-        self._detach_pipeline_run_called_with = future
+    def _pipeline_run_loop(self):
+        if not self._no_op_main_loop:
+            super()._pipeline_run_loop()
 
 
 _INSTRUMENTED_INSTANCES: List[InstrumentedCloudRunner] = []
@@ -265,6 +273,7 @@ def test_runner_restart(
     mock_requests,  # noqa: F811
     valid_client_version,  # noqa: F811
     persisted_resolution,  # noqa: F811
+    mock_get_artifact_value,  # noqa: F811
 ):
     # Emulate the state of a pipeline run which was partially
     # done already
@@ -272,65 +281,77 @@ def test_runner_restart(
     persisted_pipeline_run.status = PipelineRunStatus.RUNNING
     save_resolution(persisted_pipeline_run)
 
-    @func
-    def bar() -> int:
-        return 1
-
-    @func
-    def foo() -> List[int]:
-        child1 = bar()
-        child2 = bar()
-        child3 = bar()
-        return [child1, child2, child3]
-
+    foo_func_path = f"{foo.__module__}.{foo.__name__}"
+    bar_func_path = f"{bar.__module__}.{bar.__name__}"
     root_run = get_run(persisted_pipeline_run.root_id)
+    root_run.function_path = foo_func_path
     root_run.future_state = FutureState.RAN
     child_run1 = make_run(
         id="a" * 32,
-        future_state=FutureState.RAN,
+        future_state=FutureState.RESOLVED,
         parent_id=persisted_pipeline_run.root_id,
         root_id=persisted_pipeline_run.root_id,
+        function_path=bar_func_path,
     )
     child_run2 = make_run(
         id="b" * 32,
         future_state=FutureState.RESOLVED,
         parent_id=persisted_pipeline_run.root_id,
         root_id=persisted_pipeline_run.root_id,
+        function_path=bar_func_path,
     )
     child_run3 = make_run(
         id="c" * 32,
         future_state=FutureState.CREATED,
         parent_id=persisted_pipeline_run.root_id,
         root_id=persisted_pipeline_run.root_id,
+        function_path=bar_func_path,
     )
     child_run4 = make_run(
         id="d" * 32,
         future_state=FutureState.CREATED,
         parent_id=persisted_pipeline_run.root_id,
         root_id=persisted_pipeline_run.root_id,
+        function_path="sematic.function._make_list",
     )
+    root_run.nested_future_id = child_run4.id
     runs = [root_run, child_run1, child_run2, child_run3, child_run4]
 
+    artifact1, _ = make_artifact(1, int)
+    artifact2, _ = make_artifact(2, int)
+
+    def fake_get_value(artifact):
+        return {
+            artifact1.id: 1,
+            artifact2.id: 2,
+        }[artifact.id]
+
+    mock_get_artifact_value.side_effect = fake_get_value
+
     edge1 = Edge(
+        id="e1" * 16,
         destination_run_id=child_run4.id,
         source_run_id=child_run1.id,
         destination_name="i0",
-        artifact_id=None,
+        artifact_id=artifact1.id,
     )
     edge2 = Edge(
+        id="e2" * 16,
         destination_run_id=child_run4.id,
         source_run_id=child_run2.id,
         destination_name="i1",
-        artifact_id=None,
+        artifact_id=artifact2.id,
     )
     edge3 = Edge(
+        id="e3" * 16,
         destination_run_id=child_run4.id,
         source_run_id=child_run3.id,
         destination_name="i2",
         artifact_id=None,
     )
     edges = [edge1, edge2, edge3]
-    save_graph(runs=runs, artifacts=[], edges=edges)
+    artifacts = [artifact1, artifact2]
+    save_graph(runs=runs, artifacts=artifacts, edges=edges)
 
     # Now that we have a partially executed pipeline run, see
     # what would happen if the runner restarted.
@@ -338,23 +359,60 @@ def test_runner_restart(
     future.id = root_run.id
     future.state = FutureState[root_run.future_state]
     with environment_variables({"SEMATIC_CONTAINER_IMAGE": "foo:bar"}):
-        with pytest.raises(Exception):
-            InstrumentedCloudRunner(_is_running_remotely=True, detach=False).run(future)
-    runs, _, __ = get_root_graph(root_run.id)
-    read_run_state_by_id = {run.id: run.future_state for run in runs}  # noqa: F811
-    assert read_run_state_by_id[child_run1.id] == FutureState.CANCELED.value
+        reentrant_runner = InstrumentedCloudRunner(
+            _is_running_remotely=True,
+            detach=False,
+            rerun_from=root_run.id,
+            rerun_mode=RerunMode.REENTER,
+            no_op_main_loop=True,
+        )
+        reentrant_runner.run(future)
+    read_run_state_by_id = {
+        run.id: run.future_state
+        for run in reentrant_runner._runs.values()  # noqa: F811
+    }
+    assert read_run_state_by_id[child_run1.id] == FutureState.RESOLVED.value
     assert read_run_state_by_id[child_run2.id] == FutureState.RESOLVED.value
-    assert read_run_state_by_id[child_run3.id] == FutureState.CANCELED.value
+    assert read_run_state_by_id[child_run3.id] == FutureState.CREATED.value
+    assert read_run_state_by_id[root_run.id] == FutureState.RAN.value
 
-    # We want the root run to show up as Failed in this circumstance.
-    assert read_run_state_by_id[root_run.id] == FutureState.FAILED.value
+    assert reentrant_runner._run_called_with.function is future.function
+    assert reentrant_runner._run_called_with.kwargs == future.kwargs
+    assert reentrant_runner._run_called_with.id == future.id
+    assert reentrant_runner._init_args[1]["rerun_from"] == root_run.id
+    assert reentrant_runner._init_args[1]["rerun_mode"] == RerunMode.REENTER
 
-    new_runner = _INSTRUMENTED_INSTANCES[-1]
-    assert new_runner._run_called_with.function is future.function
-    assert new_runner._run_called_with.kwargs == future.kwargs
-    assert new_runner._run_called_with.id != future.id
-    assert (
-        new_runner._detach_pipeline_run_called_with.id == new_runner._run_called_with.id
-    )
-    assert new_runner._init_args[1]["rerun_from"] == root_run.id
-    assert new_runner._init_args[1]["rerun_mode"] == RerunMode.CONTINUE
+    assert {e.id for e in edges} == {e.id for e in reentrant_runner._edges.values()}
+    assert {a.id for a in artifacts} == {
+        a.id for a in reentrant_runner._artifacts.values()
+    }
+
+    root_future = next(f for f in reentrant_runner._futures if f.id == root_run.id)
+    future1 = next(f for f in reentrant_runner._futures if f.id == child_run1.id)
+    future2 = next(f for f in reentrant_runner._futures if f.id == child_run2.id)
+    future3 = next(f for f in reentrant_runner._futures if f.id == child_run3.id)
+    future4 = next(f for f in reentrant_runner._futures if f.id == child_run4.id)
+    assert root_future.nested_future is future4
+    assert future4.kwargs == {
+        "v0": future1,
+        "v1": future2,
+        "v2": future3,
+    }
+    assert future4.resolved_kwargs == {
+        "v0": 1,
+        "v1": 2,
+        # "v2": 3,  # the run for this hasn't executed yet
+    }
+
+
+@func
+def bar() -> int:
+    return 1
+
+
+@func
+def foo() -> List[int]:
+    child1 = bar()
+    child2 = bar()
+    child3 = bar()
+    return [child1, child2, child3]


### PR DESCRIPTION
The cloud runner is sometimes restarted unexpectedly by K8s. Prior to this PR, this was handled by starting an entirely new pipeline run, with a new id, starting where the old one left off. This PR changes the behavior such that the runner is instead able to re-create its internal state and continue from where it left off. This (unlike the previous behavior) should be transparent to end-users.

Testing
-------

Disabled the signal handlers in the StateMachineRunner, so it wouldn't interpret `kubectl delete pod ...` as cancellations, then performed the following tests, using `kubectl delete pod` on the runner pod to emulate evictions:

- With an entirely inline graph, interrupted mid-execution. [Run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/390bf91a57524b38acff77df6265fce7#run=e6d3cc3d90dc445d920c129ff8663be7&tab=source)
- With standalone functions, interrupted mid-execution. [Run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/41e720c95c95449f8e74a5f91e25a0ea#run=741f1d1d261446be88af714a9411a3ed&tab=source)
- With multiple base images, interrupted mid-execution. [Run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/41e720c95c95449f8e74a5f91e25a0ea#run=741f1d1d261446be88af714a9411a3ed&tab=source)
- With an implicit make_list, interrupted mid-execution. [Run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/d26de86afc9b401ba596690918db1b78)
- Validated that rerun-from-here still works. [Run](https://josh.dev-usw2-sematic0.sematic.cloud/runs/9034aa1bc6eb4e238d8477d8a172a7a7)