### PR TITLE
Fix incorrect dashboard rendering of cached from information

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -129,7 +129,11 @@ const FunctionSection = () => {
         const completeAt = DateTimeLong(parseJSON((selectedRun.resolved_at || selectedRun.failed_at
             || selectedRun.ended_at) as unknown as string));
 
-        return `${runDuration} on ${completeAt}`;
+        return <>
+            {runDuration}
+            on&nbsp;
+            {completeAt}
+        </>;
     }, [selectedRun]);
 
     const contextMenuAnchor = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
The information regarding cached Runs is incorrectly rendered in the Dashboard:

![image](https://github.com/sematic-ai/sematic/assets/1894533/13987363-d12b-482a-9393-1cc397ef1fa4)

This patch fixes it:

![image](https://github.com/sematic-ai/sematic/assets/1894533/399f91a7-525a-49e2-9431-4350a37befbd)
