### PR TITLE
Fix edge-case in timeout comparisons

### DIFF
--- a/sematic/runners/state_machine_runner.py
+++ b/sematic/runners/state_machine_runner.py
@@ -260,7 +260,14 @@ class StateMachineRunner(Runner, abc.ABC):
         ]
         if len(remaining_timeout_future_pairs) == 0:
             return None, None
-        return min(remaining_timeout_future_pairs)
+
+        # If there are two futures that timeout at the same time (ex: parallel
+        # runs that used the same timeout duration and started simultaneously),
+        # we fall back to comparing ids lexically to break the tie (future objects
+        # are not comparable, so we use the id).
+        return min(
+            remaining_timeout_future_pairs, key=lambda pair: (pair[0], pair[1].id)
+        )
 
     def _cancel_non_terminal_futures(self):
         for future in self._futures:

--- a/sematic/runners/tests/test_silent_runner.py
+++ b/sematic/runners/tests/test_silent_runner.py
@@ -365,3 +365,8 @@ def test_timeout():
     except Exception as e:
         error_text = str(e)
     assert TimeoutError.__name__ in error_text
+
+    runner = SilentRunner()
+    runner._futures = [do_sleep(2).set(timeout_mins=1), do_sleep(2).set(timeout_mins=1)]
+    seconds_to_timeout, future = runner._get_seconds_to_next_timeout()
+    assert abs(seconds_to_timeout - 60) < 5

--- a/sematic/runners/tests/test_silent_runner.py
+++ b/sematic/runners/tests/test_silent_runner.py
@@ -367,6 +367,10 @@ def test_timeout():
     assert TimeoutError.__name__ in error_text
 
     runner = SilentRunner()
-    runner._futures = [do_sleep(2).set(timeout_mins=1), do_sleep(2).set(timeout_mins=1)]
+    futures = [do_sleep(2).set(timeout_mins=1), do_sleep(2).set(timeout_mins=1)]
+    start_time = time.time()
+    for future in futures:
+        future.props.scheduled_epoch_time = start_time
+    runner._futures = futures
     seconds_to_timeout, future = runner._get_seconds_to_next_timeout()
     assert abs(seconds_to_timeout - 60) < 5


### PR DESCRIPTION
There was a bug that if two runs timed out at the same exact time (ex: parallel runs launched simultaneously), the comparison logic would fall back to comparing `Future` objects directly, which don't support the `<` operator. This switches so that in such cases we fall back to comparing the ids instead of the Future objects.