### PR TITLE
Force pod restarts on config map changes

### DIFF
--- a/helm/sematic-server/templates/deployment.yaml
+++ b/helm/sematic-server/templates/deployment.yaml
@@ -15,10 +15,13 @@ spec:
       sematic.ai/component: api
   template:
     metadata:
-      {{- with .Values.deployment.annotations }}
       annotations:
+      {{- with .Values.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        # forces a pod restart when config values change, without this configmap
+        # changes don't cause the deployment to restart pods
+        sematic.ai/config-checksum: {{ tpl (toYaml .Values) . | sha256sum }}
       labels:
         {{- include "sematic-server.selectorLabels" . | nindent 8 }}
         sematic.ai/component: api


### PR DESCRIPTION
currently, pods in the sematic server deployment don't restart when the configmap associated with them changes.  on every helm upgrade, helm _does_ rerun the migration pod with the updated configmap values, but the deployment pods themselves stick around unchanged.  this is a known issue in k8s: https://github.com/kubernetes/kubernetes/issues/22368

to remove any confusion here, we take a checksum of all of the values in the helm chart and apply the checksum as an annotation on the pods.  with this, k8s will forcibly refresh the pods on _any_ change to the helm values.  while that is a bit of overkill (not all changes technically require the pods to restart), it is far less error-prone than the status quo.

also documented as a helm tip here: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments