### PR TITLE
Improve parallelism for deeply nested parallel branches

### DIFF
--- a/sematic/runners/state_machine_runner.py
+++ b/sematic/runners/state_machine_runner.py
@@ -83,16 +83,13 @@ class StateMachineRunner(Runner, abc.ABC):
             state_changed = False
             for future_ in self._futures:
                 if future_.state == FutureState.CREATED:
-                    self._schedule_future_if_args_concrete(future_)
-                    state_changed = True
+                    state_changed |= self._schedule_future_if_args_concrete(future_)
                     continue
                 if future_.state == FutureState.RETRYING:
-                    self._execute_future(future_)
-                    state_changed = True
+                    state_changed |= self._execute_future(future_)
                     continue
                 if future_.state == FutureState.RAN:
-                    self._run_nested_future(future_)
-                    state_changed = True
+                    state_changed |= self._run_nested_future(future_)
                     continue
 
                 # should be unreachable code, here for a sanity check
@@ -110,6 +107,8 @@ class StateMachineRunner(Runner, abc.ABC):
                 # otherwise there might be other things we can schedule
                 # before starting the wait.
                 self._wait_for_scheduled_runs_with_timeout()
+            else:
+                logger.info("Checking for ability to schedule more")
 
         if self._root_future.state == FutureState.RESOLVED:
             self._pipeline_run_did_succeed()
@@ -465,7 +464,8 @@ class StateMachineRunner(Runner, abc.ABC):
         return concrete_kwargs
 
     @typing.final
-    def _schedule_future_if_args_concrete(self, future: AbstractFuture) -> None:
+    def _schedule_future_if_args_concrete(self, future: AbstractFuture) -> bool:
+        """Schedule a future if its inputs are ready. Return True if it was scheduled."""
         concrete_kwargs = self._get_concrete_kwargs(future)
 
         all_args_concrete = len(concrete_kwargs) == len(future.kwargs)
@@ -473,26 +473,31 @@ class StateMachineRunner(Runner, abc.ABC):
         if all_args_concrete:
             future.resolved_kwargs = concrete_kwargs
             self._execute_future(future)
+            return True
+        return False
 
-    def _execute_future(self, future: AbstractFuture) -> None:
+    def _execute_future(self, future: AbstractFuture) -> bool:
         """
-        Attempts to execute the given Future.
+        Attempts to execute the given Future. Returns true if it did.
         """
         if not self._can_schedule_future(future):
             logger.info("Currently not scheduling %s", future.function)
-            return
+            return False
 
         self._future_will_schedule(future)
 
         if future.props.standalone:
             logger.info("Scheduling %s %s", future.id, future.function)
             self._schedule_future(future)
+            return True
         else:
             logger.info("Running inline %s %s", future.id, future.function)
             self._run_inline(future)
+            return True
 
     @typing.final
-    def _run_nested_future(self, future: AbstractFuture) -> None:
+    def _run_nested_future(self, future: AbstractFuture) -> bool:
+        """Bubble resolved state up the tree. Return true if a state was changed"""
         if future.nested_future is None:
             raise RuntimeError("No nested future")
 
@@ -501,6 +506,8 @@ class StateMachineRunner(Runner, abc.ABC):
         if nested_future.state == FutureState.RESOLVED:
             future.value = nested_future.value
             self._set_future_state(future, FutureState.RESOLVED)
+            return True
+        return False
 
     def _handle_future_failure(
         self,


### PR DESCRIPTION
Closes #1120

In certain cases, Sematic could get "stuck" waiting for something on one branch of a pipeline when more work could be done in other branches. This PR makes it so that Sematic will avoid entering a wait until changes are no longer being made to the pipeline state. Essentially the bug was that it can take a few iterations through the state-evolution loop before all the changes have taken effect that allow us to know it's OK to schedule a particular run. The fix was to look at whether the state-evolution loop resulted in anything in the pipeline changing state. And if it did, don't enter the wait.

Testing
-------

Set up a pipeline that I knew would hit a condition that would wait prematurely before the fix. The sleep in the left branch of the image takes seconds, while the corresponding sleep in the right branch was configured to take hours.

Before, get stuck here until right sleep finishes:
<img width="589" alt="Screenshot 2024-04-15 at 8 18 18 AM" src="https://github.com/sematic-ai/sematic/assets/7181589/0c4775d6-afc5-4d79-bcd6-749b7a095858">

After, progress as far as possible before waiting for the right, slow branch:
<img width="620" alt="Screenshot 2024-04-15 at 8 31 42 AM" src="https://github.com/sematic-ai/sematic/assets/7181589/42551064-0af5-4bdf-96f0-1d22bcfc16f0">
