### PR TITLE
Improve <3.9 type-checking for list/set

### DIFF
--- a/sematic/types/types/list.py
+++ b/sematic/types/types/list.py
@@ -35,7 +35,7 @@ def safe_cast_list(
     if not isinstance(value, typing.Iterable):
         return None, "{} not an iterable".format(value)
 
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
 
     result: typing.List[element_type] = []  # type: ignore
 
@@ -69,18 +69,18 @@ def can_cast_to_list(from_type: typing.Any, to_type: typing.Any):
     """
     err_prefix = "Can't cast {} to {}:".format(from_type, to_type)
 
-    if not isinstance(from_type, typing._GenericAlias):  # type: ignore
+    if len(typing.get_args(from_type)) < 1:
         return False, "{} not a subscripted generic".format(err_prefix)
 
     if not (
-        isinstance(from_type.__origin__, type)
-        and issubclass(from_type.__origin__, typing.Iterable)
+        isinstance(typing.get_origin(from_type), type)
+        and issubclass(typing.get_origin(from_type), typing.Iterable)  # type: ignore
     ):
         return False, "{} not an iterable".format(err_prefix)
 
-    from_type_args = from_type.__args__
+    from_type_args = typing.get_args(from_type)
 
-    element_type = to_type.__args__[0]
+    element_type = typing.get_args(to_type)[0]
 
     for from_element_type in from_type_args:
         can_cast, error = can_cast_type(from_element_type, element_type)
@@ -92,19 +92,19 @@ def can_cast_to_list(from_type: typing.Any, to_type: typing.Any):
 
 @register_to_json_encodable(list)
 def list_to_json_encodable(value: list, type_: typing.Any) -> list:
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
     return [value_to_json_encodable(item, element_type) for item in value]
 
 
 @register_from_json_encodable(list)
 def list_from_json_encodable(value: list, type_: typing.Any) -> list:
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
     return [value_from_json_encodable(item, element_type) for item in value]
 
 
 @register_to_json_encodable_summary(list)
 def list_to_json_encodable_summary(value: list, type_: typing.Any) -> SummaryOutput:
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
 
     complete_summary, blobs = [], []
     for item in value:

--- a/sematic/types/types/set.py
+++ b/sematic/types/types/set.py
@@ -85,7 +85,7 @@ def _can_cast_to_set(
     """
     err_prefix = "Can't cast {} to {}:".format(from_type, to_type)
 
-    if not isinstance(from_type, typing._GenericAlias):  # type: ignore
+    if len(typing.get_args(from_type)) == 0:  # type: ignore
         return False, "{} not a subscripted generic".format(err_prefix)
 
     if not (

--- a/sematic/types/types/set.py
+++ b/sematic/types/types/set.py
@@ -33,7 +33,7 @@ def _set_safe_cast(
     if not isinstance(value, typing.Iterable):
         return None, f"{value} not an iterable"
 
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
 
     result: typing.Set[element_type] = set()  # type: ignore
 
@@ -52,7 +52,7 @@ def _set_to_json_encodable(value: set, type_: typing.Any) -> typing.List:
     """
     Serialization of sets
     """
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
     return [value_to_json_encodable(item, element_type) for item in value]
 
 
@@ -61,7 +61,7 @@ def _set_from_json_encodable(value: set, type_: typing.Any) -> typing.Set[typing
     """
     Deserialize a sets
     """
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
     return set(value_from_json_encodable(item, element_type) for item in value)
 
 
@@ -89,14 +89,14 @@ def _can_cast_to_set(
         return False, "{} not a subscripted generic".format(err_prefix)
 
     if not (
-        isinstance(from_type.__origin__, type)
-        and issubclass(from_type.__origin__, typing.Iterable)
+        isinstance(typing.get_origin(from_type), type)
+        and issubclass(typing.get_origin(from_type), typing.Iterable)  # type: ignore
     ):
         return False, "{} not an iterable".format(err_prefix)
 
-    from_type_args = from_type.__args__
+    from_type_args = typing.get_args(from_type)
 
-    element_type = to_type.__args__[0]
+    element_type = typing.get_args(to_type)[0]
 
     for from_element_type in from_type_args:
         can_cast, error = can_cast_type(from_element_type, element_type)
@@ -114,7 +114,7 @@ def _set_to_json_encodable_summary(
     Summary for the UI
     """
     complete_summary, blobs = [], []
-    element_type = type_.__args__[0]
+    element_type = typing.get_args(type_)[0]
 
     for item in value:
         item_summary, item_blob = get_json_encodable_summary(item, element_type)

--- a/sematic/types/types/tests/BUILD
+++ b/sematic/types/types/tests/BUILD
@@ -49,6 +49,16 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_set",
+    srcs = ["test_set.py"],
+    deps = [
+        "//sematic/types:casting",
+        "//sematic/types:init",
+        "//sematic/types:serialization",
+    ],
+)
+
+pytest_test(
     name = "test_tuple",
     srcs = ["test_tuple.py"],
     deps = [


### PR DESCRIPTION
`List` and `Set` were doing a comparison in their `can_cast_type` functions that assumed the `List[T]` variant of the type was being used instead of the `list[T]` variant. This PR makes the check compatible with both of these variants. It also adds a unit test for the `Set` type, which had been missing.