### PR TITLE
Make version parsing more robust for Kuberay

### DIFF
--- a/sematic/plugins/kuberay_wrapper/standard.py
+++ b/sematic/plugins/kuberay_wrapper/standard.py
@@ -1,7 +1,7 @@
 # Standard Library
 import json
 from copy import deepcopy
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Tuple, Type, Union
 
 # Sematic
 from sematic.abstract_plugin import AbstractPluginSettingsVar
@@ -289,9 +289,7 @@ class StandardKuberayWrapper(AbstractKuberayWrapper):
 
     @classmethod
     def _validate_kuberay_version(cls, kuberay_version: str):
-        int_tuple_version = tuple(
-            int(v) for v in kuberay_version.replace("v", "").split(".")
-        )
+        int_tuple_version = _version_tuple_from_string(kuberay_version)
         if (
             len(int_tuple_version) != 3
             or int_tuple_version < MIN_SUPPORTED_KUBERAY_VERSION
@@ -430,3 +428,11 @@ def _get_service_account() -> str:
     return get_server_setting(
         ServerSettingsVar.SEMATIC_WORKER_KUBERNETES_SA, DEFAULT_WORKER_SERVICE_ACCOUNT
     )
+
+
+def _version_tuple_from_string(version_string) -> Tuple[int, ...]:
+    try:
+        version_string = "".join(c for c in version_string if c in "1234567890.")
+        return tuple([int(v) for v in version_string.split(".")])
+    except Exception:
+        raise UnsupportedVersionError(f"Unsupported version {version_string}")

--- a/sematic/plugins/kuberay_wrapper/tests/test_standard.py
+++ b/sematic/plugins/kuberay_wrapper/tests/test_standard.py
@@ -509,3 +509,21 @@ def test_autoscaling_configuration():
         "cpu": "1500m",
         "memory": "1536Mi",
     }
+
+
+_VERSION_VALIDATION_CASES = [
+    ("", False),
+    ("0.9.9", True),
+    ("0.1.1", False),
+    ("v0.9.9", True),
+    ("1.0.0-rc", True),
+]
+
+
+@pytest.mark.parametrize("version, is_valid", _VERSION_VALIDATION_CASES)
+def test_version_validation(version, is_valid):
+    if is_valid:
+        StandardKuberayWrapper._validate_kuberay_version(version)
+    else:
+        with pytest.raises(UnsupportedVersionError):
+            StandardKuberayWrapper._validate_kuberay_version(version)


### PR DESCRIPTION
Closes #1090 

The current version parsing logic wasn't robust to non `.`/numeric characters in the version string. This is.