### PR TITLE
Fix completion date rendering

### DIFF
--- a/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
+++ b/sematic/ui/packages/common/src/pages/RunDetails/FunctionSection.tsx
@@ -131,7 +131,7 @@ const FunctionSection = () => {
 
         return <>
             {runDuration}
-            on&nbsp;
+            &nbsp;on&nbsp;
             {completeAt}
         </>;
     }, [selectedRun]);


### PR DESCRIPTION
Fixes this incorrect rendering:

![image](https://github.com/sematic-ai/sematic/assets/1894533/31ea551d-7395-4275-b924-04875f31831a)
