### PR TITLE
Fail more loudly if artifact data writes are not successful

### DIFF
--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -151,7 +151,8 @@ def _store_bytes(namespace: str, key: str, bytes_: bytes) -> None:
     url: str = response["url"]
     headers: Dict[str, str] = response["request_headers"]
 
-    requests.put(url, data=bytes_, headers=headers)
+    put_response = requests.put(url, data=bytes_, headers=headers)
+    put_response.raise_for_status()
 
 
 def _get_artifact_bytes(artifact_id: str) -> bytes:


### PR DESCRIPTION
closes #1089 

When doing a `PUT` to write artifact data, we are currently not raising an error directly. Likely an error will still occur when something downstream tries to *use* the artifact data (unless it's the last artifact in a pipeline...), but we should fail more explicitly when the error first occurs.