### PR TITLE
Reduce mnist json 'summary' by about 10x

### DIFF
--- a/sematic/examples/mnist/pytorch/train_eval.py
+++ b/sematic/examples/mnist/pytorch/train_eval.py
@@ -15,6 +15,8 @@ from torchmetrics import PrecisionRecallCurve  # type: ignore
 
 # from sematic.ee.metrics import log_metric
 
+_N_POINTS_PR_CURVE = 2000
+
 
 class Net(nn.Module):
     def __init__(self):
@@ -126,6 +128,11 @@ def test(model: nn.Module, device: torch.device, test_loader: DataLoader):
             "class": classes,
         }
     )
+
+    # We don't need every point to make a useful plot, so we'll subsample
+    # every nth row, targeting a size of about 2000 points
+    reduction_factor = int(len(df) / _N_POINTS_PR_CURVE) + 1
+    df = df.iloc[::reduction_factor, :]
 
     fig = px.scatter(
         df,


### PR DESCRIPTION
The PR curve for MNIST was including a point on the plot for every row in the eval data. This was then getting posted to the server as json in the artifact json "summary" for the plot. This could cause you to hit a "Request payload too large" from the ingress (Nginx) when running locally against a remote server. This didn't happen when running locally against a local server because there you don't go through the ingress. It also didn't happen when running in the cloud because there the network traffic stays in-cluster and thus also bypasses the ingress. This PR subsamples the points before creating the plot, with the result being that the size of the payload is reduced ~10x.

Here is what the plot looks like now:

<img width="698" alt="Screenshot 2023-08-25 at 6 04 11 PM" src="https://github.com/sematic-ai/sematic/assets/7181589/f739c0f7-e6c6-48ba-a8b1-9ba8d7cc763b">

Tested and confirmed that we no longer hit "Request payload too large" in this scenario.