### PR TITLE
Update requirements on CIFAR classifier

### DIFF
--- a/sematic/examples/cifar_classifier/requirements.txt
+++ b/sematic/examples/cifar_classifier/requirements.txt
@@ -1,8 +1,9 @@
-numpy
-torch
-torchvision
-torchmetrics
+numpy==1.24.2
+torch==1.13.1
+torchvision==0.14.1
+torchmetrics==0.11.1
 pillow
 plotly
-ray[air]
+pydantic==1.10.4
+ray[air]==2.3.0
 sematic[ray]


### PR DESCRIPTION
The latest versions of the dependencies for this example don't work. Freezing them at versions that do.

Testing
--------

```
pip install -r sematic/examples/cifar_classifier/requirements.txt
sematic run sematic/examples/cifar_classifier/main.py
sematic run --build sematic/examples/cifar_classifier/main.py -- --cloud
```