### PR TITLE
Add can_cast for tuple

### DIFF
--- a/sematic/types/types/tests/test_tuple.py
+++ b/sematic/types/types/tests/test_tuple.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import pytest
 
 # Sematic
-from sematic.types.casting import safe_cast
+from sematic.types.casting import can_cast_type, safe_cast
 from sematic.types.serialization import (
     get_json_encodable_summary,
     type_from_json_encodable,
@@ -42,6 +42,37 @@ def test_tuple(value, type_, expected_value, expected_error):
 
     assert error == expected_error
     assert cast_value == expected_value
+
+
+@pytest.mark.parametrize(
+    "from_type, to_type, expected_error",
+    (
+        (Tuple[float, int], Tuple[float, int], None),
+        (Tuple[float, int], Tuple[float, float], None),
+        (Tuple[int, str], Tuple[float, str], None),
+        (Tuple[int, str], int, "Cannot cast typing.Tuple[int, str] to int"),
+        (
+            Tuple[int, str],
+            Tuple[int, str, int],
+            "Can't cast typing.Tuple[int, str] to typing.Tuple[int, str, int]: "
+            "they have different arities (2 vs 3)",
+        ),
+        (
+            Tuple[int, str],
+            Tuple[int, int],
+            "Can't cast typing.Tuple[int, str] to typing.Tuple[int, int]:: "
+            "Cannot cast <class 'str'> to int",
+        ),
+    ),
+)
+def test_can_cast_tuple(from_type, to_type, expected_error):
+    can_cast, error = can_cast_type(from_type, to_type)
+    if expected_error is None:
+        assert error is None
+        assert can_cast
+    else:
+        assert not can_cast
+    assert error == expected_error
 
 
 def test_summary():

--- a/sematic/types/types/tuple.py
+++ b/sematic/types/types/tuple.py
@@ -1,10 +1,12 @@
 # Standard Library
+import typing
 from typing import Any, Iterable, List, Optional, Tuple, Type
 
 # Sematic
-from sematic.types.casting import safe_cast
+from sematic.types.casting import can_cast_type, safe_cast
 from sematic.types.registry import (
     SummaryOutput,
+    register_can_cast,
     register_from_json_encodable,
     register_safe_cast,
     register_to_json_encodable,
@@ -88,3 +90,44 @@ def _tuple_to_json_encodable_summary(value: Tuple, type_: Type) -> SummaryOutput
         blobs.update(element_blobs)
 
     return summary, blobs
+
+
+# Using `tuple` instead of `typing.Tuple` here because
+# `typing.Tuple[T].__origin__` is `tuple`
+@register_can_cast(tuple)
+def can_cast_to_tuple(from_type: typing.Any, to_type: typing.Any):
+    """
+    Type casting logic for `Tuple[T, U, <more?>]`.
+
+    `from_type` and `to_type` should be subscripted generics
+    of the form `Tuple[T, <more?>]`.
+
+    A type of the form `Tuple[T, <more?>]` is castable to `Tuple[U, <more>]` if the
+    two tuples have the same arity and the types in the second tuple can all be casted
+    to the corresponding types in the first.
+
+    For example `Tuple[int, float]` is castable to `Tuple[float, float]`, but
+    `Tuple[int, str]` is not.
+    """
+    err_prefix = "Can't cast {} to {}:".format(from_type, to_type)
+
+    from_args = typing.get_args(from_type)
+    if len(from_args) < 1:
+        return False, "{} not a subscripted generic".format(err_prefix)
+
+    to_args = typing.get_args(to_type)
+    if len(from_args) != len(to_args):
+        return False, "{} they have different arities ({} vs {})".format(
+            err_prefix, len(from_args), len(to_args)
+        )
+
+    from_origin = typing.get_origin(from_type)
+    if not (from_origin is not None and issubclass(from_origin, tuple)):
+        return False, "{} not a tuple".format(err_prefix)
+
+    for from_t, to_t in zip(from_args, to_args):
+        can_cast, error = can_cast_type(from_t, to_t)
+        if can_cast is False:
+            return False, "{}: {}".format(err_prefix, error)
+
+    return True, None


### PR DESCRIPTION
Apparently `tuple` was missing an implementation for `can_cast_type`. It likely went unnoticed because `can_cast` has a quick check to return `True` if the source and destination types are the same python object (`a is b` check), which would work for most cases. But for other cases you might want it to work, the implementation was missing & causing problems. This PR adds an implementation.