### PR TITLE
Have the cleaner cover cases where the runner pod is dead but Sematic's DB doesn't see that

### DIFF
--- a/helm/sematic-server/templates/cleaner-cron.yaml
+++ b/helm/sematic-server/templates/cleaner-cron.yaml
@@ -41,5 +41,6 @@ spec:
             - --stale-pipeline-runs
             - --orphaned-jobs
             - --orphaned-resources
+            - --zombie-pipeline-runs
           restartPolicy: Never
 {{- end }}

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -32,6 +32,7 @@ from sematic.api.endpoints.request_parameters import (
 from sematic.config.settings import MissingSettingsError
 from sematic.config.user_settings import UserSettingsVar
 from sematic.db.models.factories import clone_resolution, clone_root_run
+from sematic.db.models.job import Job
 from sematic.db.models.resolution import InvalidResolution, Resolution, ResolutionStatus
 from sematic.db.models.run import Run
 from sematic.db.models.user import User
@@ -673,14 +674,50 @@ def _get_zombie_resolution_ids() -> List[str]:
                 active_resolution_id, kind=JobKind.resolver
             )
             jobs = refresh_jobs(original_jobs)
-            if not any(job.get_latest_status().is_active() for job in jobs):
-                logger.warning("Resolution %s is a zombie", active_resolution_id)
-                zombie_ids.append(active_resolution_id)
+            active_jobs = [job for job in jobs if job.get_latest_status().is_active()]
+            if len(active_jobs) > 0:
+                logger.info("Resolution has active job %s", active_jobs[0].name)
+                continue
+            logger.warning(
+                "Resolution %s has no active job; likely a zombie",
+                active_resolution_id,
+            )
+            run_jobs = _get_active_jobs_for_resolution_id(active_resolution_id)
+            refreshed_jobs = refresh_jobs(run_jobs)
+            active_run_jobs = [
+                job for job in refreshed_jobs if job.get_latest_status().is_active()
+            ]
+            if len(active_run_jobs) > 0:
+                logger.warning(
+                    "Resolution may be defunct but a run job is still active: %s",
+                    active_run_jobs[0].name,
+                )
+                continue
+            else:
+                logger.warning(
+                    "Jobs for runs of resolution with id %s are no longer active",
+                    active_resolution_id,
+                )
+
+            zombie_ids.append(active_resolution_id)
         except Exception:
             logger.exception(
                 "Error refreshing jobs for resolution %s", active_resolution_id
             )
     return zombie_ids
+
+
+def _get_active_jobs_for_resolution_id(resolution_id: str) -> List[Job]:
+    runs = get_graph(Run.root_id == resolution_id)[0]
+    active_run_jobs: List[Job] = []
+    for run in runs:
+        if FutureState[run.future_state] != FutureState.SCHEDULED:  # type: ignore
+            continue
+        run_jobs = get_jobs_by_run_id(run.id, kind=JobKind.run)
+        active_run_jobs.extend(
+            job for job in run_jobs if job.get_latest_status().is_active()
+        )
+    return active_run_jobs
 
 
 _GARBAGE_COLLECTION_QUERIES["zombie"] = _get_zombie_resolution_ids

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -209,6 +209,14 @@ def put_resolution_endpoint(user: Optional[User], resolution_id: str) -> flask.R
     save_resolution(resolution)
     _publish_resolution_event(resolution)
 
+    try:
+        jobs = get_jobs_by_run_id(resolution.root_id, kind=JobKind.resolver)
+        updated_jobs = refresh_jobs(jobs)
+        for job in updated_jobs:
+            save_job(job)
+    except Exception:
+        logger.exception("Error updating jobs for resolution %s", resolution.id)
+
     return flask.jsonify({})
 
 
@@ -676,7 +684,11 @@ def _get_zombie_resolution_ids() -> List[str]:
             jobs = refresh_jobs(original_jobs)
             active_jobs = [job for job in jobs if job.get_latest_status().is_active()]
             if len(active_jobs) > 0:
-                logger.info("Resolution has active job %s", active_jobs[0].name)
+                logger.info(
+                    "Resolution has active job %s: %s",
+                    active_jobs[0].name,
+                    active_jobs[0].details,
+                )
                 continue
             logger.warning(
                 "Resolution %s has no active job; likely a zombie",
@@ -688,6 +700,14 @@ def _get_zombie_resolution_ids() -> List[str]:
                 job for job in refreshed_jobs if job.get_latest_status().is_active()
             ]
             if len(active_run_jobs) > 0:
+                # Why not consider it to be a zombie when the resolution has
+                # no job but a run does? Because (a) the run might still be doing
+                # useful work that we want it to complete (ex: to view, or for reruns)
+                # and (b) it's possible (though not likely) that we happened to catch
+                # the resolution at a moment when its pod was evicted, and it might
+                # recover with a reschedule. Making sure we only consider it a zombie
+                # if it still has runs with active jobs avoids this potential
+                # mis-identification.
                 logger.warning(
                     "Resolution may be defunct but a run job is still active: %s",
                     active_run_jobs[0].name,

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -622,7 +622,7 @@ def clean_stale_resolution_endpoint(
 ) -> flask.Response:
     resolution = get_resolution(root_id)
     root_run = get_run(root_id)
-    logger.warning(
+    logger.info(
         "Cleaning resolution %s with status %s and root run state %s",
         root_id,
         resolution.status,
@@ -642,6 +642,11 @@ def clean_stale_resolution_endpoint(
     root_run_running = not FutureState[
         root_run.future_state  # type: ignore
     ].is_terminal()
+
+    # If the root run is running, we don't want to risk stopping useful
+    # work. But zombies already are known to not have any jobs for themselves
+    # or their runs (but due to the dead resolver, they might have left runs in
+    # non-terminal states).
     if root_run_running and not is_zombie:  # type: ignore
         return jsonify_error(
             f"Couldn't clean resolution {root_id} because its root run "
@@ -674,6 +679,7 @@ def clean_stale_resolution_endpoint(
 
 
 def _get_zombie_resolution_ids() -> List[str]:
+    """Get ids of resolutions with no jobs still alive, but which appear non-terminal"""
     active_ids = get_active_resolution_ids()
     zombie_ids = []
     for active_resolution_id in active_ids:

--- a/sematic/api/endpoints/resolutions.py
+++ b/sematic/api/endpoints/resolutions.py
@@ -6,7 +6,7 @@ Module keeping all /api/v*/runs/* API endpoints.
 import logging
 from datetime import datetime
 from http import HTTPStatus
-from typing import Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 # Third-party
@@ -37,6 +37,7 @@ from sematic.db.models.run import Run
 from sematic.db.models.user import User
 from sematic.db.queries import (
     count_jobs_by_run_id,
+    get_active_resolution_ids,
     get_graph,
     get_jobs_by_run_id,
     get_resolution,
@@ -55,6 +56,7 @@ from sematic.scheduling.job_details import JobKind
 from sematic.scheduling.job_scheduler import (
     StateNotSchedulable,
     clean_jobs,
+    refresh_jobs,
     schedule_resolution,
 )
 from sematic.scheduling.kubernetes import cancel_job
@@ -62,9 +64,14 @@ from sematic.utils.exceptions import ExceptionMetadata
 
 logger = logging.getLogger(__name__)
 
-_GARBAGE_COLLECTION_QUERIES = {
+_GARBAGE_COLLECTION_QUERIES: Dict[str, Callable[[], List[str]]] = {
     "orphaned_jobs": get_resolution_ids_with_orphaned_jobs,
     "stale": get_stale_resolution_ids,
+    # Note: This is replaced below once it's defined.
+    # Unlike the first two, which require only looking in the
+    # server's metadata, to identify zombies we need to check the actual
+    # k8s cluster to see if the runner pod is still around.
+    "zombie": lambda: [],
 }
 
 
@@ -606,11 +613,30 @@ def clean_stale_resolution_endpoint(
 ) -> flask.Response:
     resolution = get_resolution(root_id)
     root_run = get_run(root_id)
+    logger.warning(
+        "Cleaning resolution %s with status %s and root run state %s",
+        root_id,
+        resolution.status,
+        root_run.future_state,
+    )
 
-    if not FutureState[root_run.future_state].is_terminal():  # type: ignore
+    resolution_jobs = get_jobs_by_run_id(root_id, kind=JobKind.resolver)
+    refreshed_resolution_jobs = refresh_jobs(resolution_jobs)
+    has_active_jobs = any(
+        job.get_latest_status().is_active() for job in refreshed_resolution_jobs
+    )
+    metadata_shows_running = not ResolutionStatus[
+        resolution.status  # type: ignore
+    ].is_terminal()
+    is_zombie = metadata_shows_running and not has_active_jobs
+
+    root_run_running = not FutureState[
+        root_run.future_state  # type: ignore
+    ].is_terminal()
+    if root_run_running and not is_zombie:  # type: ignore
         return jsonify_error(
             f"Couldn't clean resolution {root_id} because its root run "
-            f"is in state {root_run.future_state}",
+            f"is in state {root_run.future_state}, and it still has active jobs.",
             status=HTTPStatus.CONFLICT,
         )
 
@@ -624,8 +650,37 @@ def clean_stale_resolution_endpoint(
         state_change = ResolutionStatus.FAILED.value
         save_resolution(resolution)
 
+    for old_job, new_job in zip(resolution_jobs, refreshed_resolution_jobs):
+        if (
+            old_job.get_latest_status().is_active()
+            and not new_job.get_latest_status().is_active()
+        ):
+            save_job(new_job)
+
     return flask.jsonify(
         dict(
             content=state_change,
         )
     )
+
+
+def _get_zombie_resolution_ids() -> List[str]:
+    active_ids = get_active_resolution_ids()
+    zombie_ids = []
+    for active_resolution_id in active_ids:
+        try:
+            original_jobs = get_jobs_by_run_id(
+                active_resolution_id, kind=JobKind.resolver
+            )
+            jobs = refresh_jobs(original_jobs)
+            if not any(job.get_latest_status().is_active() for job in jobs):
+                logger.warning("Resolution %s is a zombie", active_resolution_id)
+                zombie_ids.append(active_resolution_id)
+        except Exception:
+            logger.exception(
+                "Error refreshing jobs for resolution %s", active_resolution_id
+            )
+    return zombie_ids
+
+
+_GARBAGE_COLLECTION_QUERIES["zombie"] = _get_zombie_resolution_ids

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -478,7 +478,7 @@ def clean_orphaned_run(run_id: str) -> str:
     return response["content"]
 
 
-def clean_stale_pipeline_run(run_id: str) -> str:
+def clean_pipeline_run(run_id: str) -> str:
     """Clean up a pipeline run whose run has terminated."""
     response = _post(f"/resolutions/{run_id}/clean", retry=True)
     return response["content"]
@@ -492,6 +492,11 @@ def get_pipeline_run_ids_with_orphaned_jobs() -> List[str]:
 def get_pipeline_runs_with_stale_statuses() -> List[str]:
     """Get ids of pipeline runs that have terminated but still have non-terminal jobs."""
     return _search_for_gc_pipeline_runs("stale")
+
+
+def get_zombie_pipeline_run_ids() -> List[str]:
+    """Get ids of pipeline runs that are non-terminal but have no associated."""
+    return _search_for_gc_pipeline_runs("zombie")
 
 
 def _search_for_gc_pipeline_runs(filter_name: str) -> List[str]:

--- a/sematic/api_client.py
+++ b/sematic/api_client.py
@@ -495,7 +495,7 @@ def get_pipeline_runs_with_stale_statuses() -> List[str]:
 
 
 def get_zombie_pipeline_run_ids() -> List[str]:
-    """Get ids of pipeline runs that are non-terminal but have no associated."""
+    """Get ids of pipeline runs that are non-terminal but have no associated pod."""
     return _search_for_gc_pipeline_runs("zombie")
 
 

--- a/sematic/cli/tests/test_clean.py
+++ b/sematic/cli/tests/test_clean.py
@@ -7,8 +7,6 @@ from click.testing import CliRunner
 # Sematic
 from sematic.cli.clean import clean
 
-# clean_zombie_pipeline_runs
-
 
 @mock.patch("sematic.cli.clean.clean_zombie_pipeline_runs")
 @mock.patch("sematic.cli.clean.clean_stale_pipeline_runs")

--- a/sematic/cli/tests/test_clean.py
+++ b/sematic/cli/tests/test_clean.py
@@ -7,7 +7,10 @@ from click.testing import CliRunner
 # Sematic
 from sematic.cli.clean import clean
 
+# clean_zombie_pipeline_runs
 
+
+@mock.patch("sematic.cli.clean.clean_zombie_pipeline_runs")
 @mock.patch("sematic.cli.clean.clean_stale_pipeline_runs")
 @mock.patch("sematic.cli.clean.clean_orphaned_runs")
 @mock.patch("sematic.cli.clean.clean_orphaned_resources")
@@ -17,12 +20,14 @@ def test_clean(
     mock_clean_orphaned_resources: mock.MagicMock,
     mock_clean_orphaned_runs: mock.MagicMock,
     mock_clean_stale_pipeline_runs: mock.MagicMock,
+    mock_clean_zombie_pipeline_runs: mock.MagicMock,
 ):
     def reset():
         mock_clean_orphaned_jobs.reset_mock()
         mock_clean_orphaned_resources.reset_mock()
         mock_clean_orphaned_runs.reset_mock()
         mock_clean_stale_pipeline_runs.reset_mock()
+        mock_clean_zombie_pipeline_runs.reset_mock()
 
     runner = CliRunner()
 
@@ -31,12 +36,14 @@ def test_clean(
     mock_clean_stale_pipeline_runs.assert_not_called()
     mock_clean_orphaned_resources.assert_not_called()
     mock_clean_orphaned_jobs.assert_not_called()
+    mock_clean_zombie_pipeline_runs.assert_not_called()
 
     runner.invoke(clean, ["--orphaned-jobs"])
     mock_clean_orphaned_runs.assert_not_called()
     mock_clean_stale_pipeline_runs.assert_not_called()
     mock_clean_orphaned_resources.assert_not_called()
     mock_clean_orphaned_jobs.assert_called()
+    mock_clean_zombie_pipeline_runs.assert_not_called()
 
     reset()
     runner.invoke(clean, ["--orphaned-resources"])
@@ -44,6 +51,7 @@ def test_clean(
     mock_clean_stale_pipeline_runs.assert_not_called()
     mock_clean_orphaned_resources.assert_called()
     mock_clean_orphaned_jobs.assert_not_called()
+    mock_clean_zombie_pipeline_runs.assert_not_called()
 
     reset()
     runner.invoke(clean, ["--orphaned-runs"])
@@ -51,6 +59,15 @@ def test_clean(
     mock_clean_stale_pipeline_runs.assert_not_called()
     mock_clean_orphaned_resources.assert_not_called()
     mock_clean_orphaned_jobs.assert_not_called()
+    mock_clean_zombie_pipeline_runs.assert_not_called()
+
+    reset()
+    runner.invoke(clean, ["--zombie-pipeline-runs"])
+    mock_clean_orphaned_runs.assert_not_called()
+    mock_clean_stale_pipeline_runs.assert_not_called()
+    mock_clean_orphaned_resources.assert_not_called()
+    mock_clean_orphaned_jobs.assert_not_called()
+    mock_clean_zombie_pipeline_runs.assert_called()
 
     reset()
     runner.invoke(clean, ["--stale-pipeline-runs", "--orphaned-resources"])

--- a/sematic/db/models/resolution.py
+++ b/sematic/db/models/resolution.py
@@ -109,6 +109,10 @@ class ResolutionStatus(Enum):
     def terminal_states(cls) -> FrozenSet:
         return _TERMINAL_STATES
 
+    @classmethod
+    def non_terminal_states(cls) -> FrozenSet:
+        return _NON_TERMINAL_STATES
+
 
 _ALLOWED_TRANSITIONS = {
     # Local resolver can jump straight to RUNNING
@@ -141,6 +145,9 @@ _ALLOWED_TRANSITIONS = {
 
 _TERMINAL_STATES = frozenset(
     {state for state in ResolutionStatus if state.is_terminal()}
+)
+_NON_TERMINAL_STATES = frozenset(
+    {state for state in ResolutionStatus if not state.is_terminal()}
 )
 
 

--- a/sematic/scheduling/job_scheduler.py
+++ b/sematic/scheduling/job_scheduler.py
@@ -46,7 +46,7 @@ def schedule_run(
     the second element is the new list of jobs associated with the run.
     """
     # before scheduling a new run, update the information about previous runs
-    existing_jobs = _refresh_jobs(existing_jobs)
+    existing_jobs = refresh_jobs(existing_jobs)
     _assert_is_scheduleable(run, resolution, existing_jobs)
     jobs = list(existing_jobs) + [_schedule_job(run, resolution, existing_jobs)]
     run.future_state = FutureState.SCHEDULED
@@ -121,7 +121,7 @@ def update_run_status(
                 future_state,
                 jobs,
             )
-            refreshed_jobs = _refresh_jobs(jobs)
+            refreshed_jobs = refresh_jobs(jobs)
             logger.warning(
                 "After refresh, jobs are: " "%s",
                 refreshed_jobs,
@@ -147,7 +147,7 @@ def update_run_status(
     if len(jobs) < 1:
         raise ValueError("No jobs for run")
 
-    jobs = _refresh_jobs(jobs)
+    jobs = refresh_jobs(jobs)
 
     if future_state.value == FutureState.SCHEDULED.value:
         if jobs[-1].latest_status.is_active():
@@ -227,7 +227,7 @@ def _assert_is_scheduleable(
         raise StateNotSchedulable(f"Run {run.id} has no container image URI")
 
 
-def _refresh_jobs(jobs: Iterable[Job]) -> Sequence[Job]:
+def refresh_jobs(jobs: Iterable[Job]) -> Sequence[Job]:
     """For any jobs that are still active, refresh them from external compute"""
     refreshed = []
     for job in jobs:

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -57,7 +57,7 @@ _kubeconfig_loaded = False
 
 
 # If a job still hasn't started after this time, consider it dead.
-_JOB_START_TIMEOUT_SECONDS = 600  # 24 * 3600
+_JOB_START_TIMEOUT_SECONDS = 24 * 3600
 
 # ordered from highest to lowest precedence
 # to be interpreted as: pods with phases earlier in the list are newer

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -55,6 +55,10 @@ from sematic.utils.retry import retry
 logger = logging.getLogger(__name__)
 _kubeconfig_loaded = False
 
+
+# If a job still hasn't started after this time, consider it dead.
+_JOB_START_TIMEOUT_SECONDS = 600  # 24 * 3600
+
 # ordered from highest to lowest precedence
 # to be interpreted as: pods with phases earlier in the list are newer
 # interpreted from the list from this resource:
@@ -229,6 +233,7 @@ def cancel_job(job: Job) -> Job:
     details.still_exists = False
     details.canceled = True
     job.details = details
+    job.update_status(details.get_status(time.time()))
 
     return job
 
@@ -254,13 +259,28 @@ def refresh_job(job: Job) -> Job:
         if e.status == 404:
             logger.warning("Got 404 while looking for job %s", job.identifier())
             if not job.details.has_started:
+                # still hasn't started
                 job.update_status(
                     replace(
                         job.latest_status,
                         last_updated_epoch_seconds=time.time(),
                     )
                 )
-                return job  # still hasn't started
+                if (
+                    time.time() - job.created_at.timestamp()
+                    > _JOB_START_TIMEOUT_SECONDS
+                ):
+                    try:
+                        # Cancel in case there's still something in K8s
+                        # to clean, even though we got a 404 for the job
+                        # already, just to be safe.
+                        return cancel_job(job)
+                    except Exception:
+                        logger.exception("Error while cleaning job")
+                        job.set_details(job.details.force_clean())
+                        return job
+
+                return job
             else:
                 details.still_exists = False
                 job.details = details

--- a/sematic/scheduling/tests/test_job_scheduler.py
+++ b/sematic/scheduling/tests/test_job_scheduler.py
@@ -19,7 +19,7 @@ from sematic.resolvers.resource_requirements import (
 from sematic.scheduling.job_details import JobStatus, KubernetesJobState
 from sematic.scheduling.job_scheduler import (
     StateNotSchedulable,
-    _refresh_jobs,
+    refresh_jobs,
     schedule_resolution,
     schedule_run,
 )
@@ -116,7 +116,7 @@ def test_schedule_resolution_bad_version(mock_k8s, resolution: Resolution):
 def test_refresh_jobs(mock_k8s):
     job1 = make_job(name="job1")
     job2 = make_job(name="job2")
-    refreshed = _refresh_jobs([job1, job2])
+    refreshed = refresh_jobs([job1, job2])
     assert [job.identifier() for job in refreshed] == [
         job1.identifier(),
         job2.identifier(),
@@ -132,7 +132,7 @@ def test_refresh_jobs(mock_k8s):
             last_updated_epoch_seconds=time.time(),
         )
     )
-    refreshed = _refresh_jobs([job1, job2])
+    refreshed = refresh_jobs([job1, job2])
     assert [job.identifier() for job in refreshed] == [
         job1.identifier(),
         job2.identifier(),


### PR DESCRIPTION
Closes #1088 

We have observed that this can happen if, for example, the runner pod OOM'd. We don't want the Sematic dashboard to show such things as still active when they're really not.

Additionally, the runner jobs weren't really getting their statuses updated except when they were created and when they were killed. I added some intermediate updates by having the jobs get updated whenever the resolution object is saved.

Finally, there are cases where the runner job looked like it might just be pending on k8s, and that was getting confused as still being active. To catch cases like this, I added logic that if a job still hasn't been started (which for run jobs is as soon as k8s acknowledges them, and for resolution jobs as soon as the runner pod updates the resolution status at its start) within 24 hours, consider the job as defunct and no longer active.

Testing
--------

Hacked the runner code so it didn't respond to signals by calling the cancellation API. Hacked the job creation timeout to be 10 minutes rather than 24 hours. Then:

- Had the runner immediately exit without doing anything else. Confirmed that this got seen as garbage and cleaned
- Started the testing pipeline with two jobs set to wait for 15 minutes. Once the jobs were actually in progress and at the sleep runs, I killed the runner pod for one. Confirmed that it got cleaned (but not until AFTER the sleep run had finished its work), but the one where I didn't kill the runner finished successfully.

Also deployed to dev1, and it cleaned up all the garbage we had there except for stuff from the LocalRunner that hadn't been marked terminal yet. A separate strategy will be needed to address defunct local runners; that's out of scope for this PR.