### PR TITLE
Have the server log more errors & warnings

### DIFF
--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import sys
-import traceback
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import (
@@ -296,36 +295,16 @@ def get_request_parameters(
 
 
 def jsonify_error(error: str, status: HTTPStatus):
-    is_warning = False
+    cause = sys.exc_info()[1]
 
-    # Since jsonify_error is explicitly called to handle the
-    # error, there is no uncaught exception to be handled by
-    # the "catch all" exception handler & logger. This ensures
-    # that we generate a log message even for these explicitly
-    # handled errors, so we can triage more easily.
     if status is None:
         logger.error("Attempting to create an error without a code: %s", error)
     elif 400 <= status.value < 500:
-        logger.warning("Bad request error: '%s'", error, stack_info=True)
-        is_warning = True
+        logger.warning(
+            "Bad request error: '%s'", error, exc_info=cause, stack_info=cause is None
+        )
     else:
-        logger.exception("Server error: '%s'", error)
-
-    # The above prints the error summary and stack to *this* call.
-    # We also want to show the stack trace for the root cause exception,
-    # if there indeed was one.
-    exception_type, exception, trace = sys.exc_info()
-    if exception is None:
-        logger.warning("No exception cause")
-    else:
-        for line in traceback.format_exception(
-            etype=exception_type, value=exception, tb=trace
-        ):
-            line = line[:-1]  # strip terminal newline
-            if is_warning:
-                logger.warning(line)
-            else:
-                logger.error(line)
+        logger.error("Server error: '%s'", error, exc_info=cause)
 
     return flask.Response(
         json.dumps(dict(error=error)),

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -315,7 +315,7 @@ def jsonify_error(error: str, status: HTTPStatus):
     # We also want to show the stack trace for the root cause exception,
     # if there indeed was one.
     exception_type, exception, trace = sys.exc_info()
-    if exception:
+    if exception is None:
         logger.warning("No exception cause")
     else:
         for line in traceback.format_exception(

--- a/sematic/api/endpoints/request_parameters.py
+++ b/sematic/api/endpoints/request_parameters.py
@@ -1,6 +1,8 @@
 # Standard Library
 import json
 import logging
+import sys
+import traceback
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import (
@@ -294,6 +296,37 @@ def get_request_parameters(
 
 
 def jsonify_error(error: str, status: HTTPStatus):
+    is_warning = False
+
+    # Since jsonify_error is explicitly called to handle the
+    # error, there is no uncaught exception to be handled by
+    # the "catch all" exception handler & logger. This ensures
+    # that we generate a log message even for these explicitly
+    # handled errors, so we can triage more easily.
+    if status is None:
+        logger.error("Attempting to create an error without a code: %s", error)
+    elif 400 <= status.value < 500:
+        logger.warning("Bad request error: '%s'", error, stack_info=True)
+        is_warning = True
+    else:
+        logger.exception("Server error: '%s'", error)
+
+    # The above prints the error summary and stack to *this* call.
+    # We also want to show the stack trace for the root cause exception,
+    # if there indeed was one.
+    exception_type, exception, trace = sys.exc_info()
+    if exception:
+        logger.warning("No exception cause")
+    else:
+        for line in traceback.format_exception(
+            etype=exception_type, value=exception, tb=trace
+        ):
+            line = line[:-1]  # strip terminal newline
+            if is_warning:
+                logger.warning(line)
+            else:
+                logger.error(line)
+
     return flask.Response(
         json.dumps(dict(error=error)),
         status=status.value,

--- a/sematic/logs.py
+++ b/sematic/logs.py
@@ -53,7 +53,7 @@ def make_log_config(log_to_disk: bool = False, level: Union[int, str] = logging.
                     **_LOG_FILE_ROTATION_SETTINGS,  # type: ignore
                 ),
                 "error": dict(
-                    level="ERROR",
+                    level="WARNING",
                     filters=["request_context"],
                     filename=os.path.join(get_config().config_dir, "error.log"),
                     **_LOG_FILE_ROTATION_SETTINGS,  # type: ignore


### PR DESCRIPTION
There were a couple of situations where it would be helpful to have errors logged in the server logs, but that wasn't happening. Basically (1) anything that was going uncaught was relying on the `uvicorn.*` logger to get logged, whereas we want it to be handled by the `sematic.*` logger as well, (2) any time we were explicitly returning a json error response, we wouldn't log anything to the server logs unless the particular code calling `jsonify_error` had already logged the exception. This PR addresses both of these.

Testing
--------

Ran the local server and intentionally injected exceptions, both uncaught ones and ones that resulted in a `jsonify_error`. Made sure the exceptions made it to the local server logs. Then did the same thing with code deployed to my namespace.