### PR TITLE
Reduce chances of excessive retry

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -214,7 +214,11 @@ def get_runs(
 
 
 def save_graph(
-    root_id: str, runs: List[Run], artifacts: List[Artifact], edges: List[Edge]
+    root_id: str,
+    runs: List[Run],
+    artifacts: List[Artifact],
+    edges: List[Edge],
+    retry: bool = True,
 ):
     """
     Persist a graph.
@@ -227,7 +231,7 @@ def save_graph(
         }
     }
 
-    _put("/graph", payload)
+    _put("/graph", payload, retry=retry)
     notify_graph_update(root_id)
 
 

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -361,7 +361,7 @@ class LocalRunner(SilentRunner):
         self._deactivate_all_resources()
         self._disconnect_from_sio_server()
         if save_graph:
-            self._save_graph(runs_only=True)
+            self._save_graph(runs_only=True, retry=False)
 
         root_run = self._get_run(self._root_future.id)
         pipeline_run = api_client.get_pipeline_run(self._root_future.id)
@@ -620,7 +620,7 @@ class LocalRunner(SilentRunner):
         if not FutureState[run.future_state].is_terminal():  # type: ignore
             run.future_state = FutureState.CANCELED.value  # type: ignore
             self._add_run(run)
-        self._save_graph(runs_only=True)
+        self._save_graph(runs_only=True, retry=False)
 
     def _future_did_fail(self, failed_future: AbstractFuture) -> None:
         super()._future_did_fail(failed_future)
@@ -654,7 +654,7 @@ class LocalRunner(SilentRunner):
                 )
 
         self._add_run(run)
-        self._save_graph(runs_only=True)
+        self._save_graph(runs_only=True, retry=False)
 
     def _notify_pipeline_update(self):
         api_client.notify_pipeline_update(
@@ -728,7 +728,7 @@ class LocalRunner(SilentRunner):
 
             self._add_run(run)
 
-        self._save_graph(runs_only=True)
+        self._save_graph(runs_only=True, retry=False)
 
     def _update_pipeline_run_status(self, status: PipelineRunStatus):
         pipeline_run = api_client.get_pipeline_run(self._root_future.id)
@@ -971,7 +971,7 @@ class LocalRunner(SilentRunner):
 
         return self._runs[future.id]
 
-    def _save_graph(self, runs_only: bool = False):
+    def _save_graph(self, runs_only: bool = False, retry: bool = True):
         """
         Persist the graph to the DB.
 
@@ -979,7 +979,14 @@ class LocalRunner(SilentRunner):
         ----------
         runs_only:
             If true, only runs will be persisted. Artifacts and edges
-            will remain buffered.
+            will remain buffered. Should be set to True if the graph is
+            being saved only to move the runs to a terminal state, as
+            saving only the runs reduces the chances that the entire
+            save fails.
+        retry:
+            Whether the graph saved will be retried. Should be set to
+            False when _save_graph is called for cleanup operations so we can
+            exit quickly and cleanly.
         """
         runs = list(self._buffer_runs.values())
 
@@ -994,7 +1001,11 @@ class LocalRunner(SilentRunner):
             return
 
         api_client.save_graph(
-            root_id=self._futures[0].id, runs=runs, artifacts=artifacts, edges=edges
+            root_id=self._futures[0].id,
+            runs=runs,
+            artifacts=artifacts,
+            edges=edges,
+            retry=retry,
         )
 
         self._buffer_runs.clear()

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -361,7 +361,7 @@ class LocalRunner(SilentRunner):
         self._deactivate_all_resources()
         self._disconnect_from_sio_server()
         if save_graph:
-            self._save_graph()
+            self._save_graph(runs_only=True)
 
         root_run = self._get_run(self._root_future.id)
         pipeline_run = api_client.get_pipeline_run(self._root_future.id)
@@ -620,7 +620,7 @@ class LocalRunner(SilentRunner):
         if not FutureState[run.future_state].is_terminal():  # type: ignore
             run.future_state = FutureState.CANCELED.value  # type: ignore
             self._add_run(run)
-        self._save_graph()
+        self._save_graph(runs_only=True)
 
     def _future_did_fail(self, failed_future: AbstractFuture) -> None:
         super()._future_did_fail(failed_future)
@@ -654,7 +654,7 @@ class LocalRunner(SilentRunner):
                 )
 
         self._add_run(run)
-        self._save_graph()
+        self._save_graph(runs_only=True)
 
     def _notify_pipeline_update(self):
         api_client.notify_pipeline_update(
@@ -728,7 +728,7 @@ class LocalRunner(SilentRunner):
 
             self._add_run(run)
 
-        self._save_graph()
+        self._save_graph(runs_only=True)
 
     def _update_pipeline_run_status(self, status: PipelineRunStatus):
         pipeline_run = api_client.get_pipeline_run(self._root_future.id)
@@ -971,15 +971,26 @@ class LocalRunner(SilentRunner):
 
         return self._runs[future.id]
 
-    def _save_graph(self):
+    def _save_graph(self, runs_only: bool = False):
         """
-        Persist the graph to the DB
+        Persist the graph to the DB.
+
+        Parameters
+        ----------
+        runs_only:
+            If true, only runs will be persisted. Artifacts and edges
+            will remain buffered.
         """
         runs = list(self._buffer_runs.values())
-        artifacts = list(self._buffer_artifacts.values())
-        edges = list(self._buffer_edges.values())
 
-        if not any(len(buffer) for buffer in (runs, artifacts, edges)):
+        if runs_only:
+            artifacts = []
+            edges = []
+        else:
+            artifacts = list(self._buffer_artifacts.values())
+            edges = list(self._buffer_edges.values())
+
+        if not any(len(buffer) for buffer in (runs, artifacts, edges)):  # type: ignore
             return
 
         api_client.save_graph(
@@ -987,8 +998,10 @@ class LocalRunner(SilentRunner):
         )
 
         self._buffer_runs.clear()
-        self._buffer_artifacts.clear()
-        self._buffer_edges.clear()
+
+        if not runs_only:
+            self._buffer_artifacts.clear()
+            self._buffer_edges.clear()
 
     @classmethod
     def _get_resource_manager(cls) -> ServerResourceManager:


### PR DESCRIPTION
If `save_graph` is consistently resulting in error, it can take an unpleasant number of attempts to get the program to finally exit. This is because there is an attempt to save the graph during run failure handling, pipeline run (i.e. resolution) run handling, and cancellation run handling. This PR does two things to address this:

(1) Don't retry `save_graph` when performing cleanup operations, to encourage a quick and clean exit
(2) During cleanup operations, only save the runs, which reduces chances that problems with artifact/edge saves prevent the run state from getting updated.

WRT the latter, artifacts in particular have an extra risk of failure compared to runs; their "json summaries" can be too large, which can cause the graph save attempt to be rejected.

Testing
--------

Ran mnist without #1046 with a setup that would hit a "request payload too large" during one of the graph saves. Confirmed that "leaving it alone," it only went through the retry logic once prior to exiting. Then ran again and used CTRL+C during a retry delay and confirmed that the program quickly cleaned up and exited without any additional retries.