### PR TITLE
Link dev guide from main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Learn more about Sematic and get in touch with the following resources:
 To contribute to Sematic, check out [open issues tagged "good first
 issue"](https://github.com/sematic-ai/sematic/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22),
 and get in touch with us on [Discord](https://discord.gg/4KZJ6kYVax).
-
+You can find instructions on how to get your development environment set up
+in our [developer docs](./developer-docs/README.md). If you'd like to add
+an example, you may also find
+[this guide](https://docs.sematic.dev/project/contributor-guide/contribute-example)
+helpful.
 
 ![scarf pixel](https://static.scarf.sh/a.png?x-pxid=80c3593f-25a0-4b06-90a1-0b670a6567d4)


### PR DESCRIPTION
Link to the developer guide from the main readme, so contributors can more easily find info on how to set up their dev environment.