### PR TITLE
Switch runs and pipelines panels

### DIFF
--- a/sematic/ui/packages/common/src/pages/Home/index.tsx
+++ b/sematic/ui/packages/common/src/pages/Home/index.tsx
@@ -65,18 +65,18 @@ export default function Home() {
         <Container>
             <div id={"main-content"}>
                 <div>
-                    <div id={"latest-runs"}>
-                        <LatestRuns />
-                    </div>
-                    <div><Blog /></div>
-                </div>
-                <div>
                     <div id={"latest-pipelines"}>
                         <LatestPipelines />
                     </div>
                     <div>
                         <Community />
                     </div>
+                </div>
+                <div>
+                    <div id={"latest-runs"}>
+                        <LatestRuns />
+                    </div>
+                    <div><Blog /></div>
                 </div>
             </div>
         </Container>


### PR DESCRIPTION
Recently, after user feedback, the "Pipelines" and "Runs" buttons were switched in the Dashboard header. But on the homepage, the 2 "Pipelines" and "Runs" panels were kept in the same order.

Now when viewing the homepage, this creates an unpleasant experience.

This PR switches the 2 panels as well.

Before:
![image](https://github.com/sematic-ai/sematic/assets/1894533/8b3c978e-d741-4a54-a60c-873998e76aa9)

After:
![image](https://github.com/sematic-ai/sematic/assets/1894533/48017ac2-deb5-4cc9-b11e-28b74d5935af)
