### PR TITLE
Fix log view regression

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
@@ -84,7 +84,7 @@ export default function LogsPane() {
         if (!selectedRun ) {
             return null;
         }
-        if (includes(["CREATED", "SCHEDULED"], selectedRun.future_state)) {
+        if (selectedRun.future_state === "CREATED") {
             return <Alert severity="info" sx={{ mt: 3 }}>
                 {"Run has not started. There are no logs yet."}
             </Alert>

--- a/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/logs/LogsPane.tsx
@@ -3,7 +3,6 @@ import { TextField } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import { buttonClasses } from "@mui/material/Button";
 import BidirectionalLogView, { ConciseLineTemplate } from "@sematic/common/src/pages/RunDetails/logs/BidirectionalLogView";
-import includes from "lodash/includes";
 import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import useUnmount from "react-use/lib/useUnmount";
 import LayoutServiceContext from "src/context/LayoutServiceContext";


### PR DESCRIPTION
In the new log view UI, it was waiting to present the logs for a run until the run reached a state where the logs would be available. However, while logs appear during the `SCHEDULED` state, while the run is executing, the UI considered this to be a state where logs were not available. The effect was that the logs for a run would not show up until after the run completed. This regression appeared in v0.34.0. This PR fixes the regression.

Testing
-------
Submitted the testing pipeline including a "sleep" step, and observed that the logs for the step were shown during the execution of the run.