### PR TITLE
Fixes an issue related to artifact rendering

### DIFF
--- a/sematic/ui/packages/common/src/typeViz/common.tsx
+++ b/sematic/ui/packages/common/src/typeViz/common.tsx
@@ -94,7 +94,7 @@ export function renderArtifactRow(name: string, typeSerialization: AnyTypeSerial
         ({ type, renderDetails } = result);
     } else { // Fallback to repr or val
         ({ type } = typeSerialization);
-        if (valueSummary["repr"] !== undefined) {
+        if (valueSummary?.["repr"] !== undefined) {
             renderDetails = TypeComponents.get("repr")!;
         } else {
             renderDetails = TypeComponents.get("val")!;


### PR DESCRIPTION
After the fix, we will be able to render WorkloadConfig
Example:
<img width="1276" alt="image" src="https://github.com/sematic-ai/sematic/assets/133257643/ead1fac9-12d1-4243-8916-7699742e8dbd">
