### PR TITLE
Fix error in version CLI command when Server unreachable

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -721,6 +721,7 @@ def _put(
 
 def validate_server_compatibility(
     use_cached: bool = True,
+    retry: bool = True,
 ) -> Dict[Literal["server", "min_client_supported"], List[int]]:
     """Check that the client is compatible with the server.
 
@@ -750,6 +751,7 @@ def validate_server_compatibility(
             attempt_auth=False,
             validate_version_compatibility=False,  # to avoid recursion
             validate_json=True,
+            retry=retry,
         )
     except (BadRequestError, InvalidResponseError):
         raise unexpected_server_response_error

--- a/sematic/cli/version.py
+++ b/sematic/cli/version.py
@@ -6,9 +6,15 @@ import click
 
 # Sematic
 from sematic import api_client
+from sematic.api_client import APIConnectionError
 from sematic.cli.cli import cli
 from sematic.config.config import switch_env
 from sematic.versions import CURRENT_VERSION_STR, version_as_string
+
+UNREACHABLE_SERVER_MESSAGE = (
+    "The configured server is unreachable. Please see this documentation for help: "
+    "https://docs.sematic.dev/onboarding/get-started#starting-the-web-dashboard"
+)
 
 
 @cli.command("version", short_help="Print version information.")
@@ -18,14 +24,23 @@ def version():
     """
     switch_env("user")
     click.echo(f"Sematic client v{CURRENT_VERSION_STR} is installed.")
+
     try:
-        server_version_metadata = api_client.validate_server_compatibility()
-        server_version = version_as_string(server_version_metadata["server"])
-        min_client_version = version_as_string(
-            server_version_metadata["min_client_supported"]
-        )
-        click.echo(f"The server is at version v{server_version}")
-        click.echo(f"Client versions >= v{min_client_version} are supported.")
+        try:
+            server_version_metadata = api_client.validate_server_compatibility(
+                retry=False
+            )
+            server_version = version_as_string(server_version_metadata["server"])
+            min_client_version = version_as_string(
+                server_version_metadata["min_client_supported"]
+            )
+            click.echo(f"The server is at version v{server_version}")
+            click.echo(f"Client versions >= v{min_client_version} are supported.")
+
+        except APIConnectionError:
+            click.echo(UNREACHABLE_SERVER_MESSAGE)
+
     except api_client.IncompatibleClientError as e:
         click.echo(str(e))
+
     click.echo(f"Python v{platform.python_version()} is running this binary.")


### PR DESCRIPTION
When the Server is unreachable:
```
$ sematic version
Sematic client v0.34.1 is installed.
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 1 seconds with 6 tries left...
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 2.1 seconds with 5 tries left...
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 4.3 seconds with 4 tries left...
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 8.7 seconds with 3 tries left...
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 17.5 seconds with 2 tries left...
WARNING:sematic.utils.retry:Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
WARNING:sematic.utils.retry:Retrying request in 35.1 seconds with 1 tries left...
Traceback (most recent call last):
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 714, in urlopen
    httplib_response = self._make_request(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 415, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connection.py", line 244, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/local/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.10/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.10/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.10/http/client.py", line 1037, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.10/http/client.py", line 975, in send
    self.connect()
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f420e1bd2d0>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 798, in urlopen
    retries = retries.increment(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='127.0.0.1', port=5001): Max retries exceeded with url: /api/v1/meta/versions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f420e1bd2d0>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/api_client.py", line 840, in request
    response = retry_call(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/utils/retry.py", line 206, in retry_call
    return __retry_internal(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/utils/retry.py", line 77, in __retry_internal
    return f()
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=5001): Max retries exceeded with url: /api/v1/meta/versions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f420e1bd2d0>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tudor/sematic_venv/bin/sematic", line 8, in <module>
    sys.exit(cli())
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/cli/version.py", line 22, in version
    server_version_metadata = api_client.validate_server_compatibility()
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/api_client.py", line 740, in validate_server_compatibility
    response = request(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/api_client.py", line 808, in request
    return retry_call(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/utils/retry.py", line 206, in retry_call
    return __retry_internal(
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/utils/retry.py", line 77, in __retry_internal
    return f()
  File "/home/tudor/sematic_venv/lib/python3.10/site-packages/sematic/api_client.py", line 852, in request
    raise APIConnectionError(
sematic.api_client.APIConnectionError: Unable to connect to the Sematic API at http://127.0.0.1:5001.
Make sure the correct server address is set with
	$ sematic settings set SEMATIC_API_ADDRESS <address>
```

## Testing

```
$ bazel run sematic/cli:main -- version
[...]
Sematic client v0.34.1 is installed.
The configured server is unreachable. Please see this documentation for help: https://docs.sematic.dev/onboarding/get-started#starting-the-web-dashboard
Python v3.8.15 is running this binary.
```
