### PR TITLE
Have the cancel CLI use the API from the config

### DIFF
--- a/sematic/cli/cancel.py
+++ b/sematic/cli/cancel.py
@@ -4,6 +4,7 @@ import click
 # Sematic
 import sematic.api_client as api_client
 from sematic.cli.cli import cli
+from sematic.config.config import switch_env
 
 
 @cli.command("cancel", short_help="Cancel a run")  # type: ignore
@@ -12,6 +13,7 @@ def cancel(run_id: str):
     """
     Cancel a pipeline execution.
     """
+    switch_env("user")  # we want to always connect to the API in the user's config
     try:
         run = api_client.get_run(run_id)
     except api_client.BadRequestError:


### PR DESCRIPTION
The CLI for `cancel` was currently always using the local user env (since that is the default for CLI commands). But really we want it to communicate with whatever API the user's config is set up to talk to.

Testing
-------

Made sure my Sematic config was pointing to a remote server and used this command. Ensured it used the remote server to complete the request.