### PR TITLE
Fix serialization dataclass check

### DIFF
--- a/sematic/types/serialization.py
+++ b/sematic/types/serialization.py
@@ -210,7 +210,8 @@ def _is_dataclass(type_: typing.Any) -> bool:
     # We don't use dataclasses.is_dataclass because we don't
     # want to know whether any parent classes are dataclasses, just
     # this one
-    return "__dataclass_fields__" in type_.__dict__
+    dunder_dict = getattr(type_, "__dict__", {})
+    return "__dataclass_fields__" in dunder_dict
 
 
 def _get_category(type_: typing.Any) -> str:

--- a/sematic/types/tests/BUILD
+++ b/sematic/types/tests/BUILD
@@ -29,3 +29,11 @@ pytest_test(
         "//sematic/types:registry",
     ]
 )
+
+pytest_test(
+    name = "test_serialization",
+    srcs = ["test_serialization.py"],
+    deps = [
+        "//sematic/types:serialization",
+    ]
+)

--- a/sematic/types/tests/test_serialization.py
+++ b/sematic/types/tests/test_serialization.py
@@ -1,0 +1,33 @@
+# Standard Library
+from dataclasses import dataclass
+from typing import Union
+
+# Sematic
+from sematic.types.serialization import _is_dataclass
+
+
+@dataclass
+class Dc:
+    field: int
+
+
+class DcChild(Dc):
+    pass
+
+
+@dataclass
+class DcDcChild(Dc):
+    field2: int
+
+
+class Plain:
+    pass
+
+
+def test_is_dataclass():
+    assert _is_dataclass(Dc)
+    assert not _is_dataclass(DcChild)
+    assert not _is_dataclass(Plain)
+    assert _is_dataclass(DcDcChild)
+    assert not _is_dataclass(Union[Dc, Plain])
+    assert not _is_dataclass(Union)


### PR DESCRIPTION
The code for checking whether a type in `serialization.py` would fail if given `_is_dataclass(Union)`, because `Union` has no `__dict__`. This change fixes it. Note that if you use a bare `Union` in a function type annotation, you still get the following:

```
TypeError: Invalid type annotation for argument 'x' of sematic.tests.test_function.f: typing.Union must be parametrized (typing.Union[...] instead of typing.Union).
```