### PR TITLE
Allow custom image pull secrets

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,7 +81,7 @@ settings by setting the environment variable `SEMATIC_CONFIG_DIR`. This can
 be either a relative path (it will be treated as relative to your home
 directory) or an absolute path.
 
-This is the full list of supported user settings:
+This is a partial list of supported user settings:
 - `SEMATIC_API_ADDRESS`: the address of the Sematic server to use for pipeline
   executions; optional
 - `SEMATIC_API_KEY`: the user's personal API key, used to associate pipeline
@@ -100,24 +100,15 @@ This is the full list of supported user settings:
 The same way that certain settings need to be kept on the user side, certain
 ones need to configure the backend Server.
 
-These can be accessed and modified just like the user settings, but by using
-the `sematic server-settings` command instead:
+The way you configure these depends on how the server you are using is deployed.
+If you are using a local server, created with `sematic start`, you can use:
 
 ```shell
-$ sematic server-settings show
-Active server settings:
-
-KUBERNETES_NAMESPACE: default
-SEMATIC_AUTHORIZED_EMAIL_DOMAIN: XXX
-SEMATIC_AUTHENTICATE: 'true'
-GOOGLE_OAUTH_CLIENT_ID: XXX
-GRAFANA_PANEL_URL: XXX
-
+$ sematic settings set -p sematic.config.server_settings.ServerSettings GRAFANA_PANEL_URL https://grafana.com/
 ```
 
-These settings are simply stored in the `~/.sematic/server.yaml` file on the
-machine which needs to start a backend Server (this file does not have the
-settings nested under a "default" entry):
+These settings are simply stored in the same `~/.sematic/settings.yaml` file on the
+machine where the user settings are stored:
 
 ```shell
 $ cat ~/.sematic/server.yaml
@@ -130,9 +121,10 @@ GRAFANA_PANEL_URL: XXX
 ```
 
 They can also be overridden via environment variables, just like the user
-settings.
+settings. If you have deployed your Sematic server in a Docker container, environment
+variables are the preferred way to configure it.
 
-This is the full list of supported server settings:
+This is a partial list of supported server settings:
 - `SEMATIC_AUTHENTICATE`: whether to require authentication on API calls;
   optional
 - `SEMATIC_AUTHORIZED_EMAIL_DOMAIN`: the email domain that is allowed to create
@@ -140,14 +132,20 @@ This is the full list of supported server settings:
 - `SEMATIC_WORKER_API_ADDRESS`: the address of the remote cloud worker API,
   such as the Kubernetes API; optional; if set, this should be set to the DNS
   location of the Sematic service within Kubernetes
+- `SEMATIC_DASHBOARD_URL`: the address that will be used to construct links
+  to locations in the dashboard (ex: in log outputs).
 - `GOOGLE_OAUTH_CLIENT_ID`: the Google OAuth client ID to use for
   authentication; optional
 - `GITHUB_OAUTH_CLIENT_ID`: the GitHub OAuth client ID to use for
   authentication; optional
-- `KUBERNETES_NAMESPACE`: the namespace to use for Kubernetes jobs; required
-  only for cloud pipeline submissions
 - `GRAFANA_PANEL_URL`: the URL of the Grafana deployment that tracks jobs
   details
+
+There are other settings which are only relevant in the case that you have done
+a helm deployment of Sematic. For these configurations, please refer to our
+(helm docs)[https://sematic-ai.github.io/helm-charts/sematic-server/].
+Note that those docs also provide ways to configure the settings above via helm,
+which is preferred for helm deployments.
 
 ### Cancel pipelines
 

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -52,6 +52,7 @@ data:
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
   ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ .Values.worker.can_customize_security_context | quote }}
+  WORKER_IMAGE_PULL_SECRETS: {{ toJson .Values.worker.image_pull_secrets | quote }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
 {{ if .Values.deployment.socket_io.dedicated }}
   SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -139,6 +139,7 @@ worker:
   service_account:
     name: default
   can_customize_security_context: false
+  image_pull_secrets: null
 
 service:
   create: false

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -1,5 +1,6 @@
 # Standard Library
 import functools
+import json
 from typing import Dict, Tuple, Type, cast
 
 # Sematic
@@ -42,6 +43,10 @@ class ServerSettingsVar(AbstractPluginSettingsVar):
     # Controls which Kubernetes Service Account the server
     # uses for jobs.
     SEMATIC_WORKER_KUBERNETES_SA = "SEMATIC_WORKER_KUBERNETES_SA"
+
+    # What, if any, imagePullSecrets should be used for runner and
+    # standalone jobs?
+    WORKER_IMAGE_PULL_SECRETS = "WORKER_IMAGE_PULL_SECRETS"
 
     # Controls whether users who are defining pipelines can
     # customize the Kubernetes security context in which their
@@ -89,3 +94,15 @@ def get_bool_server_setting(var: ServerSettingsVar, *args) -> bool:
     on the first optional vararg as a default value. If that does not exist, it raises.
     """
     return as_bool(get_server_setting(var, *args))
+
+
+def get_json_server_setting(var: ServerSettingsVar, *args):
+    """
+    Retrieves and returns the specified settings value as a json-encodable, with
+    environment override.
+
+    Loads and returns the specified settings value. If it does not exist, it falls back
+    on the first optional vararg as a default value. If that does not exist, it raises.
+    """
+    as_str = get_server_setting(var, *[json.dumps(arg) for arg in args])
+    return json.loads(as_str)

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -23,6 +23,7 @@ from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR, ON_WORKER_ENV_VAR
 from sematic.config.server_settings import (
     ServerSettingsVar,
     get_bool_server_setting,
+    get_json_server_setting,
     get_server_setting,
 )
 from sematic.config.settings import get_plugin_setting
@@ -543,6 +544,7 @@ def _schedule_kubernetes_job(
     secret_env_vars = []
     tolerations = []
     security_context = None
+    image_pull_secrets = _get_image_pull_secrets()
 
     if resource_requirements is not None:
         node_selector = resource_requirements.kubernetes.node_selector
@@ -620,6 +622,7 @@ def _schedule_kubernetes_job(
                 ),
                 spec=kubernetes.client.V1PodSpec(  # type: ignore
                     node_selector=node_selector,
+                    image_pull_secrets=image_pull_secrets,
                     containers=[
                         kubernetes.client.V1Container(  # type: ignore
                             name=name,
@@ -891,3 +894,35 @@ def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
     volume_mount = V1VolumeMount(mount_path="/dev/shm", name=volume_name)
 
     return volume, volume_mount
+
+
+def _get_image_pull_secrets() -> Optional[
+    List[kubernetes.client.V1LocalObjectReference]
+]:
+    def encodable_to_obj(encodable):
+        if not isinstance(encodable, dict):
+            raise ValueError(
+                f"{ServerSettingsVar.WORKER_IMAGE_PULL_SECRETS.value} should be "
+                f"a list of dictionaries. One entry was: {encodable}"
+            )
+        if "name" not in encodable:
+            raise ValueError(
+                f"An entry in {ServerSettingsVar.WORKER_IMAGE_PULL_SECRETS.value} "
+                f"was missing the 'name' key: {encodable}"
+            )
+        return kubernetes.client.V1LocalObjectReference(name=encodable["name"])
+
+    as_encodables = get_json_server_setting(
+        ServerSettingsVar.WORKER_IMAGE_PULL_SECRETS, None
+    )
+
+    if as_encodables is None:
+        return None
+
+    if not isinstance(as_encodables, list):
+        raise ValueError(
+            f"{ServerSettingsVar.WORKER_IMAGE_PULL_SECRETS.value} should be "
+            f"a list of dictionaries. Got: {as_encodables}"
+        )
+
+    return [encodable_to_obj(encodable) for encodable in as_encodables]

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -907,6 +907,7 @@ def _get_image_pull_secrets() -> Optional[
     pull secret object references.
     https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LocalObjectReference.md
     """
+
     def encodable_to_obj(encodable):
         if not isinstance(encodable, dict):
             raise ValueError(

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -901,6 +901,8 @@ def _get_image_pull_secrets() -> Optional[
 ]:
     """Get custom image pull secrets based on server configuration.
 
+    Uses the WORKER_IMAGE_PULL_SECRETS configuration.
+
     Returns
     -------
     Either None (if no custom pull secrets are configured), or a list of

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -899,6 +899,14 @@ def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
 def _get_image_pull_secrets() -> Optional[
     List[kubernetes.client.V1LocalObjectReference]
 ]:
+    """Get custom image pull secrets based on server configuration.
+
+    Returns
+    -------
+    Either None (if no custom pull secrets are configured), or a list of
+    pull secret object references.
+    https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LocalObjectReference.md
+    """
     def encodable_to_obj(encodable):
         if not isinstance(encodable, dict):
             raise ValueError(


### PR DESCRIPTION
In some cases, runner and standalone pods may need to pull their images from a private registry that isn't automatically accessible on the basis of the service accounts already associated with the pod. This PR makes it possible to specify custom image pull secrets for these pods.

Testing
-------
Deployed to my namespace and tested with and without configuring `worker.image_pull_secrets`. Confirmed that the pods got created with the proper configuration for their imagePullSecrets.