### PR TITLE
Change the default to be usage of the new UI

### DIFF
--- a/sematic/ui/packages/common/src/component/SettingsMenu.tsx
+++ b/sematic/ui/packages/common/src/component/SettingsMenu.tsx
@@ -25,7 +25,7 @@ const PaperStyleOverride = css`
 
 export function SwitchUICommand() {
     const switchToOldUI = useCallback(() => {
-        window.localStorage.removeItem("sematic-feature-flag-newui");
+        window.localStorage.setItem("sematic-feature-flag-oldui", "true");
         window.location.reload();
     }, []);
 

--- a/sematic/ui/packages/main/src/components/PromotionBanner.tsx
+++ b/sematic/ui/packages/main/src/components/PromotionBanner.tsx
@@ -32,7 +32,7 @@ const PromotionBanner = (props: PromotionBannerProps) => {
     const { onClose } = props;
 
     const switchToNewUI = useCallback(() => {
-        window.localStorage.setItem("sematic-feature-flag-newui", "true");
+        window.localStorage.removeItem("sematic-feature-flag-oldui");
         window.location.reload();
     }, []);
 

--- a/sematic/ui/packages/main/src/components/SideBar.tsx
+++ b/sematic/ui/packages/main/src/components/SideBar.tsx
@@ -21,7 +21,7 @@ import logo from "../Fox.png";
 import UserAvatar from "./UserAvatar";
 
 const switchToNewUI = () => {
-    window.localStorage.setItem("sematic-feature-flag-newui", "true");
+    window.localStorage.removeItem("sematic-feature-flag-oldui");
     window.location.reload();
 };
 

--- a/sematic/ui/packages/main/src/index.tsx
+++ b/sematic/ui/packages/main/src/index.tsx
@@ -87,7 +87,7 @@ function App() {
     </SlotFillProvider>;
 }
 
-const isNewUIEnabled = getFeatureFlagValue("newui");
+const isNewUIEnabled = !getFeatureFlagValue("oldui");
 
 const NewRoutesOverrides = isNewUIEnabled ? (<>
     <Route path="runs" element={<NewShell />} >

--- a/sematic/ui/packages/tests/e2e/main.cy.ts
+++ b/sematic/ui/packages/tests/e2e/main.cy.ts
@@ -1,16 +1,10 @@
 describe("Sematic application", () => {
     it("renders the get started page", () => {
-        cy.then(() => {
-            window.localStorage.setItem("sematic-feature-flag-newui", "true");
-        });
         cy.visit("/getstarted");
         cy.contains("Start your own project");
     });
 
     it("renders the pipeline index page", () => {
-        cy.then(() => {
-            window.localStorage.setItem("sematic-feature-flag-newui", "true");
-        });
         cy.visit("/pipelines");
 
         const table = cy.getBySel("RunList");
@@ -22,9 +16,6 @@ describe("Sematic application", () => {
     });
 
     it("renders the run search page", () => {
-        cy.then(() => {
-            window.localStorage.setItem("sematic-feature-flag-newui", "true");
-        });
         cy.visit("/runs");
 
         const table = cy.getBySel("RunList");
@@ -36,9 +27,6 @@ describe("Sematic application", () => {
     });
 
     it("renders the run details page", () => {
-        cy.then(() => {
-            window.localStorage.setItem("sematic-feature-flag-newui", "true");
-        });
         cy.visit("/runs");
 
         cy.getBySel("runlist-row").first().click();


### PR DESCRIPTION
The new dashboard has been vetted well enough that we can change the default behavior to be using the new UI. We still likely want to keep the old one around for a few more releases in case this change surfaces new users that haven't tried the dashboard and run into problems. If that happens, we can fix their issues and let them manually switch back to the old one as a mitigation.

Testing
--------
Cleared my local storage, rebuilt & started the app, and refreshed my page. Confirmed it used the new UI. Used the toggles to switch between the new and old UIs and confirmed that they still toggle.