### PR TITLE
More responsive log reading

### DIFF
--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -3,6 +3,7 @@ import base64
 import json
 import logging
 import sys
+import time
 from dataclasses import asdict, dataclass, replace
 from enum import Enum, unique
 from typing import Iterable, List, Optional, TypeVar
@@ -626,6 +627,7 @@ def get_log_lines_from_line_stream(
     cursor_line_index: Optional[int] = None,
     default_log_info_message: Optional[str] = None,
     reverse: bool = False,
+    time_limit_seconds: float = 10.0,
 ) -> LogLineResult:
     """Given a stream of log lines, produce an object containing the desired subset
 
@@ -654,6 +656,9 @@ def get_log_lines_from_line_stream(
         to be provided.
     reverse:
         Whether the log lines are being traversed in reverse order.
+    time_limit_seconds:
+        The LogLineResult should be returned in less than this amount of time even if
+        max_lines have not been found, provided that at least one line has been found.
 
     Returns
     -------
@@ -663,8 +668,10 @@ def get_log_lines_from_line_stream(
     original_cursor_line_index = cursor_line_index
     buffer_iterator = iter(line_stream)
     keep_going = True
+    search_timed_out = False
     lines: List[str] = []
     line_ids: List[int] = []
+    started_traversal = time.time()
 
     def passes_filter(line: LogLine) -> bool:
         return all(substring in line.line for substring in filter_strings)
@@ -700,6 +707,10 @@ def get_log_lines_from_line_stream(
             line_ids.append(to_line_id(line.source_file, line.source_file_index))
             if len(lines) >= max_lines:
                 keep_going = False
+            if len(lines) >= 1 and time.time() - started_traversal > time_limit_seconds:
+                logger.info("Reached time limit while traversing logs")
+                keep_going = False
+                search_timed_out = True
         except StopIteration:
             keep_going = False
 
@@ -739,7 +750,8 @@ def get_log_lines_from_line_stream(
     forward_cursor_token = None
     reverse_cursor_token = None
     if forward_cursor_file is not None:
-        if reverse or (len(lines) == max_lines or still_running):
+        # there might be a chance to continue in the forward direction
+        if reverse or (len(lines) == max_lines or still_running or search_timed_out):
             forward_cursor_token = Cursor(
                 source_log_key=forward_cursor_file,
                 source_file_line_index=forward_cursor_index,  # type: ignore
@@ -749,7 +761,8 @@ def get_log_lines_from_line_stream(
                 reverse=False,
             ).to_token()
     if reverse_cursor_file is not None:
-        if not reverse or len(lines) == max_lines:
+        # there might be a chance to continue in the reverse direction
+        if not reverse or len(lines) == max_lines or search_timed_out:
             reverse_cursor_token = Cursor(
                 source_log_key=reverse_cursor_file,
                 source_file_line_index=reverse_cursor_index,  # type: ignore

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -29,6 +29,8 @@ LOG_PATH_FORMAT = "{prefix}/run_id/{run_id}/{log_kind}/"
 DEFAULT_END_INDEX = sys.maxsize
 DEFAULT_START_INDEX = -1
 
+DEFAULT_READ_TIMEOUT_SECONDS = 10.0
+
 logger = logging.getLogger(__name__)
 
 
@@ -627,7 +629,7 @@ def get_log_lines_from_line_stream(
     cursor_line_index: Optional[int] = None,
     default_log_info_message: Optional[str] = None,
     reverse: bool = False,
-    time_limit_seconds: float = 10.0,
+    time_limit_seconds: float = DEFAULT_READ_TIMEOUT_SECONDS,
 ) -> LogLineResult:
     """Given a stream of log lines, produce an object containing the desired subset
 


### PR DESCRIPTION
We write log chunks to cloud storage every ~10 seconds, but we SKIP writing a log file if there were no log lines produced in that time period. When we request logs from the dashboard, we request them with a limit for the number of lines (2000). We will traverse the files in storage until we get to 2000 lines, so long as there are more files available for traversal. If your logging is dense, you will get to 2k lines quickly. If your logging is sparse in the sense that you only get messages every few minutes, but when those messages do show up there are at least several lines, then you get to 2k lines fairly quickly. The worst case scenario for how many remote log files you must traverse is if your logging produces a small number of lines every several seconds (absolute worst case would be one line every 10 seconds).

This PR adds a time limit such that even if 2000 lines haven't been found yet, and there are more files to check, we will still stop after 10 seconds of searching and return whatever we have. However, in order to make sure the cursor makes some progress with each call, and the user gets something if possible, we won't do an early return if NO lines have yet been found.

Testing
--------
Made a run where the "log flush" interval was only 1 second, with a single log line produced every second. This ensures the kind of "worst case" sparsity this PR is targeting. Run is [here](https://josh.dev-usw2-sematic0.sematic.cloud/runs/0c827b7bebfe42a6a4981846c95af76f#tab=logs&run=e4142beba6674b949caab21aa0bd34ea).

Tried the following with that run:

- while it had been running a while, visit log tab. Ensure there are lines shown within a few seconds
- try loading next log lines. Ensure more log lines are shown
- try jumping to the end and ensuring log lines are shown
- try jumping to the end and ensuring log lines are shown
- try "loading next" after jumping to the end and ensure more log lines are shown
- try adding filters with varying degrees of rareness (ex: `58.` to catch ~1 line for every 100s of execution, `857.` to catch roughly every 1000s of execution). Ensured that the search lasted until at least one line was shown OR the search request timed out.

Note that it *is* still possible to get the search request to time out if you use a filter for something that is incredibly rare (or nonexistent) and traversing all the existing log files takes more time than the request is allowed. However, this is probably a somewhat acceptable failure mode (at any rate, solving it would probably require that we create a search index for the logs or some other such highly complex solution). If you *don't* use any filtering, you should always get back at least one line or be told (truthfully) that there are no lines yet.