### PR TITLE
Capability of mounting underlying node paths in the pod

### DIFF
--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -187,6 +187,8 @@ changes.
               --raise-retry 0.7 \
               --external-resource \
               --expand-shared-memory \
+              --mount-host-path /tmp /test \
+              --mount-host-path /tmp /test2 \
               --cache-namespace test \
               --images \
               --virtual-funcs \

--- a/docs/api.md
+++ b/docs/api.md
@@ -211,14 +211,15 @@ Information on the Kubernetes resources required.
 - `security_context`: KubernetesSecurityContext
 
     Custom security context for your container to run in. Can ONLY be set
-    if your Sematic administrator has enabled the
-    `ALLOW_CUSTOM_SECURITY_CONTEXTS` server setting.
+    if your Sematic cluster administrator has enabled the
+    `ALLOW_CUSTOM_SECURITY_CONTEXTS` Server setting.
 
 - `host_path_mounts`: List[KubernetesHostPathMount]
 
     The "hostPath"-type configurations for volumes to mount on the pod to allow access to
-    the underlying nodes' file systems. More details can be found here:
-    https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+    the underlying nodes' file systems. Can ONLY be used if your Sematic cluster
+    administrator has enabled the `ALLOW_HOST_PATH_MOUNTING` Server setting. More details
+    can be found here: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 
 ### `KubernetesSecretMount`
 
@@ -356,7 +357,8 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 
 ### `KubernetesSecurityContext`
 
-A custom security context for your Sematic job to run in. The
+A custom security context for your Sematic job to run in. Can ONLY be used if your Sematic
+cluster administrator has enabled the `ALLOW_CUSTOM_SECURITY_CONTEXTS` Server setting. The
 following docs are sourced from the
 [Kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core).
 For more up-to-date documentation, please refer to those docs.
@@ -403,16 +405,13 @@ For more up-to-date documentation, please refer to those docs.
 ### `KubernetesHostPathMount`
 
 A "hostPath"-type configuration for a volume to mount on the pod to allow access to the
-underlying node's file system.
+underlying node's file system. Can ONLY be used if your Sematic cluster administrator has
+enabled the `ALLOW_HOST_PATH_MOUNTING` Server setting.
 
 More details can be found here:
 https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 
 #### Parameters
-
-- `name`: str
-
-    The name of the volume. Corresponds to the "name" configuration.
 
 - `node_path`: str
 
@@ -423,6 +422,12 @@ https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 
     The path where to mount the volume in the pod. Corresponds to the "mountPath"
     configuration.
+
+- `name`: str
+
+    The name of the volume. Must be an RFC 1123-compliant max 64-character label.
+    Corresponds to the "name" configuration. If unspecified, or set as None or empty, will
+    default to a label that is auto-generated based on the `pod_mount_path`.
 
 - `type`: str
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,12 @@ Information on the Kubernetes resources required.
     if your Sematic administrator has enabled the
     `ALLOW_CUSTOM_SECURITY_CONTEXTS` server setting.
 
+- `host_path_mounts`: List[KubernetesHostPathMount]
+
+    The "hostPath"-type configurations for volumes to mount on the pod to allow access to
+    the underlying nodes' file systems. More details can be found here:
+    https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+
 ### `KubernetesSecretMount`
 
 Information about how to expose Kubernetes secrets when running a Sematic func.
@@ -393,6 +399,35 @@ For more up-to-date documentation, please refer to those docs.
 - `drop`: List[str]
 
     The capabilities to drop.
+
+### `KubernetesHostPathMount`
+
+A "hostPath"-type configuration for a volume to mount on the pod to allow access to the
+underlying node's file system.
+
+More details can be found here:
+https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+
+#### Parameters
+
+- `name`: str
+
+    The name of the volume. Corresponds to the "name" configuration.
+
+- `node_path`: str
+
+    The path on the underlying node to mount into the pod. Corresponds to the "path"
+    configuration.
+
+- `pod_mount_path`: str
+
+    The path where to mount the volume in the pod. Corresponds to the "mountPath"
+    configuration.
+
+- `type`: str
+
+    The type of the volume mount. Corresponds to the "type" configuration. Defaults to
+    the empty string.
 
 ## Fault tolerance
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -111,7 +111,7 @@ These settings are simply stored in the same `~/.sematic/settings.yaml` file on 
 machine where the user settings are stored:
 
 ```shell
-$ cat ~/.sematic/server.yaml
+$ cat ~/.sematic/settings.yaml
 AWS_S3_BUCKET: XXX
 KUBERNETES_NAMESPACE: default
 SEMATIC_AUTHORIZED_EMAIL_DOMAIN: XXX

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -52,6 +52,7 @@ data:
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
   ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ .Values.worker.can_customize_security_context | quote }}
+  ALLOW_HOST_PATH_MOUNTING: {{ .Values.worker.can_mount_host_paths | quote }}
   WORKER_IMAGE_PULL_SECRETS: {{ toJson .Values.worker.image_pull_secrets | quote }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
   SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -142,6 +142,7 @@ worker:
   service_account:
     name: default
   can_customize_security_context: false
+  can_mount_host_paths: false
   image_pull_secrets: null
 
 service:

--- a/sematic/__init__.py
+++ b/sematic/__init__.py
@@ -47,6 +47,7 @@ from sematic.resolvers.cloud_resolver import CloudResolver  # noqa: F401,E402
 from sematic.resolvers.local_resolver import LocalResolver  # noqa: F401,E402
 from sematic.resolvers.resource_requirements import (  # noqa: F401,E402
     KubernetesCapabilities,
+    KubernetesHostPathMount,
     KubernetesResourceRequirements,
     KubernetesSecretMount,
     KubernetesSecurityContext,

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -53,6 +53,10 @@ class ServerSettingsVar(AbstractPluginSettingsVar):
     # job runs.
     ALLOW_CUSTOM_SECURITY_CONTEXTS = "ALLOW_CUSTOM_SECURITY_CONTEXTS"
 
+    # Controls whether users can mount underlying Kubernetes node
+    # paths into the Worker pods.
+    ALLOW_HOST_PATH_MOUNTING = "ALLOW_HOST_PATH_MOUNTING"
+
     # GRAFANA
     GRAFANA_PANEL_URL = "GRAFANA_PANEL_URL"
 

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -5,11 +5,14 @@ Flexible-structure pipeline meant to be used in testing.
 import logging
 import os
 import random
+import shutil
 import sys
 import time
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 # Third-party
+import psutil
 import ray
 
 # Sematic
@@ -17,7 +20,11 @@ import sematic
 from sematic.ee.ray import RayCluster, RayNodeConfig, SimpleRayCluster
 from sematic.function import _make_tuple
 from sematic.plugins.external_resource.timed_message import TimedMessage
-from sematic.resolvers.resource_requirements import ResourceRequirements
+from sematic.resolvers.resource_requirements import (
+    KubernetesHostPathMount,
+    KubernetesResourceRequirements,
+    ResourceRequirements,
+)
 from sematic.types import Image, S3Location
 from sematic.types.serialization import get_json_encodable_summary
 
@@ -104,15 +111,51 @@ def add_using_resource(a: float, b: float) -> float:
 
 
 @sematic.func(standalone=True)
-def add_with_resource_requirements(a: float, b: float) -> float:
+def add_with_expanded_shared_memory(a: float, b: float) -> float:
     """
-    Adds two numbers with ResourceRequirements.
+    Adds two numbers with an expanded shared memory partition.
     """
     # Disclaimer: Does not come with ResourceRequirements!
     # You need to specify your own by doing:
-    #   function = add_with_resource_requirements(...)
+    #   function = add_with_*(...)
     #   function.set(resource_requirements=my_resource_requirements)
-    logger.info("Executing: add_with_resource_requirements(a=%s, b=%s)", a, b)
+    logger.info("Executing: add_with_expanded_shared_memory(a=%s, b=%s)", a, b)
+
+    memory_mb = int(psutil.virtual_memory().total / 1024 / 1024)
+    logger.info("System memory capacity: %s MB", memory_mb)
+    root_mb = int(shutil.disk_usage("/")[0] / 1024 / 1024)
+    logger.info("Root partition size: %s MB", root_mb)
+    shm_mb = int(shutil.disk_usage("/dev/shm")[0] / 1024 / 1024)
+    logger.info("Shared memory partition size: %s MB", shm_mb)
+
+    time.sleep(5)
+    return a + b
+
+
+@sematic.func(standalone=True)
+def add_with_host_path_mounts(a: float, b: float, pod_mount_paths: List[str]) -> float:
+    """
+    Adds two numbers with mounted host paths.
+    """
+    # Disclaimer: Does not come with ResourceRequirements!
+    # You need to specify your own by doing:
+    #   function = add_with_*(...)
+    #   function.set(resource_requirements=my_resource_requirements)
+    logger.info(
+        "Executing: add_with_host_path_mounts(a=%s, b=%s, pod_mount_paths=%s)",
+        a,
+        b,
+        pod_mount_paths,
+    )
+
+    for pod_mount_path in pod_mount_paths:
+        with open(Path(pod_mount_path) / "sammy.txt", "wt") as f:
+            f.write("Sammy was here")
+
+        logger.info("Contents of '%s':", pod_mount_path)
+        os.system(f"ls -la {pod_mount_path}")
+        sys.stdout.flush()
+
     time.sleep(5)
     return a + b
 
@@ -452,7 +495,8 @@ def testing_pipeline(
     oom: bool = False,
     external_resource: bool = False,
     ray_resource: bool = False,
-    resource_requirements: Optional[ResourceRequirements] = None,
+    expand_shared_memory: bool = False,
+    mount_host_paths: Optional[List[Tuple[str, str]]] = None,
     cache: bool = False,
     images: bool = False,
     s3_uris: Optional[List[str]] = None,
@@ -503,9 +547,13 @@ def testing_pipeline(
     oom: bool
         Whether to include a function that causes an Out of Memory error.
         Defaults to False.
-    resource_requirements: Optional[ResourceRequirements]
-        If not None, includes a function that runs with the specified requirements.
+    expand_shared_memory: bool
+        Whether to include a function that mounts an expanded shared memory volume.
         Defaults to False.
+    mount_host_paths: Optional[List[Tuple[str, str]]]
+        If not None, includes a function that mounts the specified volumes from the
+        underlying node into the pod, and creates testimony files in each of these
+        locations. Defaults to None.
     external_resource: bool
         Whether to use an external resource. Defaults to False.
     ray_resource: bool
@@ -596,8 +644,45 @@ def testing_pipeline(
         futures.append(add_using_resource(initial_future, 1.0))
         futures.append(add_inline_using_resource(initial_future, 1.0))
 
-    if resource_requirements is not None:
-        future = add_with_resource_requirements(initial_future, 3)
+    if expand_shared_memory:
+        k8_resource_requirements = KubernetesResourceRequirements(
+            mount_expanded_shared_memory=True
+        )
+        resource_requirements = ResourceRequirements(
+            kubernetes=k8_resource_requirements
+        )
+
+        future = add_with_expanded_shared_memory(initial_future, 3)
+        future.set(resource_requirements=resource_requirements)
+        futures.append(future)
+
+    if mount_host_paths:
+        k8_host_path_mounts = []
+        pod_mount_paths = []
+        for node_path, pod_mount_path in mount_host_paths:
+            # from the kubernetes documentation:
+            # > a lowercase RFC 1123 label must consist of lower case alphanumeric
+            # > characters or '-', and must start and end with an alphanumeric character
+            # > (e.g. 'my-name',  or '123-abc', regex used for validation is
+            # > '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+            name = f"volume{pod_mount_path.replace('/', '-')}"
+            host_path_mount = KubernetesHostPathMount(
+                name=name,
+                node_path=node_path,
+                pod_mount_path=pod_mount_path,
+                type="Directory",
+            )
+            k8_host_path_mounts.append(host_path_mount)
+            pod_mount_paths.append(pod_mount_path)
+
+        k8_resource_requirements = KubernetesResourceRequirements(
+            host_path_mounts=k8_host_path_mounts
+        )
+        resource_requirements = ResourceRequirements(
+            kubernetes=k8_resource_requirements
+        )
+
+        future = add_with_host_path_mounts(initial_future, 3, pod_mount_paths)
         future.set(resource_requirements=resource_requirements)
         futures.append(future)
 

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -660,17 +660,8 @@ def testing_pipeline(
         k8_host_path_mounts = []
         pod_mount_paths = []
         for node_path, pod_mount_path in mount_host_paths:
-            # from the kubernetes documentation:
-            # > a lowercase RFC 1123 label must consist of lower case alphanumeric
-            # > characters or '-', and must start and end with an alphanumeric character
-            # > (e.g. 'my-name',  or '123-abc', regex used for validation is
-            # > '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
-            name = f"volume{pod_mount_path.replace('/', '-')}"
             host_path_mount = KubernetesHostPathMount(
-                name=name,
-                node_path=node_path,
-                pod_mount_path=pod_mount_path,
-                type="Directory",
+                node_path=node_path, pod_mount_path=pod_mount_path, type="Directory"
             )
             k8_host_path_mounts.append(host_path_mount)
             pod_mount_paths.append(pod_mount_path)

--- a/sematic/examples/testing_pipeline/requirements.txt
+++ b/sematic/examples/testing_pipeline/requirements.txt
@@ -1,3 +1,4 @@
 debugpy
+psutil
 ray>=2.2.0
 sematic[ray]

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -52,7 +52,7 @@ class KubernetesSecretMount:
 
 @unique
 class KubernetesTolerationOperator(Enum):
-    """The way that a toleration should be checked to see if it applies
+    """The way that a toleration should be checked to see if it applies.
 
     See Kubernetes documentation for more:
     https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -77,7 +77,7 @@ class KubernetesTolerationOperator(Enum):
 
 @unique
 class KubernetesTolerationEffect(Enum):
-    """The effect that the toleration is meant to tolerate
+    """The effect that the toleration is meant to tolerate.
 
     See Kubernetes documentation for more:
     https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -110,7 +110,7 @@ class KubernetesTolerationEffect(Enum):
 
 @dataclass(frozen=True)
 class KubernetesToleration:
-    """Toleration for a node taint, enabling the pod for the function to run on the node
+    """Toleration for a node taint, enabling the pod for the function to run on the node.
 
     See Kubernetes documentation for more:
     https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -142,7 +142,7 @@ class KubernetesToleration:
     toleration_seconds: Optional[int] = None
 
     def to_api_keyword_args(self) -> Dict[str, Optional[Union[str, int]]]:
-        """Convert to the format for kwargs the API python client API for tolerations"""
+        """Convert to the format for kwargs the API python client API for tolerations."""
         effect: Optional[str] = self.effect.value
         if self.effect == KubernetesTolerationEffect.All:
             # the actual API makes "all" the default behavior with no other way to
@@ -158,7 +158,7 @@ class KubernetesToleration:
         )
 
     def __post_init__(self):
-        """Ensure that the values in the toleration are valid; raise otherwise
+        """Ensure that the values in the toleration are valid; raise otherwise.
 
         Raises
         ------
@@ -203,9 +203,9 @@ class KubernetesCapabilities:
 
     Attributes
     ----------
-    add:
+    add: List[str]
         Added capabilities
-    drop:
+    drop: List[str]
         Dropped capabilities
     """
 
@@ -222,17 +222,17 @@ class KubernetesSecurityContext:
 
     Attributes
     ----------
-    allow_privilege_escalation:
+    allow_privilege_escalation: bool
         AllowPrivilegeEscalation controls whether a process can gain more privileges
         than its parent process. This bool directly controls if the no_new_privs
         flag will be set on the container process. AllowPrivilegeEscalation is true
         always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note
         that this field cannot be set when spec.os.name is windows.
-    privileged:
+    privileged: bool
         Run container in privileged mode. Processes in privileged containers are
         essentially equivalent to root on the host. Defaults to false. Note that
         this field cannot be set when spec.os.name is windows.
-    capabilities:
+    capabilities: KubernetesCapabilities
         The capabilities to add/drop when running containers. Defaults to the default
         set of capabilities granted by the container runtime. Note that this field
         cannot be set when spec.os.name is windows.
@@ -244,18 +244,47 @@ class KubernetesSecurityContext:
 
 
 @dataclass(frozen=True)
+class KubernetesHostPathMount:
+    """A "hostPath"-type configuration for a volume to mount on the pod to allow access to
+    the underlying node's file system.
+
+    More details can be found here:
+    https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+
+    Attributes
+    ----------
+    name: str
+        The name of the volume. Corresponds to the "name" configuration.
+    node_path: str
+        The path on the underlying node to mount into the pod. Corresponds to the "path"
+        configuration.
+    pod_mount_path: str
+        The path where to mount the volume in the pod. Corresponds to the "mountPath"
+        configuration.
+    type: str
+        The type of the volume mount. Corresponds to the "type" configuration. Defaults to
+        the empty string.
+    """
+
+    name: str
+    node_path: str
+    pod_mount_path: str
+    type: str = field(default="")
+
+
+@dataclass(frozen=True)
 class KubernetesResourceRequirements:
     """Information on the Kubernetes resources required.
 
     Attributes
     ----------
     node_selector: Dict[str, str]
-        The kind of Kubernetes node that the job must run on. More detail can
+        The kind of Kubernetes node that the job must run on. More details can
         be found here:
         https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
         The value of this field will be used as the nodeSelector described there.
     requests: Dict[str, str]
-        Requests for resources on a kubernetes pod. More detail can be found
+        Requests for resources on a kubernetes pod. More details can be found
         here:
         https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         The values used here will apply to both the "requests" and the "limits" of the
@@ -277,6 +306,10 @@ class KubernetesResourceRequirements:
         The Kubernetes security context the job will run with. Note that this
         field will only be respected if ALLOW_CUSTOM_SECURITY_CONTEXTS has been
         enabled by your Sematic administrator.
+    host_path_mounts: List[KubernetesHostPathMount]
+        The "hostPath"-type configurations for volumes to mount on the pod to allow access
+        to the underlying nodes' file systems. More details can be found here:
+        https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
     """
 
     node_selector: Dict[str, str] = field(default_factory=dict)
@@ -284,7 +317,8 @@ class KubernetesResourceRequirements:
     secret_mounts: KubernetesSecretMount = field(default_factory=KubernetesSecretMount)
     tolerations: List[KubernetesToleration] = field(default_factory=list)
     mount_expanded_shared_memory: bool = field(default=False)
-    security_context: Optional[KubernetesSecurityContext] = None
+    security_context: Optional[KubernetesSecurityContext] = field(default=None)
+    host_path_mounts: List[KubernetesHostPathMount] = field(default_factory=list)
 
     def clone(self) -> "KubernetesResourceRequirements":
         """Deep copy these requirements."""

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -1,7 +1,9 @@
 # Standard Library
+import re
 from dataclasses import dataclass, field, replace
 from enum import Enum, unique
 from typing import Dict, List, Optional, Union
+from uuid import uuid4
 
 KUBERNETES_SECRET_NAME = "sematic-func-secrets"
 
@@ -253,23 +255,44 @@ class KubernetesHostPathMount:
 
     Attributes
     ----------
-    name: str
-        The name of the volume. Corresponds to the "name" configuration.
     node_path: str
         The path on the underlying node to mount into the pod. Corresponds to the "path"
         configuration.
     pod_mount_path: str
         The path where to mount the volume in the pod. Corresponds to the "mountPath"
         configuration.
+    name: str
+        The name of the volume. Must be an RFC 1123-compliant max 64-character label.
+        Corresponds to the "name" configuration. If unspecified, or set as None or empty,
+        will default to a label that is auto-generated based on the `pod_mount_path`.
     type: str
         The type of the volume mount. Corresponds to the "type" configuration. Defaults to
         the empty string.
     """
 
-    name: str
     node_path: str
     pod_mount_path: str
+    name: str = field(default="")
     type: str = field(default="")
+
+    def __post_init__(self):
+        if not self.name:
+            # from the kubernetes documentation:
+            # > a lowercase RFC 1123 label must consist of lower case alphanumeric
+            # > characters or '-', and must start and end with an alphanumeric character
+            # > (e.g. 'my-name', or '123-abc', regex used for validation is
+            # > '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+            sanitized = re.sub("_|/|\\s", "-", self.pod_mount_path)
+            # pod_mount_path must be absolute, so we know sanitized starts with a dash
+            name = f"volume{sanitized}"
+            # must also have at most 64 characters
+            if len(name) > 64:
+                # randomize the last few characters to avoid artificial collisions caused
+                # by the truncation, when the user specifies multiple very long paths with
+                # the same root
+                name = f"{name[:58]}{uuid4().hex[:6]}"
+
+            object.__setattr__(self, "name", name)
 
 
 @dataclass(frozen=True)
@@ -304,11 +327,13 @@ class KubernetesResourceRequirements:
         (through external action), then the pod will be terminated.
     security_context: Optional[KubernetesSecurityContext]
         The Kubernetes security context the job will run with. Note that this
-        field will only be respected if ALLOW_CUSTOM_SECURITY_CONTEXTS has been
-        enabled by your Sematic administrator.
+        field will only be respected if `ALLOW_CUSTOM_SECURITY_CONTEXTS` has been
+        enabled by your Sematic cluster administrator. Defaults to None.
     host_path_mounts: List[KubernetesHostPathMount]
         The "hostPath"-type configurations for volumes to mount on the pod to allow access
-        to the underlying nodes' file systems. More details can be found here:
+        to the underlying nodes' file systems. Note that thi can only be used if your
+        Sematic cluster administrator has enabled the `ALLOW_HOST_PATH_MOUNTING` Server
+        setting. Defaults to an empty list. More details can be found here:
         https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
     """
 
@@ -328,6 +353,7 @@ class KubernetesResourceRequirements:
             node_selector=dict(self.node_selector),
             requests=dict(self.requests),
             tolerations=[t for t in self.tolerations],
+            host_path_mounts=[m for m in self.host_path_mounts],
         )
 
 

--- a/sematic/resolvers/tests/test_resource_requirements.py
+++ b/sematic/resolvers/tests/test_resource_requirements.py
@@ -4,6 +4,7 @@ import pytest
 # Sematic
 from sematic.resolvers.resource_requirements import (
     KubernetesCapabilities,
+    KubernetesHostPathMount,
     KubernetesResourceRequirements,
     KubernetesSecretMount,
     KubernetesSecurityContext,
@@ -43,6 +44,14 @@ def test_is_serializable():
                 allow_privilege_escalation=True,
                 capabilities=KubernetesCapabilities(add=["SYS_ADMIN"]),
             ),
+            host_path_mounts=[
+                KubernetesHostPathMount(
+                    name="volume-tmp",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp",
+                    type="Directory",
+                ),
+            ],
         )
     )
     encoded = value_to_json_encodable(requirements, ResourceRequirements)

--- a/sematic/resolvers/tests/test_resource_requirements.py
+++ b/sematic/resolvers/tests/test_resource_requirements.py
@@ -59,7 +59,7 @@ def test_is_serializable():
     assert decoded == requirements
 
 
-def test_validation():
+def test_tolerations_validation():
     with pytest.raises(
         ValueError,
         match="toleration_seconds should only be specified when the effect is NoExecute.",
@@ -71,3 +71,20 @@ def test_validation():
             operator=KubernetesTolerationOperator.Equal,
             toleration_seconds=42,
         )
+
+
+def test_host_path_mounts_name_sanitization():
+    mount = KubernetesHostPathMount(node_path="/tmp", pod_mount_path="/host_tmp")
+    assert mount.name == "volume-host-tmp"
+
+    mount = KubernetesHostPathMount(
+        name="", node_path="/tmp", pod_mount_path="/host_tmp"
+    )
+    assert mount.name == "volume-host-tmp"
+
+    path = "/0123456789012345678901234567890123456789012345678901234567890123456789"
+    mount = KubernetesHostPathMount(node_path="/tmp", pod_mount_path=path)
+    assert len(mount.name) == 64
+    assert (
+        mount.name[:58] == "volume-012345678901234567890123456789012345678901234567890"
+    )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -83,7 +83,7 @@ DEFAULT_WORKER_SERVICE_ACCOUNT = "default"
 
 # from the kubernetes documentation:
 # > a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
-# > and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc',
+# > and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc',
 # > regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
 LABEL_REGEX_PATTERN = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
@@ -454,7 +454,6 @@ def _get_pods_for_job(
     The second element of the tuple is a boolean indicating if there was
     an infra failure during pod retrieval (True if there was an error).
     """
-    k8s_pods = None
     has_infra_failure = False
     try:
         k8s_pods = kubernetes.client.CoreV1Api().list_namespaced_pod(
@@ -590,10 +589,20 @@ def _schedule_kubernetes_job(
                 ),
             )
 
-        for host_path_mount in resource_requirements.kubernetes.host_path_mounts:
-            volume, mount = _host_path_volumes(host_path_mount=host_path_mount)
-            volumes.append(volume)
-            volume_mounts.append(mount)
+        if resource_requirements.kubernetes.host_path_mounts:
+            allow_mounting = get_bool_server_setting(
+                ServerSettingsVar.ALLOW_HOST_PATH_MOUNTING, False
+            )
+            if not allow_mounting:
+                raise ValueError(
+                    "User tried to mount host paths for their Sematic function, but "
+                    "ALLOW_HOST_PATH_MOUNTING is not enabled."
+                )
+
+            for host_path_mount in resource_requirements.kubernetes.host_path_mounts:
+                volume, mount = _host_path_volumes(host_path_mount=host_path_mount)
+                volumes.append(volume)
+                volume_mounts.append(mount)
 
         secret_env_vars.extend(
             _environment_secrets(resource_requirements.kubernetes.secret_mounts)
@@ -914,14 +923,9 @@ def _host_path_volumes(
 ) -> Tuple[V1Volume, V1VolumeMount]:
     """Returns the volume and mount for the specified "hostPath" configuration."""
 
-    if not host_path_mount.name:
-        raise ValueError("Host path volume name must not be empty")
-
-    if not re.fullmatch(LABEL_REGEX_PATTERN, host_path_mount.name):
-        raise ValueError(
-            f"Host path volume name must start with an alphanumeric character and only"
-            f"contain alphanumeric characters and dashes. Got: '{host_path_mount.name}'"
-        )
+    _validate_rfc1123_label(
+        label_value=host_path_mount.name, label_name="Host path volume name"
+    )
 
     if host_path_mount.node_path is None or not os.path.isabs(
         host_path_mount.node_path
@@ -994,3 +998,22 @@ def _get_image_pull_secrets() -> Optional[
         )
 
     return [encodable_to_obj(encodable) for encodable in as_encodables]
+
+
+def _validate_rfc1123_label(label_value: str, label_name: str) -> None:
+    """Validates that the specified label value is an acceptable RFC 1123 max 64-character
+    label name that can be used in Kubernetes, raising `ValueError` if not.
+    """
+    if not label_value:
+        raise ValueError(f"{label_name} must not be empty.")
+
+    if len(label_value) > 64:
+        raise ValueError(
+            f"{label_name} must have at most 64 characters. Got: '{label_value}'"
+        )
+
+    if not re.fullmatch(LABEL_REGEX_PATTERN, label_value):
+        raise ValueError(
+            f"{label_name} must start with an alphanumeric character and only contain "
+            f"alphanumeric characters and dashes. Got: '{label_value}'"
+        )

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -1,6 +1,8 @@
 # Standard Library
 import logging
+import os
 import pathlib
+import re
 import time
 import uuid
 from dataclasses import replace
@@ -11,6 +13,7 @@ import kubernetes
 from kubernetes.client.exceptions import ApiException, OpenApiException
 from kubernetes.client.models import (
     V1ContainerStatus,
+    V1HostPathVolumeSource,
     V1Pod,
     V1PodCondition,
     V1Volume,
@@ -35,6 +38,7 @@ from sematic.graph import RerunMode
 from sematic.plugins.storage.s3_storage import S3Storage, S3StorageSettingsVar
 from sematic.resolvers.resource_requirements import (
     KUBERNETES_SECRET_NAME,
+    KubernetesHostPathMount,
     KubernetesResourceRequirements,
     KubernetesSecretMount,
     ResourceRequirements,
@@ -76,6 +80,12 @@ RESOLUTION_RESOURCE_REQUIREMENTS = ResourceRequirements(
 )
 
 DEFAULT_WORKER_SERVICE_ACCOUNT = "default"
+
+# from the kubernetes documentation:
+# > a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+# > and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc',
+# > regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+LABEL_REGEX_PATTERN = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
 
 def _unique_job_id_suffix() -> str:
@@ -580,6 +590,11 @@ def _schedule_kubernetes_job(
                 ),
             )
 
+        for host_path_mount in resource_requirements.kubernetes.host_path_mounts:
+            volume, mount = _host_path_volumes(host_path_mount=host_path_mount)
+            volumes.append(volume)
+            volume_mounts.append(mount)
+
         secret_env_vars.extend(
             _environment_secrets(resource_requirements.kubernetes.secret_mounts)
         )
@@ -876,9 +891,7 @@ def _environment_secrets(
 
 
 def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
-    """
-    Returns a memory-backed shared memory partition and mount with a default size.
-    """
+    """Returns a memory-backed shared memory partition and mount with a default size."""
     # the "Memory" medium cannot have a size_limit specified by default;
     # it requires the SizeMemoryBackedVolumes feature gate be activated by the
     # cluster admin - please see
@@ -892,6 +905,50 @@ def _shared_memory() -> Tuple[V1Volume, V1VolumeMount]:
 
     volume = V1Volume(name=volume_name, empty_dir=empty_dir)
     volume_mount = V1VolumeMount(mount_path="/dev/shm", name=volume_name)
+
+    return volume, volume_mount
+
+
+def _host_path_volumes(
+    host_path_mount: KubernetesHostPathMount,
+) -> Tuple[V1Volume, V1VolumeMount]:
+    """Returns the volume and mount for the specified "hostPath" configuration."""
+
+    if not host_path_mount.name:
+        raise ValueError("Host path volume name must not be empty")
+
+    if not re.fullmatch(LABEL_REGEX_PATTERN, host_path_mount.name):
+        raise ValueError(
+            f"Host path volume name must start with an alphanumeric character and only"
+            f"contain alphanumeric characters and dashes. Got: '{host_path_mount.name}'"
+        )
+
+    if host_path_mount.node_path is None or not os.path.isabs(
+        host_path_mount.node_path
+    ):
+        raise ValueError(
+            f"'hostPath' node path must be a valid absolute path. "
+            f"Got: '{host_path_mount.node_path}'"
+        )
+
+    if host_path_mount.pod_mount_path is None or not os.path.isabs(
+        host_path_mount.pod_mount_path
+    ):
+        raise ValueError(
+            f"'hostPath' mount path must be a valid absolute path. "
+            f"Got: '{host_path_mount.pod_mount_path}'"
+        )
+
+    volume = V1Volume(
+        name=host_path_mount.name,
+        host_path=V1HostPathVolumeSource(
+            path=host_path_mount.node_path, type=host_path_mount.type
+        ),
+    )
+
+    volume_mount = V1VolumeMount(
+        mount_path=host_path_mount.pod_mount_path, name=host_path_mount.name
+    )
 
     return volume, volume_mount
 

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -28,6 +28,7 @@ from sematic.scheduling.job_details import (
     PodSummary,
 )
 from sematic.scheduling.kubernetes import (
+    _host_path_volumes,
     _schedule_kubernetes_job,
     cancel_job,
     refresh_job,
@@ -118,6 +119,7 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
         {
             "SEMATIC_CONTAINER_IMAGE": image_uri,
             "ALLOW_CUSTOM_SECURITY_CONTEXTS": "true",
+            "ALLOW_HOST_PATH_MOUNTING": "true",
             "WORKER_IMAGE_PULL_SECRETS": json.dumps([{"name": "foo-secret"}]),
         }
     ):
@@ -265,20 +267,7 @@ def test_schedule_security_context_feature_flag(k8s_batch_client, mock_kube_conf
                 allow_privilege_escalation=True,
                 capabilities=KubernetesCapabilities(add=["SYS_ADMIN"]),
             ),
-            host_path_mounts=[
-                KubernetesHostPathMount(
-                    name="volume-tmp1",
-                    node_path="/tmp",
-                    pod_mount_path="/host_tmp1",
-                    type="Directory",
-                ),
-                KubernetesHostPathMount(
-                    name="volume-tmp2",
-                    node_path="/tmp",
-                    pod_mount_path="/host_tmp2",
-                    type="Directory",
-                ),
-            ],
+            host_path_mounts=[],
         )
     )
 
@@ -288,7 +277,9 @@ def test_schedule_security_context_feature_flag(k8s_batch_client, mock_kube_conf
             "ALLOW_CUSTOM_SECURITY_CONTEXTS": "false",
         }
     ):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=".* ALLOW_CUSTOM_SECURITY_CONTEXTS is not enabled."
+        ):
             _schedule_kubernetes_job(
                 name=name,
                 image=image_uri,
@@ -661,3 +652,159 @@ def test_schedule_run_job(mock_uuid, mock_schedule_k8s_job):
         resource_requirements=resource_requests,
         args=["--run_id", run_id],
     )
+
+
+@mock.patch("sematic.scheduling.kubernetes.load_kube_config")
+@mock.patch("sematic.scheduling.kubernetes.kubernetes.client.BatchV1Api")
+def test_schedule_host_path_mounting_flag(k8s_batch_client, mock_kube_config):
+    name = "the-name"
+    requests = {"cpu": "42"}
+    node_selector = {"foo": "bar"}
+    environment_secrets = {"api_key_1": "MY_API_KEY"}
+    file_secrets = {"api_key_2": "the_file.txt"}
+    secret_root = "/the-secrets"
+    image_uri = "the-image"
+    namespace = "the-namespace"
+    custom_service_account = "custom-sa"
+    args = ["a", "b", "c"]
+    configured_env_vars = {
+        "SOME_ENV_VAR": "some-env-var-value",
+        "SEMATIC_API_ADDRESS": "http://theurl.com",
+    }
+    api_url_override = "http://urloverride.com"
+
+    resource_requirements = ResourceRequirements(
+        kubernetes=KubernetesResourceRequirements(
+            requests=requests,
+            node_selector=node_selector,
+            secret_mounts=KubernetesSecretMount(
+                environment_secrets=environment_secrets,
+                file_secrets=file_secrets,
+                file_secret_root_path=secret_root,
+            ),
+            tolerations=[
+                KubernetesToleration(
+                    key="foo",
+                    operator=KubernetesTolerationOperator.Equal,
+                    effect=KubernetesTolerationEffect.NoExecute,
+                    value="bar",
+                    toleration_seconds=42,
+                ),
+                KubernetesToleration(),
+            ],
+            mount_expanded_shared_memory=True,
+            security_context=None,
+            host_path_mounts=[
+                KubernetesHostPathMount(
+                    name="volume-tmp1",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp1",
+                    type="Directory",
+                ),
+                KubernetesHostPathMount(
+                    name="volume-tmp2",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp2",
+                    type="Directory",
+                ),
+            ],
+        )
+    )
+
+    with environment_variables(
+        {"SEMATIC_CONTAINER_IMAGE": image_uri, "ALLOW_HOST_PATH_MOUNTING": "false"}
+    ):
+        with pytest.raises(
+            ValueError, match=".* ALLOW_HOST_PATH_MOUNTING is not enabled."
+        ):
+            _schedule_kubernetes_job(
+                name=name,
+                image=image_uri,
+                environment_vars=configured_env_vars,
+                namespace=namespace,
+                service_account=custom_service_account,
+                resource_requirements=resource_requirements,
+                api_address_override=api_url_override,
+                args=args,
+            )
+
+    with environment_variables(
+        {"SEMATIC_CONTAINER_IMAGE": image_uri, "ALLOW_HOST_PATH_MOUNTING": "true"}
+    ):
+        _schedule_kubernetes_job(
+            name=name,
+            image=image_uri,
+            environment_vars=configured_env_vars,
+            namespace=namespace,
+            service_account=custom_service_account,
+            resource_requirements=resource_requirements,
+            api_address_override=api_url_override,
+            args=args,
+        )
+
+    k8s_batch_client.return_value.create_namespaced_job.assert_called_once()
+
+
+def test_host_path_volumes_validation():
+    with pytest.raises(
+        ValueError,
+        match="Host path volume name must have at most 64 characters.*",
+    ):
+        name = "0123456789012345678901234567890123456789012345678901234567890123456789"
+        _host_path_volumes(
+            KubernetesHostPathMount(
+                name=name,
+                node_path="/tmp",
+                pod_mount_path="/host_tmp",
+            )
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Host path volume name must start with an alphanumeric.*",
+    ):
+        _host_path_volumes(
+            KubernetesHostPathMount(
+                name="/tmp", node_path="/tmp", pod_mount_path="/host_tmp"
+            )
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=".* only contain alphanumeric characters and dashes.*",
+    ):
+        _host_path_volumes(
+            KubernetesHostPathMount(
+                name="a_b", node_path="/tmp", pod_mount_path="/host_tmp"
+            )
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=".* node path must be a valid absolute path.*",
+    ):
+        _host_path_volumes(
+            KubernetesHostPathMount(node_path="", pod_mount_path="/host_tmp")
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=".* node path must be a valid absolute path.*",
+    ):
+        _host_path_volumes(
+            KubernetesHostPathMount(node_path="abc", pod_mount_path="/host_tmp")
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=".* mount path must be a valid absolute path.*",
+    ):
+        _host_path_volumes(KubernetesHostPathMount(node_path="/tmp", pod_mount_path=""))
+
+    with pytest.raises(
+        ValueError,
+        match=".* mount path must be a valid absolute path.*",
+    ):
+        _host_path_volumes(
+            KubernetesHostPathMount(node_path="/tmp", pod_mount_path="abc")
+        )

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -13,6 +13,7 @@ from sematic.config.server_settings import ServerSettingsVar
 from sematic.db.tests.fixtures import make_job
 from sematic.resolvers.resource_requirements import (
     KubernetesCapabilities,
+    KubernetesHostPathMount,
     KubernetesResourceRequirements,
     KubernetesSecretMount,
     KubernetesSecurityContext,
@@ -96,6 +97,20 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
                 allow_privilege_escalation=True,
                 capabilities=KubernetesCapabilities(add=["SYS_ADMIN"]),
             ),
+            host_path_mounts=[
+                KubernetesHostPathMount(
+                    name="volume-tmp1",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp1",
+                    type="Directory",
+                ),
+                KubernetesHostPathMount(
+                    name="volume-tmp2",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp2",
+                    type="Directory",
+                ),
+            ],
         )
     )
 
@@ -123,16 +138,6 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
     job = kwargs["body"]
     assert job.spec.template.spec.node_selector == node_selector
 
-    secret_volume = job.spec.template.spec.volumes[0]
-    assert secret_volume.name == "sematic-func-secrets-volume"
-    assert secret_volume.secret.items[0].key == next(iter(file_secrets.keys()))
-    assert secret_volume.secret.items[0].path == next(iter(file_secrets.values()))
-    assert job.spec.template.spec.service_account_name == custom_service_account
-
-    shared_memory_volume = job.spec.template.spec.volumes[1]
-    assert shared_memory_volume.name == "expanded-shared-memory-volume"
-    assert shared_memory_volume.empty_dir.medium == "Memory"
-
     assert len(job.spec.template.spec.image_pull_secrets) == 1
     assert job.spec.template.spec.image_pull_secrets[0].name == "foo-secret"
 
@@ -159,6 +164,42 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
     assert container.image == image_uri
     assert container.resources.limits == requests
     assert container.resources.requests == requests
+
+    secret_volume = job.spec.template.spec.volumes[0]
+    assert secret_volume.name == "sematic-func-secrets-volume"
+    assert secret_volume.secret.items[0].key == next(iter(file_secrets.keys()))
+    assert secret_volume.secret.items[0].path == next(iter(file_secrets.values()))
+    assert job.spec.template.spec.service_account_name == custom_service_account
+
+    secret_volume_mount = container.volume_mounts[0]
+    assert secret_volume_mount.mount_path == secret_root
+    assert secret_volume_mount.name == "sematic-func-secrets-volume"
+
+    shared_memory_volume = job.spec.template.spec.volumes[1]
+    assert shared_memory_volume.name == "expanded-shared-memory-volume"
+    assert shared_memory_volume.empty_dir.medium == "Memory"
+
+    secret_volume_mount = container.volume_mounts[1]
+    assert secret_volume_mount.mount_path == "/dev/shm"
+    assert secret_volume_mount.name == "expanded-shared-memory-volume"
+
+    host_path_volume1 = job.spec.template.spec.volumes[2]
+    assert host_path_volume1.name == "volume-tmp1"
+    assert host_path_volume1.host_path.path == "/tmp"
+    assert host_path_volume1.host_path.type == "Directory"
+
+    host_path_volume_mount1 = container.volume_mounts[2]
+    assert host_path_volume_mount1.mount_path == "/host_tmp1"
+    assert host_path_volume_mount1.name == "volume-tmp1"
+
+    host_path_volume2 = job.spec.template.spec.volumes[3]
+    assert host_path_volume2.name == "volume-tmp2"
+    assert host_path_volume2.host_path.path == "/tmp"
+    assert host_path_volume2.host_path.type == "Directory"
+
+    host_path_volume_mount2 = container.volume_mounts[3]
+    assert host_path_volume_mount2.mount_path == "/host_tmp2"
+    assert host_path_volume_mount2.name == "volume-tmp2"
 
     tolerations = job.spec.template.spec.tolerations
     assert len(tolerations) == 2
@@ -224,6 +265,20 @@ def test_schedule_security_context_feature_flag(k8s_batch_client, mock_kube_conf
                 allow_privilege_escalation=True,
                 capabilities=KubernetesCapabilities(add=["SYS_ADMIN"]),
             ),
+            host_path_mounts=[
+                KubernetesHostPathMount(
+                    name="volume-tmp1",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp1",
+                    type="Directory",
+                ),
+                KubernetesHostPathMount(
+                    name="volume-tmp2",
+                    node_path="/tmp",
+                    pod_mount_path="/host_tmp2",
+                    type="Directory",
+                ),
+            ],
         )
     )
 


### PR DESCRIPTION
Introduces the capability of mounting paths from the underlying node filesystem into the Worker pod.

This is added as a new `ResourceRequirements` parameter.

The documentation is updated to cover the new capability, and to cover other missing capabilities.

## Testing

The unit tests are updated to cover the new functionality:
```
$ bazel test //sematic/scheduling/tests:test_kubernetes
$ bazel test //sematic/resolvers/tests:test_resource_requirements
```

The Testing Pipeline is enhanced with a new parameter to test mounting paths, and writing to and reading from them inside the Worker pods. The existing `ResourceRequirements` testing, which only covered shared memory mount expansion, is also refactored, and enhanced to check its effects.

```
$ bazel run //sematic/examples/testing_pipeline:__main__ -- \
    --cloud \
    --expand-shared-memory \
    --mount-host-path /tmp /test \
    --mount-host-path /tmp /test2
```

Expanded shared memory Function logs:
```
[...]
2023-10-04 21:55:25,906 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: add_with_expanded_shared_memory(a=3.0, b=3.0)
2023-10-04 21:55:25,906 - INFO - sematic.examples.testing_pipeline.pipeline: System memory capacity: 7834 MB
2023-10-04 21:55:25,906 - INFO - sematic.examples.testing_pipeline.pipeline: Root partition size: 102387 MB
2023-10-04 21:55:25,906 - INFO - sematic.examples.testing_pipeline.pipeline: Shared memory partition size: 7094 MB
[...]
```

Validated manually that this would print `64 MB` for the shared memory when the flag is not actually set.

Host path mounts Function logs:
```
[...]
2023-10-04 21:55:24,685 - INFO - __main__: Executing add_with_host_path_mounts
2023-10-04 21:55:24,685 - INFO - sematic.examples.testing_pipeline.pipeline: Executing: add_with_host_path_mounts(a=3.0, b=3.0, pod_mount_paths=['/test', '/test2'])
2023-10-04 21:55:24,685 - INFO - sematic.examples.testing_pipeline.pipeline: Contents of '/test':
total 4
drwxrwxrwt 8 root root 189 Oct 4 21:55 .
drwxr-xr-x 1 root root 76 Oct 4 21:55 ..
drwxrwxrwt 2 root root 6 Mar 22 2023 .ICE-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .Test-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .X11-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .XIM-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .font-unix
-rw-r--r-- 1 root root 14 Oct 4 21:55 sammy.txt
drwx------ 3 root root 17 Jun 13 14:49 systemd-private-04155cef5fe44407b7976cb03ff52b97-chronyd.service-fBEr7S
2023-10-04 21:55:24,706 - INFO - sematic.examples.testing_pipeline.pipeline: Contents of '/test2':
total 4
drwxrwxrwt 8 root root 189 Oct 4 21:55 .
drwxr-xr-x 1 root root 76 Oct 4 21:55 ..
drwxrwxrwt 2 root root 6 Mar 22 2023 .ICE-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .Test-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .X11-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .XIM-unix
drwxrwxrwt 2 root root 6 Mar 22 2023 .font-unix
-rw-r--r-- 1 root root 14 Oct 4 21:55 sammy.txt
drwx------ 3 root root 17 Jun 13 14:49 systemd-private-04155cef5fe44407b7976cb03ff52b97-chronyd.service-fBEr7S
2023-10-04 21:55:29,714 - INFO - __main__: Finished executing add_with_host_path_mounts
[...]
```
