### PR TITLE
Allow custom annotations & labels

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -228,6 +228,20 @@ Information on the Kubernetes resources required.
     administrator has enabled the `ALLOW_HOST_PATH_MOUNTING` Server setting. More details
     can be found here: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 
+- `annotations`: Dict[str, str]
+
+    The annotations that should be applied to the Kubernetes job (and therefore pod).
+    Note that ONLY annotations whose keys have been explicitly allowed by your
+    Sematic cluster administrator will actually be applied. Any annotations whose
+    keys have not been approved will be ignored.
+
+- `labels`: Dict[str, str]
+
+    The labels that should be applied to the Kubernetes job (and therefore pod).
+    Note that ONLY labels whose keys have been explicitly allowed by your
+    Sematic cluster administrator will actually be applied. Any labels whose
+    keys have not been approved will be ignored.
+
 ### `KubernetesSecretMount`
 
 Information about how to expose Kubernetes secrets when running a Sematic func.

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -51,6 +51,8 @@ data:
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
+  SEMATIC_WORKER_ALLOWED_ANNOTATION_KEYS: {{ toJson .Values.worker.allowed_annotation_keys | quote }}
+  SEMATIC_WORKER_ALLOWED_LABEL_KEYS: {{ toJson .Values.worker.allowed_label_keys | quote }}
   ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ .Values.worker.can_customize_security_context | quote }}
   ALLOW_HOST_PATH_MOUNTING: {{ .Values.worker.can_mount_host_paths | quote }}
   WORKER_IMAGE_PULL_SECRETS: {{ toJson .Values.worker.image_pull_secrets | quote }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -144,6 +144,8 @@ worker:
   can_customize_security_context: false
   can_mount_host_paths: false
   image_pull_secrets: null
+  allowed_annotation_keys: []
+  allowed_label_keys: []
 
 service:
   create: true

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -44,6 +44,14 @@ class ServerSettingsVar(AbstractPluginSettingsVar):
     # uses for jobs.
     SEMATIC_WORKER_KUBERNETES_SA = "SEMATIC_WORKER_KUBERNETES_SA"
 
+    # Controls which Kubernetes annotations pipeline authors
+    # can apply to their jobs.
+    SEMATIC_WORKER_ALLOWED_ANNOTATION_KEYS = "SEMATIC_WORKER_ALLOWED_ANNOTATION_KEYS"
+
+    # Controls which Kubernetes labels pipeline authors
+    # can apply to their jobs.
+    SEMATIC_WORKER_ALLOWED_LABEL_KEYS = "SEMATIC_WORKER_ALLOWED_LABEL_KEYS"
+
     # What, if any, imagePullSecrets should be used for runner and
     # standalone jobs?
     WORKER_IMAGE_PULL_SECRETS = "WORKER_IMAGE_PULL_SECRETS"

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -450,7 +450,7 @@ def _get_runner(args: argparse.Namespace) -> StateMachineRunner:
                 labels={
                     "allowed-label-1": "43",
                     "allowed-label-2": "yo",
-                    "forbidden-label": "xxx",
+                    "forbidden-label": "1337-hax",
                 },
             )
         )

--- a/sematic/examples/testing_pipeline/__main__.py
+++ b/sematic/examples/testing_pipeline/__main__.py
@@ -442,6 +442,16 @@ def _get_runner(args: argparse.Namespace) -> StateMachineRunner:
         extra_kwargs["resources"] = ResourceRequirements(
             kubernetes=KubernetesResourceRequirements(
                 requests={"memory": "3Gi"},
+                annotations={
+                    "allowed-annotation-1": "42",
+                    "allowed-annotation-2": "foo",
+                    "forbidden-annotation": "bad-wolf",
+                },
+                labels={
+                    "allowed-label-1": "43",
+                    "allowed-label-2": "yo",
+                    "forbidden-label": "xxx",
+                },
             )
         )
     return CloudRunner(

--- a/sematic/examples/testing_pipeline/pipeline.py
+++ b/sematic/examples/testing_pipeline/pipeline.py
@@ -648,7 +648,7 @@ def testing_pipeline(
 
     if expand_shared_memory:
         k8_resource_requirements = KubernetesResourceRequirements(
-            mount_expanded_shared_memory=True
+            mount_expanded_shared_memory=True,
         )
         resource_requirements = ResourceRequirements(
             kubernetes=k8_resource_requirements

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -335,6 +335,14 @@ class KubernetesResourceRequirements:
         Sematic cluster administrator has enabled the `ALLOW_HOST_PATH_MOUNTING` Server
         setting. Defaults to an empty list. More details can be found here:
         https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+    annotations: Dict[str, str]
+        Kubernetes annotations to apply to the created pod. Only annotation keys
+        which have been allowed by your Sematic administrator can be used here.
+        Others will be ignored.
+    labels: Dict[str, str]
+        Kubernetes labels to apply to the created pod. Only label keys
+        which have been allowed by your Sematic administrator can be used here.
+        Others will be ignored.
     """
 
     node_selector: Dict[str, str] = field(default_factory=dict)
@@ -344,6 +352,8 @@ class KubernetesResourceRequirements:
     mount_expanded_shared_memory: bool = field(default=False)
     security_context: Optional[KubernetesSecurityContext] = field(default=None)
     host_path_mounts: List[KubernetesHostPathMount] = field(default_factory=list)
+    annotations: Dict[str, str] = field(default_factory=dict)
+    labels: Dict[str, str] = field(default_factory=dict)
 
     def clone(self) -> "KubernetesResourceRequirements":
         """Deep copy these requirements."""
@@ -354,6 +364,8 @@ class KubernetesResourceRequirements:
             requests=dict(self.requests),
             tolerations=[t for t in self.tolerations],
             host_path_mounts=[m for m in self.host_path_mounts],
+            annotations=dict(self.annotations),
+            labels=dict(self.labels),
         )
 
 

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -112,6 +112,16 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
                     type="Directory",
                 ),
             ],
+            annotations={
+                "allowed-annotation-1": "42",
+                "allowed-annotation-2": "43",
+                "forbidden-annotation": "666",
+            },
+            labels={
+                "allowed-label-1": "-42",
+                "allowed-label-2": "-43",
+                "forbidden-label": "-666",
+            },
         )
     )
 
@@ -121,6 +131,12 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
             "ALLOW_CUSTOM_SECURITY_CONTEXTS": "true",
             "ALLOW_HOST_PATH_MOUNTING": "true",
             "WORKER_IMAGE_PULL_SECRETS": json.dumps([{"name": "foo-secret"}]),
+            "SEMATIC_WORKER_ALLOWED_ANNOTATION_KEYS": json.dumps(
+                ["allowed-annotation-1", "allowed-annotation-2"]
+            ),
+            "SEMATIC_WORKER_ALLOWED_LABEL_KEYS": json.dumps(
+                ["allowed-label-1", "allowed-label-2"]
+            ),
         }
     ):
         _schedule_kubernetes_job(


### PR DESCRIPTION
Allow annotations and labels to be specified in `KubernetesResourceRequirements` IF they have been allow-listed using a server config. The reason we need to have an allow-list is that allowing the user to arbitrarily specify annotations and labels can contain foot-guns (ex: a user specifying a label of `sematic.ai/component: api` might wind up having their pod be considered part of the Sematic k8s service object). In the worst case, they can contain security holes (ex: an annotation of  `kubernetes.io/psp: eks.privileged`).

Testing
-------

Deployed a server with this code to staging. Then:

- re-ran an old pipeline execution from the UI to confirm it still worked.
- Ran the testing pipeline with custom runner resources and confirmed that the specified annotations and labels appeared (except for the ones that were not allow-listed).
- Modified the testing pipeline to launch a worker pod with resources specifying custom annotations and labels. Confirmed the approved ones appeared on the resulting pod.