### PR TITLE
If user token has no hd, use email address domain

### DIFF
--- a/sematic/api/endpoints/auth.py
+++ b/sematic/api/endpoints/auth.py
@@ -103,8 +103,9 @@ def google_login() -> flask.Response:
             ServerSettingsVar.SEMATIC_AUTHORIZED_EMAIL_DOMAIN, None
         )
 
+        user_domain = idinfo.get("hd") or idinfo.get("email").split("@")[-1]
         if authorized_email_domain is not None:
-            if idinfo.get("hd") not in authorized_email_domain.split(","):
+            if user_domain not in authorized_email_domain.split(","):
                 raise ValueError("Incorrect email domain")
 
     except (ValueError, GoogleAuthError):

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -88,8 +88,8 @@ def test_login_new_user(idinfo, test_client: flask.testing.FlaskClient):  # noqa
 
 
 def test_login_new_user_no_hd(
-    idinfo, test_client: flask.testing.FlaskClient
-):  # noqa: F811
+    idinfo, test_client: flask.testing.FlaskClient  # noqa: F811
+):
     idinfo["hd"] = None
     with mock_server_settings({ServerSettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123"}):
         with mock.patch(

--- a/sematic/api/endpoints/tests/test_auth.py
+++ b/sematic/api/endpoints/tests/test_auth.py
@@ -87,6 +87,30 @@ def test_login_new_user(idinfo, test_client: flask.testing.FlaskClient):  # noqa
         assert len(user.api_key) > 0
 
 
+def test_login_new_user_no_hd(
+    idinfo, test_client: flask.testing.FlaskClient
+):  # noqa: F811
+    idinfo["hd"] = None
+    with mock_server_settings({ServerSettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123"}):
+        with mock.patch(
+            "google.oauth2.id_token.verify_oauth2_token", return_value=idinfo
+        ):
+            response = test_client.post("/login/google", json={"token": "abc"})
+
+            returned_user = User.from_json_encodable(
+                response.json["user"]  # type: ignore
+            )
+
+    saved_user = get_user(response.json["user"]["id"])  # type: ignore
+
+    for user in (returned_user, saved_user):
+        assert user.first_name == "Ringo"
+        assert user.last_name == "Starr"
+        assert user.email == "ringo@example.com"
+        assert user.avatar_url == "https://picture"
+        assert len(user.api_key) > 0
+
+
 def test_login_existing_user(
     persisted_user: User, test_client: flask.testing.FlaskClient  # noqa: F811
 ):
@@ -153,6 +177,27 @@ def test_login_invalid_domain(test_client: flask.testing.FlaskClient):  # noqa: 
 def test_login_valid_domain(
     idinfo, test_client: flask.testing.FlaskClient  # noqa: F811
 ):
+    with mock_server_settings(
+        {
+            ServerSettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",
+            ServerSettingsVar.SEMATIC_AUTHORIZED_EMAIL_DOMAIN: (
+                "example.com,example2.com"
+            ),
+        }
+    ):
+        with mock.patch(
+            "google.oauth2.id_token.verify_oauth2_token",
+            return_value=idinfo,
+        ):
+            response = test_client.post("/login/google", json={"token": "abc"})
+
+            assert response.status_code == HTTPStatus.OK
+
+
+def test_login_valid_domain_no_hd(
+    idinfo, test_client: flask.testing.FlaskClient  # noqa: F811
+):
+    idinfo["hd"] = None
     with mock_server_settings(
         {
             ServerSettingsVar.GOOGLE_OAUTH_CLIENT_ID: "ABC123",


### PR DESCRIPTION
Closes #1093

Google only sets the`hd` claim on an id token [under certain circumstances](https://developers.google.com/identity/openid-connect/openid-connect). If it's not set, we should consider the user's email domain to be whatever comes after the `@` in their email address.