### PR TITLE
Alow custom resources for runner pods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,13 @@ Executes a pipeline on a Kubernetes cluster.
     is meant to be used for retries or for hotfixes, without needing to re-run the
     entire pipeline again.
 
+- `resources`: ResourceRequirements
+
+    Specifies [resource requiremets](#resource-requirements) that will be used to
+    execute the runner itself. Note that these are the resources that will be
+    available when executing non-standalone (aka inline) runs. Defaults to use
+    half a CPU and 2 Gi of memory.
+
 ### `SilentRunner`
 
 A runner to execute a DAG in memory, without tracking to the DB.

--- a/sematic/db/migrations/20231115163910_runner_resources.sql
+++ b/sematic/db/migrations/20231115163910_runner_resources.sql
@@ -4,4 +4,5 @@ ALTER TABLE resolutions ADD COLUMN resource_requirements_json JSONB;
 
 -- migrate:down
 
-ALTER TABLE resolutions DROP COLUMN resource_requirements_json;
+-- TODO #302: implement sustainable way to upgrade sqlite3 DBs
+-- ALTER TABLE resolutions DROP COLUMN resource_requirements_json;

--- a/sematic/db/migrations/20231115163910_runner_resources.sql
+++ b/sematic/db/migrations/20231115163910_runner_resources.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+ALTER TABLE resolutions ADD COLUMN resource_requirements_json JSONB;
+
+-- migrate:down
+
+ALTER TABLE resolutions DROP COLUMN resource_requirements_json;

--- a/sematic/db/models/factories.py
+++ b/sematic/db/models/factories.py
@@ -243,6 +243,7 @@ def clone_resolution(resolution: Resolution, root_id: str) -> Resolution:
     # a json encodable, but this property will auto-update the json
     # encodable field.
     cloned_resolution.git_info = resolution.git_info
+    cloned_resolution.resource_requirements = resolution.resource_requirements
 
     return cloned_resolution
 

--- a/sematic/db/schema.sql.sqlite
+++ b/sematic/db/schema.sql.sqlite
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS "resolutions" (
                     user_id character(32),
                     run_command TEXT,
                     build_config TEXT,
-                    organization_id character(32),
+                    organization_id character(32), resource_requirements_json JSONB,
 
                     PRIMARY KEY (root_id),
                     FOREIGN KEY (root_id) REFERENCES runs(id),
@@ -241,4 +241,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20230627153433'),
   ('20230706150252'),
   ('20230712105529'),
-  ('20230712121255');
+  ('20230712121255'),
+  ('20231115163910');

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -158,7 +158,10 @@ EXIT_HELP = (
     "Includes a function which will exit with the specified code. "
     "If specified without a value, defaults to 0. Defaults to None."
 )
-CUSTOM_RUNNER_RESOURCES_HELP = "Specifies custom resources for the CloudRunner."
+CUSTOM_RUNNER_RESOURCES_HELP = (
+    "Specifies custom resources for the CloudRunner. When used, a hard-coded "
+    "custom resource config will be used."
+)
 
 
 class StoreCacheNamespace(argparse.Action):

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -14,6 +14,10 @@ import debugpy
 # Sematic
 from sematic import CloudRunner, LocalRunner, SilentRunner
 from sematic.examples.testing_pipeline.pipeline import testing_pipeline
+from sematic.resolvers.resource_requirements import (
+    KubernetesResourceRequirements,
+    ResourceRequirements,
+)
 from sematic.runners.state_machine_runner import StateMachineRunner
 
 logger = logging.getLogger(__name__)
@@ -154,6 +158,7 @@ EXIT_HELP = (
     "Includes a function which will exit with the specified code. "
     "If specified without a value, defaults to 0. Defaults to None."
 )
+CUSTOM_RUNNER_RESOURCES_HELP = "Specifies custom resources for the CloudRunner."
 
 
 class StoreCacheNamespace(argparse.Action):
@@ -232,6 +237,7 @@ def _parse_args() -> argparse.Namespace:
             "--max-parallelism",
             "--oom",
             "--ray-resource",
+            "--custom-runner-resources",
         ),
     )
     parser.add_argument(
@@ -381,6 +387,12 @@ def _parse_args() -> argparse.Namespace:
         dest="exit_code",
         help=EXIT_HELP,
     )
+    parser.add_argument(
+        "--custom-runner-resources",
+        action="store_true",
+        default=False,
+        help=CUSTOM_RUNNER_RESOURCES_HELP,
+    )
 
     args = parser.parse_args()
     if args.log_level is not None:
@@ -412,11 +424,19 @@ def _get_runner(args: argparse.Namespace) -> StateMachineRunner:
             rerun_from=args.rerun_from, cache_namespace=args.cache_namespace
         )
 
+    extra_kwargs = dict()
+    if args.custom_runner_resources:
+        extra_kwargs["resources"] = ResourceRequirements(
+            kubernetes=KubernetesResourceRequirements(
+                requests={"memory": "3Gi"},
+            )
+        )
     return CloudRunner(
         detach=args.detach,
         cache_namespace=args.cache_namespace,
         max_parallelism=args.max_parallelism,
         rerun_from=args.rerun_from,
+        **extra_kwargs,
     )
 
 

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -369,3 +369,10 @@ class ResourceRequirements:
             self,
             kubernetes=self.kubernetes.clone(),
         )
+
+
+DEFAULT_RUNNER_RESOURCES = ResourceRequirements(
+    kubernetes=KubernetesResourceRequirements(
+        requests={"cpu": "500m", "memory": "2Gi"},
+    )
+)

--- a/sematic/runners/local_runner.py
+++ b/sematic/runners/local_runner.py
@@ -30,6 +30,7 @@ from sematic.db.models.run import Run
 from sematic.graph import FutureGraph, Graph, RerunMode
 from sematic.plugins.abstract_builder import get_build_config, get_run_command
 from sematic.resolvers.resource_managers.server_manager import ServerResourceManager
+from sematic.resolvers.resource_requirements import ResourceRequirements
 from sematic.runners.silent_runner import SilentRunner
 from sematic.utils.exceptions import ExceptionMetadata, format_exception_for_run
 from sematic.utils.git import get_git_info
@@ -451,8 +452,12 @@ class LocalRunner(SilentRunner):
             run_command=get_run_command(),
             build_config=get_build_config(),
         )
+        pipeline_run.resource_requirements = self._get_runner_resources()
 
         return pipeline_run
+
+    def _get_runner_resources(self) -> Optional[ResourceRequirements]:
+        return None
 
     def _get_git_info(self, object: Any) -> Optional[GitInfo]:
         if self._git_info is not None:

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -281,6 +281,7 @@ def _schedule_resolution_job(
         resolution_id=resolution.root_id,
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
+        resource_requirements=resolution.resource_requirements,
         max_parallelism=max_parallelism,
         rerun_from=rerun_from,
         rerun_mode=rerun_mode,

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -37,9 +37,9 @@ from sematic.db.models.job import Job
 from sematic.graph import RerunMode
 from sematic.plugins.storage.s3_storage import S3Storage, S3StorageSettingsVar
 from sematic.resolvers.resource_requirements import (
+    DEFAULT_RUNNER_RESOURCES,
     KUBERNETES_SECRET_NAME,
     KubernetesHostPathMount,
-    KubernetesResourceRequirements,
     KubernetesSecretMount,
     ResourceRequirements,
 )
@@ -73,11 +73,6 @@ POD_CONDITION_PRECEDENCE = [
     "PodHasNetwork",
     "PodScheduled",
 ]
-RESOLUTION_RESOURCE_REQUIREMENTS = ResourceRequirements(
-    kubernetes=KubernetesResourceRequirements(
-        requests={"cpu": "500m", "memory": "2Gi"},
-    )
-)
 
 DEFAULT_WORKER_SERVICE_ACCOUNT = "default"
 
@@ -708,6 +703,7 @@ def schedule_resolution_job(
     resolution_id: str,
     image: str,
     user_settings: Dict[str, str],
+    resource_requirements: Optional[ResourceRequirements] = None,
     max_parallelism: Optional[int] = None,
     rerun_from: Optional[str] = None,
     rerun_mode: Optional[RerunMode] = None,
@@ -722,6 +718,7 @@ def schedule_resolution_job(
     socketio_address_override = get_server_setting(
         ServerSettingsVar.SEMATIC_WORKER_SOCKET_IO_ADDRESS, None
     )
+    resource_requirements = resource_requirements or DEFAULT_RUNNER_RESOURCES
 
     job = make_job(
         namespace=namespace,
@@ -760,7 +757,7 @@ def schedule_resolution_job(
         service_account=service_account,
         api_address_override=api_address_override,
         socketio_address_override=socketio_address_override,
-        resource_requirements=RESOLUTION_RESOURCE_REQUIREMENTS,
+        resource_requirements=resource_requirements,
         args=args,
     )
     return job

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -100,6 +100,26 @@ def test_schedule_resolution(mock_k8s, resolution: Resolution):
         resolution_id=resolution.root_id,
         image=resolution.container_image_uri,
         user_settings=resolution.settings_env_vars,
+        resource_requirements=None,
+        max_parallelism=3,
+        rerun_from="foobar",
+        rerun_mode=None,
+    )
+
+
+def test_schedule_resolution_custom_resources(mock_k8s, resolution: Resolution):
+    custom_reqs = ResourceRequirements(
+        kubernetes=KubernetesResourceRequirements(requests={"memory": "1000Ti"}),
+    )
+    resolution.resource_requirements = custom_reqs
+    _, job = schedule_resolution(resolution, max_parallelism=3, rerun_from="foobar")
+    assert isinstance(job, Job)
+    mock_k8s.schedule_resolution_job.assert_called_once()
+    mock_k8s.schedule_resolution_job.assert_called_with(
+        resolution_id=resolution.root_id,
+        image=resolution.container_image_uri,
+        user_settings=resolution.settings_env_vars,
+        resource_requirements=custom_reqs,
         max_parallelism=3,
         rerun_from="foobar",
         rerun_mode=None,


### PR DESCRIPTION
Closes #1095

Until now, runner pods could only use fixed resource requirements. We had to pick a value that was big enough to not OOM in the vast majority of cases while also not being wasteful in what was requested. This led to a few limitations:

1. Not all runner pods had equal compute needs (inline runs might require more or less memory, importing large libs might increase memory near the limit for some workloads, etc.)
2. Anything requiring a secret could not be executed inline. Note that inline (aka non-standalone) stuff should STILL be only used for lightweight tasks, these do sometimes require secrets (ex: a func which makes just one quick API call)
3. It wasn't possible to pursue cluster resource efficiency/reliability goals by putting runner pods on non-pre-emptible nodes or similar.

This PR adds the functionality to overcome these limitations.

Testing
--------

- Executed the test pipeline using custom resources and looked at the pod spec to confirm they were actually used
- cloned a pipeline run that had done that and confirmed that the cloned one also used custom resources

In both cases I confirmed that custom compute (ex: cpu and mem) was used, as well as that secrets were properly mounted to the runner.