### PR TITLE
Improve `sematic version` CLI

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -894,9 +894,6 @@ def _raise_for_response(
     if response.status_code == 404:
         exception = ResourceNotFoundError(f"Resource {url} was not found")
 
-    if response.status_code == 413:
-        logger.info(response.request.body)
-
     elif 400 <= response.status_code < 500:
         exception = BadRequestError(
             f"The {method} request to {url} was invalid, "

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -44,10 +44,12 @@ API_CALLS_BACKOFF = 2
 # The client should always verify that it is compatible with the server
 # it is talking to before using the API, but we don't want to do that every
 # time. This caches whether we have validated it or not.
+# When it is set, it stores the json_encodable response from
+# the server's meta/versions API call.
 # TODO: encapsulate this flag and the API call functions in a stateful client class that
 #  can also keep track of a flag that suppresses cleanup stack traces on unsuccessful
 #  pipeline run terminations
-_validated_client_version = False
+_server_version_metadata = None
 
 
 class APIConnectionError(ConnectionError):
@@ -706,15 +708,15 @@ def _put(
     return response.json()
 
 
-def validate_server_compatibility(use_cached: bool = True) -> None:
+def validate_server_compatibility(use_cached: bool = True) -> Dict[Literal["server", "min_client_supported"], List[int]]:
     """Check that the client is compatible with the server.
 
     Raises an error if the server and client are incompatible, or if this can't be
     verified.
     """
-    global _validated_client_version
-    if _validated_client_version and use_cached:
-        return
+    global _server_version_metadata 
+    if _server_version_metadata and use_cached:
+        return _server_version_metadata 
 
     base_url = get_config().api_url.replace("/api/v1", "")
     unexpected_server_response_error = IncompatibleClientError(
@@ -770,7 +772,7 @@ def validate_server_compatibility(use_cached: bool = True) -> None:
         version_as_string(server_version),
     )
 
-    _validated_client_version = True
+    _server_version_metadata = response_json
 
 
 def request(
@@ -911,6 +913,9 @@ def _raise_for_response(
     if exception is None:
         return
 
+    if response.status_code == 413:
+        import pdb; pdb.set_trace()
+        logger.error(response.request.body)
     logger.error(
         "Server returned %s for %s %s: %s",
         response.status_code,

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -708,15 +708,17 @@ def _put(
     return response.json()
 
 
-def validate_server_compatibility(use_cached: bool = True) -> Dict[Literal["server", "min_client_supported"], List[int]]:
+def validate_server_compatibility(
+    use_cached: bool = True,
+) -> Dict[Literal["server", "min_client_supported"], List[int]]:
     """Check that the client is compatible with the server.
 
     Raises an error if the server and client are incompatible, or if this can't be
     verified.
     """
-    global _server_version_metadata 
+    global _server_version_metadata
     if _server_version_metadata and use_cached:
-        return _server_version_metadata 
+        return _server_version_metadata
 
     base_url = get_config().api_url.replace("/api/v1", "")
     unexpected_server_response_error = IncompatibleClientError(
@@ -773,6 +775,7 @@ def validate_server_compatibility(use_cached: bool = True) -> Dict[Literal["serv
     )
 
     _server_version_metadata = response_json
+    return _server_version_metadata
 
 
 def request(
@@ -891,6 +894,9 @@ def _raise_for_response(
     if response.status_code == 404:
         exception = ResourceNotFoundError(f"Resource {url} was not found")
 
+    if response.status_code == 413:
+        logger.info(response.request.body)
+
     elif 400 <= response.status_code < 500:
         exception = BadRequestError(
             f"The {method} request to {url} was invalid, "
@@ -913,9 +919,6 @@ def _raise_for_response(
     if exception is None:
         return
 
-    if response.status_code == 413:
-        import pdb; pdb.set_trace()
-        logger.error(response.request.body)
     logger.error(
         "Server returned %s for %s %s: %s",
         response.status_code,

--- a/sematic/cli/BUILD
+++ b/sematic/cli/BUILD
@@ -203,6 +203,7 @@ sematic_py_lib(
     deps = [
         ":cli",
         "//sematic:versions",
+        "//sematic:api_client",
     ],
 )
 

--- a/sematic/cli/version.py
+++ b/sematic/cli/version.py
@@ -6,7 +6,8 @@ import click
 
 # Sematic
 from sematic.cli.cli import cli
-from sematic.versions import CURRENT_VERSION_STR, MIN_CLIENT_SERVER_SUPPORTS_STR
+from sematic import api_client
+from sematic.versions import CURRENT_VERSION_STR, version_as_string
 
 
 @cli.command("version", short_help="Print version information.")
@@ -14,6 +15,13 @@ def version():
     """
     Print the Server, Client, and Python versions.
     """
-    click.echo(f"Sematic server v{CURRENT_VERSION_STR} is installed.")
-    click.echo(f"Client versions >= v{MIN_CLIENT_SERVER_SUPPORTS_STR} are supported.")
-    click.echo(f"Python v{platform.python_version()} is running this binary.")
+    click.echo(f"Sematic client v{CURRENT_VERSION_STR} is installed.")
+    try:
+        server_version_metadata = api_client.validate_server_compatibility()
+        server_version = version_as_string(server_version_metadata["server"])
+        min_client_version = version_as_string(server_version_metadata["min_client_supported"])
+        click.echo(f"The server is at version v{server_version}")
+        click.echo(f"Client versions >= v{min_client_version} are supported.")
+        click.echo(f"Python v{platform.python_version()} is running this binary.")
+    except api_client.IncompatibleClientError as e:
+        click.echo(str(e))

--- a/sematic/cli/version.py
+++ b/sematic/cli/version.py
@@ -26,6 +26,6 @@ def version():
         )
         click.echo(f"The server is at version v{server_version}")
         click.echo(f"Client versions >= v{min_client_version} are supported.")
-        click.echo(f"Python v{platform.python_version()} is running this binary.")
     except api_client.IncompatibleClientError as e:
         click.echo(str(e))
+    click.echo(f"Python v{platform.python_version()} is running this binary.")

--- a/sematic/cli/version.py
+++ b/sematic/cli/version.py
@@ -5,8 +5,9 @@ import platform
 import click
 
 # Sematic
-from sematic.cli.cli import cli
 from sematic import api_client
+from sematic.cli.cli import cli
+from sematic.config.config import switch_env
 from sematic.versions import CURRENT_VERSION_STR, version_as_string
 
 
@@ -15,11 +16,14 @@ def version():
     """
     Print the Server, Client, and Python versions.
     """
+    switch_env("user")
     click.echo(f"Sematic client v{CURRENT_VERSION_STR} is installed.")
     try:
         server_version_metadata = api_client.validate_server_compatibility()
         server_version = version_as_string(server_version_metadata["server"])
-        min_client_version = version_as_string(server_version_metadata["min_client_supported"])
+        min_client_version = version_as_string(
+            server_version_metadata["min_client_supported"]
+        )
         click.echo(f"The server is at version v{server_version}")
         click.echo(f"Client versions >= v{min_client_version} are supported.")
         click.echo(f"Python v{platform.python_version()} is running this binary.")

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -10,6 +10,7 @@ import pytest
 import sematic.api_client as api_client
 from sematic.abstract_future import FutureState
 from sematic.plugins.storage.memory_storage import MemoryStorage
+from sematic.versions import CURRENT_VERSION, MIN_CLIENT_SERVER_SUPPORTS
 
 
 @pytest.fixture(scope="function")
@@ -19,14 +20,17 @@ def test_storage():
 
 @pytest.fixture
 def valid_client_version():
-    current_validated_client_version = api_client._validated_client_version
+    current_version_metadata = api_client._server_version_metadata
 
-    api_client._validated_client_version = True
+    api_client._server_version_metadata = {
+        "server": CURRENT_VERSION,
+        "min_client_supported": MIN_CLIENT_SERVER_SUPPORTS,
+    }
 
     try:
         yield
     finally:
-        api_client._validated_client_version = current_validated_client_version
+        api_client._server_version_metadata = current_version_metadata
 
 
 @pytest.fixture

--- a/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/RunSection.tsx
@@ -81,7 +81,7 @@ const RunSection = () => {
         if (!resolution) {
             return "-";
         }
-        return resolution.kind === "KUBERNETES" ? "CloudResolver" : "LocalResolver";
+        return resolution.kind === "KUBERNETES" ? "CloudRunner" : "LocalRunner";
 
     }, [resolution])
 


### PR DESCRIPTION
The `sematic version` CLI was a bit misleading, as it checked the client's version and called it the server version. This PR changes it so that both the client and the server version are reported, along with the min version from the actual server.

Testing
-------

```
$ sematic version
Sematic client v0.34.0 is installed.
The server is at version v0.34.0
Client versions >= v0.30.0 are supported.
Python v3.8.15 is running this binary.
```

And with an unsupported server/client combo:

```
$ sematic version
Sematic client v0.34.0 is installed.
The Sematic API client is at version 0.34.0, which is newer than the Sematic server's version of 0.33.0. Please downgrade your client to 0.33.0, or ask your server admin to upgrade to at least 0.34.0.
```