### PR TITLE
Remove configurability for dedicated socket io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ commands:
           pkg-manager: pip
           app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
           pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
-      - run:
-          # This is necessary because some packages have platform-dependent dependencies
-          # For example sqlalchemy requires greenlet only on certain platforms
-          name: Freeze requirements
-          command: pip-compile --resolver=backtracking --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
+      # - run:
+      #     # This is necessary because some packages have platform-dependent dependencies
+      #     # For example sqlalchemy requires greenlet only on certain platforms
+      #     name: Freeze requirements
+      #     command: pip-compile --resolver=backtracking --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
   
   install-npm-dependencies:
     description: Install NPM dependencies in the UI folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,6 @@ commands:
           pkg-manager: pip
           app-dir: ~/project/requirements  # If you're requirements.txt isn't in the root directory.
           pip-dependency-file: ci-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
-      # - run:
-      #     # This is necessary because some packages have platform-dependent dependencies
-      #     # For example sqlalchemy requires greenlet only on certain platforms
-      #     name: Freeze requirements
-      #     command: pip-compile --resolver=backtracking --allow-unsafe ~/project/requirements/requirements.in > ~/project/requirements/requirements.txt
   
   install-npm-dependencies:
     description: Install NPM dependencies in the UI folder

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -117,6 +117,20 @@ delta, but only:
 when performing the upgrade.
 {% endhint %}
 
+### vX.X.X to v0.35.0
+
+In v0.35.0 support for deploying Sematic with a combined API and SocketIO server
+was removed. Most users deploy with a dedicated SocketIO server anyway, in which
+case this change does not impact you. You may still want to remove the
+`deployment.socket_io.dedicated` configuration from your helm values, as it will
+now be ignored.
+
+The default for the helm configuration `service.create` was changed to `true` as
+well. Again, most users have this set to `true` in which case it does not impact
+you. If you were relying on the default to be `false` so you could create your
+own Kubernetes service object for Sematic, you now must explicitly set
+`service.create` to `false` in your helm values.
+ 
 ### vX.X.X to v0.32.0
 
 In v0.32.0 new constraints were added to the schema of the database that

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -54,9 +54,7 @@ data:
   ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ .Values.worker.can_customize_security_context | quote }}
   WORKER_IMAGE_PULL_SECRETS: {{ toJson .Values.worker.image_pull_secrets | quote }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
-{{ if .Values.deployment.socket_io.dedicated }}
   SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}
-{{ end }}
 {{ if .Values.ingress.sematic_dashboard_url }}
   SEMATIC_DASHBOARD_URL: {{ .Values.ingress.sematic_dashboard_url | quote }}
 {{ end }}

--- a/helm/sematic-server/templates/deployment.yaml
+++ b/helm/sematic-server/templates/deployment.yaml
@@ -4,11 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
-    {{- if .Values.deployment.socket_io.dedicated }}
     app.kubernetes.io/component: api
-    {{- else }}
-    app.kubernetes.io/component: all
-    {{- end }}
 spec:
   {{- if not .Values.deployment.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replica_count }}
@@ -16,11 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "sematic-server.selectorLabels" . | nindent 6 }}
-      {{- if .Values.deployment.socket_io.dedicated }}
       sematic.ai/component: api
-      {{- else }}
-      sematic.ai/component: all
-      {{- end }}
   template:
     metadata:
       {{- with .Values.deployment.annotations }}
@@ -29,11 +21,7 @@ spec:
       {{- end }}
       labels:
         {{- include "sematic-server.selectorLabels" . | nindent 8 }}
-        {{- if .Values.deployment.socket_io.dedicated }}
         sematic.ai/component: api
-        {{- else }}
-        sematic.ai/component: all
-        {{- end }}
     spec:
       {{- with .Values.image.pull_secrets }}
       imagePullSecrets:

--- a/helm/sematic-server/templates/ingress.yaml
+++ b/helm/sematic-server/templates/ingress.yaml
@@ -55,7 +55,6 @@ spec:
             name: {{ $serviceName }}
             port:
               number: {{ $servicePort }}
-      {{- if $.Values.deployment.socket_io.dedicated }}
       - path: {{ printf "%s/socket.io" (.path | trimSuffix "/") }}
         {{- if .pathType }}
         pathType: {{ .pathType }}
@@ -74,7 +73,6 @@ spec:
             name: {{ $socketioServiceName }}
             port:
               number: {{ $servicePort }}
-      {{- end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/sematic-server/templates/pdb.yaml
+++ b/helm/sematic-server/templates/pdb.yaml
@@ -8,9 +8,5 @@ spec:
   selector:
     matchLabels:
       {{- include "sematic-server.labels" . | nindent 6 }}
-      {{- if .Values.deployment.socket_io.dedicated }}
       app.kubernetes.io/component: api
-      {{- else }}
-      app.kubernetes.io/component: all
-      {{- end }}
 {{- end }}

--- a/helm/sematic-server/templates/service.yaml
+++ b/helm/sematic-server/templates/service.yaml
@@ -5,11 +5,7 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "sematic-server.labels" . | nindent 4 }}
-    {{- if .Values.deployment.socket_io.dedicated }}
     app.kubernetes.io/component: api
-    {{- else }}
-    app.kubernetes.io/component: all
-    {{- end }}
   annotations:
     {{- if .Values.gcp.enabled }}
     {{- if .Values.ingress.create }}
@@ -28,9 +24,5 @@ spec:
       name: http
   selector:
     {{- include "sematic-server.selectorLabels" . | nindent 4 }}
-    {{- if .Values.deployment.socket_io.dedicated }}
     sematic.ai/component: api
-    {{- else }}
-    sematic.ai/component: all
-    {{- end }}
 {{- end }}

--- a/helm/sematic-server/templates/socketio_deployment.yaml
+++ b/helm/sematic-server/templates/socketio_deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.deployment.socket_io.dedicated }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,4 +68,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}

--- a/helm/sematic-server/templates/socketio_service.yaml
+++ b/helm/sematic-server/templates/socketio_service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.service.create }}
-{{- if .Values.deployment.socket_io.dedicated }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,5 +18,4 @@ spec:
   selector:
     {{- include "sematic-server.selectorLabels" . | nindent 4 }}
     sematic.ai/component: socket_io
-{{- end }}
 {{- end }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -48,9 +48,7 @@ database:
   auto_migrate: true
 
 deployment:
-  socket_io:
-    dedicated: true
-  worker_count: 1 # if you want to increase this, enable socket_io.dedicated above
+  worker_count: 1
   replica_count: 2
   affinity: {}
   annotations: {}
@@ -147,7 +145,7 @@ worker:
   image_pull_secrets: null
 
 service:
-  create: false
+  create: true
   type: ClusterIP
   port: 80
 

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -49,7 +49,7 @@ database:
 
 deployment:
   socket_io:
-    dedicated: false
+    dedicated: true
   worker_count: 1 # if you want to increase this, enable socket_io.dedicated above
   replica_count: 2
   affinity: {}

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -53,7 +53,7 @@ seaborn
 matplotlib
 statsmodels
 scikit-learn
-numpy
+numpy>=1.24.0
 xgboost
 accelerate
 datasets>=2.12.0


### PR DESCRIPTION
You actually get errors connecting to socketio if you don't use a dedicated socketio. So the default setting is broken. This PR makes it so that this is no longer configurable, and you must have a dedicated socketio server. It also changes the default value for whether to create a service to `true`, which is the more appropriate value (that is another place where a vanilla install would fail to work as expected).

Tested by deleting the staging deployment, removing the configs for the standalone SocketIO server and the service creation from the staging deployment's chart, and installed the deployment to staging again.