### PR TITLE
Fail while doing __eq__ (and other comparison) on Future

### DIFF
--- a/sematic/future.py
+++ b/sematic/future.py
@@ -42,6 +42,8 @@ class Future(AbstractFuture):
     * A set of input arguments, that can be concrete values or futures themselves
     """
 
+    __hash__ = AbstractFuture.__hash__
+
     def resolve(
         self, resolver: Optional[Union[Resolver, Runner]] = None, tracking: bool = True
     ) -> Any:
@@ -203,4 +205,31 @@ class Future(AbstractFuture):
     def __itruediv__(self, _):
         raise NotImplementedError(
             "Future.__itruediv__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
+        )
+
+    def __eq__(self, _value: Any):
+        if isinstance(_value, AbstractFuture):
+            return super(Future, self).__eq__(_value)
+        raise NotImplementedError(
+            "Future.__eq__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
+        )
+
+    def __gt__(self, _):
+        raise NotImplementedError(
+            "Future.__gt__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
+        )
+
+    def __ge__(self, _):
+        raise NotImplementedError(
+            "Future.__ge__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
+        )
+
+    def __lt__(self, _):
+        raise NotImplementedError(
+            "Future.__lt__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
+        )
+
+    def __le__(self, _):
+        raise NotImplementedError(
+            "Future.__le__ is not supported yet. Find a workaround at https://docs.sematic.dev/diving-deeper/future-algebra#arithmetic-operations"  # noqa: E501
         )

--- a/sematic/tests/test_future.py
+++ b/sematic/tests/test_future.py
@@ -133,3 +133,28 @@ def test_idiv():
     with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
         f = foo()
         f /= 1
+
+
+def test_eq():
+    with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
+        foo() == 1
+
+
+def test_ge():
+    with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
+        foo() >= 1
+
+
+def test_gt():
+    with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
+        foo() > 1
+
+
+def test_le():
+    with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
+        foo() <= 1
+
+
+def test_lt():
+    with pytest.raises(NotImplementedError, match="docs.sematic.dev"):
+        foo() < 1


### PR DESCRIPTION
Addressed #87 

Fail while doing `__eq__`, `__gt__`, `__ge__`, `__lt__` and `__le__` operations on `Future`.
